### PR TITLE
Fixed incorrect signature of application(_:open:options:) function on…

### DIFF
--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -84,11 +84,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    func application(_ application: UIApplication, open url: URL, options: [ UIApplication.OpenURLOptionsKey : Any ]) -> Bool {
         // TODO: Pass this parameters to openHABViewController somehow to open specified sitemap/page and send specified command
         // Probably need to do this in a way compatible to Android app's URL
 
-        os_log("Calling Application Bundle ID: %{PUBLIC}@", log: .notifications, type: .info, sourceApplication ?? "")
+        os_log("Calling Application Bundle ID: %{PUBLIC}@", log: .notifications, type: .info, options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String ?? "")
         os_log("URL scheme: %{PUBLIC}@", log: .notifications, type: .info, url.scheme ?? "")
         os_log("URL query: %{PUBLIC}@", log: .notifications, type: .info, url.query ?? "")
 


### PR DESCRIPTION
… UIApplicationDelegate which was causing a crash when attempting to import a PKCS#12 certificate.

Signed-off-by: David O'Neill <ufodone@gmail.com>