### PR TITLE
webview cache

### DIFF
--- a/openHAB/GenericUITableViewCell.swift
+++ b/openHAB/GenericUITableViewCell.swift
@@ -10,6 +10,10 @@
 
 import UIKit
 
+protocol GenericCellCacheProtocol: UITableViewCell {
+    func invalidateCache()
+}
+
 class GenericUITableViewCell: UITableViewCell {
 
     @objc func displayWidget() {

--- a/openHAB/NewImageUITableViewCell.swift
+++ b/openHAB/NewImageUITableViewCell.swift
@@ -11,10 +11,6 @@ import os.log
 import SDWebImage
 import UIKit
 
-protocol NewImageUITableViewCellDelegate: class {
-    func didLoadImageOf(_ cell: NewImageUITableViewCell?)
-}
-
 enum ImageType {
     case link(url: URL?)
     case embedded(image: UIImage?)
@@ -23,8 +19,9 @@ enum ImageType {
 
 class NewImageUITableViewCell: GenericUITableViewCell {
 
-    var mainImageView: ScaleAspectFitImageView!
-    weak var delegate: NewImageUITableViewCellDelegate?
+    var didLoad: (() -> Void)?
+
+    private var mainImageView: ScaleAspectFitImageView!
     private var refreshTimer: Timer?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -81,7 +78,7 @@ class NewImageUITableViewCell: GenericUITableViewCell {
         switch widgetPayload {
         case .embedded(let image):
             mainImageView.image = image
-            delegate?.didLoadImageOf(self)
+            didLoad?()
         case .link(let url):
             guard let url = url else { return }
             loadRemoteImage(withURL: url)
@@ -134,7 +131,7 @@ class NewImageUITableViewCell: GenericUITableViewCell {
                 return
             }
             self?.widget?.image = image
-            self?.delegate?.didLoadImageOf(self)
+            self?.didLoad?()
         }
     }
 

--- a/openHAB/OpenHABViewController.swift
+++ b/openHAB/OpenHABViewController.swift
@@ -28,7 +28,7 @@ protocol ModalHandler: class {
     func modalDismissed(to: TargetController)
 }
 
-class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, OpenHABTrackerDelegate, OpenHABSitemapPageDelegate, OpenHABSelectionTableViewControllerDelegate, ColorPickerUITableViewCellDelegate, AFRememberingSecurityPolicyDelegate, ClientCertificateManagerDelegate, NewImageUITableViewCellDelegate, ModalHandler, VideoUITableViewCellDelegate {
+class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, OpenHABTrackerDelegate, OpenHABSitemapPageDelegate, OpenHABSelectionTableViewControllerDelegate, ColorPickerUITableViewCellDelegate, AFRememberingSecurityPolicyDelegate, ClientCertificateManagerDelegate, ModalHandler {
 
     var tracker: OpenHABTracker?
 
@@ -200,12 +200,10 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
 
     func registerTableViewCells() {
-
         widgetTableView.register(MapViewTableViewCell.self, forCellReuseIdentifier: OpenHABViewControllerMapViewCellReuseIdentifier)
         widgetTableView.register(cellType: MapViewTableViewCell.self)
         widgetTableView.register(NewImageUITableViewCell.self, forCellReuseIdentifier: OpenHABViewControllerImageViewCellReuseIdentifier)
         widgetTableView.register(cellType: VideoUITableViewCell.self)
-
     }
 
     @objc func handleRefresh(_ refreshControl: UIRefreshControl?) {
@@ -410,9 +408,16 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
             (cell as? ColorPickerUITableViewCell)?.delegate = self
         case "Image", "Chart":
             cell = tableView.dequeueReusableCell(withIdentifier: OpenHABViewControllerImageViewCellReuseIdentifier, for: indexPath) as! NewImageUITableViewCell
-            (cell as? NewImageUITableViewCell)?.delegate = self
+            (cell as? NewImageUITableViewCell)?.didLoad = { [weak self] in
+                self?.widgetTableView.beginUpdates()
+                self?.widgetTableView.endUpdates()
+            }
         case "Video":
             cell = tableView.dequeueReusableCell(withIdentifier: "VideoUITableViewCell", for: indexPath) as! VideoUITableViewCell
+            (cell as? VideoUITableViewCell)?.didLoad = { [weak self] in
+                self?.widgetTableView.beginUpdates()
+                self?.widgetTableView.endUpdates()
+            }
         case "Webview":
             cell = tableView.dequeueReusableCell(for: indexPath) as WebUITableViewCell
         case "Mapview":
@@ -443,12 +448,6 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
             cell.backgroundColor = UIColor.groupTableViewBackground
         } else {
             cell.backgroundColor = UIColor.white
-        }
-
-        if let cell = cell as? VideoUITableViewCell {
-            cell.delegate = self
-            cell.url = URL(string: widget?.url ?? "")
-            return cell
         }
 
         if let cell = cell as? GenericUITableViewCell {
@@ -513,29 +512,9 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        // stop playback only if the cell is not visible, otherwise playback would be interrupted if a long polling request finishes
-        guard let videoCell = cell as? VideoUITableViewCell,
-            let indexPath = tableView.indexPath(for: cell),
-            let visibleIndexPaths = tableView.indexPathsForVisibleRows,
-            !visibleIndexPaths.contains(indexPath)
-        else {
-            return
-        }
-
-        videoCell.url = nil
-    }
-
-    func didLoadImageOf(_ cell: NewImageUITableViewCell?) {
-        UIView.performWithoutAnimation {
-            widgetTableView.beginUpdates()
-            widgetTableView.endUpdates()
-        }
-    }
-
-    func didLoadVideoOf(_ cell: VideoUITableViewCell?) {
-        UIView.performWithoutAnimation {
-            widgetTableView.beginUpdates()
-            widgetTableView.endUpdates()
+        // invalidate cache only if the cell is not visible
+        if let cell = cell as? GenericCellCacheProtocol, let indexPath = tableView.indexPath(for: cell), let visibleIndexPaths = tableView.indexPathsForVisibleRows, !visibleIndexPaths.contains(indexPath) {
+            cell.invalidateCache()
         }
     }
 
@@ -705,15 +684,12 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
             pageRequest.setValue("long-polling", forHTTPHeaderField: "X-Atmosphere-Transport")
             pageRequest.timeoutInterval = 300.0
         } else {
-            atmosphereTrackingId = ""
+            atmosphereTrackingId = "0"
             UIApplication.shared.isNetworkActivityIndicatorVisible = true
             pageRequest.timeoutInterval = 10.0
         }
-        if atmosphereTrackingId == "" {
-            pageRequest.setValue(atmosphereTrackingId, forHTTPHeaderField: "X-Atmosphere-tracking-id")
-        } else {
-            pageRequest.setValue("0", forHTTPHeaderField: "X-Atmosphere-tracking-id")
-        }
+        pageRequest.setValue(atmosphereTrackingId, forHTTPHeaderField: "X-Atmosphere-tracking-id")
+
         if currentPageOperation != nil {
             currentPageOperation?.cancel()
             currentPageOperation = nil
@@ -726,12 +702,9 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
             os_log("Page loaded with success", log: OSLog.remoteAccess, type: .info)
             let headers = operation.response?.allHeaderFields
 
-            if headers?["X-Atmosphere-tracking-id"] != nil {
-                if let object = headers?["X-Atmosphere-tracking-id"] {
-                    os_log("Found X-Atmosphere-tracking-id: %{PUBLIC}@", log: .remoteAccess, type: .info, object as! CVarArg)
-                }
-                // Establish the strong self reference
-                self.atmosphereTrackingId = headers?["X-Atmosphere-tracking-id"] as? String ?? ""
+            self.atmosphereTrackingId = headers?["X-Atmosphere-tracking-id"] as? String ?? ""
+            if !self.atmosphereTrackingId.isEmpty {
+                os_log("Found X-Atmosphere-tracking-id: %{PUBLIC}@", log: .remoteAccess, type: .info, self.atmosphereTrackingId)
             }
             let response = responseObject as? Data
             // If we are talking to openHAB 1.X, talk XML

--- a/openHAB/WebUITableViewCell.swift
+++ b/openHAB/WebUITableViewCell.swift
@@ -11,21 +11,30 @@
 import os.log
 import WebKit
 
-class WebUITableViewCell: GenericUITableViewCell, WKUIDelegate {
-    var isLoadingUrl = false
-    var isLoaded = false
-
+class WebUITableViewCell: GenericUITableViewCell {
     @IBOutlet weak var widgetWebView: WKWebView!
+
+    private var url: URL?
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 
         selectionStyle = .none
         separatorInset = .zero
+    }
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        widgetWebView.navigationDelegate = self
     }
 
     override func displayWidget() {
         os_log("webview loading url %{PUBLIC}@", log: .default, type: .info, widget.url)
+
+        guard url?.absoluteString != widget.url else {
+            os_log("webview URL has not changed, abort loading", log: .viewCycle, type: .info)
+            return
+        }
 
         let prefs = UserDefaults.standard
         let openHABUsername = prefs.string(forKey: "username")
@@ -38,26 +47,53 @@ class WebUITableViewCell: GenericUITableViewCell, WKUIDelegate {
         let base64LoginString = loginData.base64EncodedString()
 
         if let url = URL(string: widget.url) {
+            self.url = url
             var request = URLRequest(url: url)
             request.setValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
             widgetWebView?.scrollView.isScrollEnabled = false
             widgetWebView?.scrollView.bounces = false
             widgetWebView?.load(request)
         }
-
-    }
-
-    func webViewDidStartLoad(_ webView: UIWebView) {
-        os_log("webview started loading", log: .viewCycle, type: .info)
-    }
-
-    func webViewDidFinishLoad(_ webView: UIWebView) {
-        os_log("webview finished load", log: .viewCycle, type: .info)
     }
 
     func setFrame(_ frame: CGRect) {
         os_log("setFrame", log: .viewCycle, type: .info)
         super.frame = frame
         widgetWebView?.reload()
+    }
+}
+
+extension WebUITableViewCell: GenericCellCacheProtocol {
+    func invalidateCache() {
+        url = nil
+        widgetWebView?.stopLoading()
+    }
+}
+
+extension WebUITableViewCell: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        os_log("webview started loading with URL: %{PUBLIC}s", log: .viewCycle, type: .info, widget.url)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        os_log("webview finished load with URL: %{PUBLIC}s", log: .viewCycle, type: .info, widget.url)
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        if let response = navigationResponse.response as? HTTPURLResponse, response.statusCode >= 400 {
+            os_log("webview failed with status code: %{PUBLIC}i", log: .urlComposition, type: .debug, response.statusCode)
+            url = nil
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        os_log("webview failed with error: %{PUBLIC}s", log: .urlComposition, type: .debug, error.localizedDescription)
+        url = nil
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        os_log("webview failed with error: %{PUBLIC}s", log: .urlComposition, type: .debug, error.localizedDescription)
+        url = nil
     }
 }


### PR DESCRIPTION
@timbms 

I've implemented webview "caching", with a strategy quite similar to videos, i.e. it will reload only when it comes into sight (and on pull to refresh). 

I've also changed a few other things, **so I'd appreciate a review and would like to hear your thoughts**:

1. `GenericCellCacheProtocol`

I've added a `GenericCellCacheProtocol` to allow more generic cache invalidation in `tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath)`

2. `NewImageUITableViewCellDelegate` and `VideoUITableViewCellDelegate` removed

I've removed those delegates and added a closure instead, for a more _Swifty_ approach. Imho this is easier to read and cleaner than a separate delegate for each of those cells.

Signed-off-by: weak <weak@fraglab.at>