### PR TITLE
Update color picker.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,12 +9,12 @@ target 'openHAB' do
     pod 'SDWebImage', '~> 5.0' , :modular_headers => true
     pod 'SDWebImageSVGCoder'
     pod 'GDataXML-HTML', '~> 1.3.0'
-    pod 'NKOColorPickerView', '~> 0.5'
     pod 'Firebase/Core'
     pod 'Fabric', '~> 1.7.2'
     pod 'Crashlytics', '~> 3.9.3'
     pod 'SwiftMessages'
     pod 'SideMenu', '~> 5.0'
+    pod 'FlexColorPicker'
 end
 
 target 'openHABTestsSwift' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,6 +47,7 @@ PODS:
     - FirebaseCore (~> 6.0)
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
+  - FlexColorPicker (1.2.1)
   - GDataXML-HTML (1.3.0)
   - GoogleAppMeasurement (6.0.2):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
@@ -77,7 +78,6 @@ PODS:
     - nanopb/encode (= 0.3.901)
   - nanopb/decode (0.3.901)
   - nanopb/encode (0.3.901)
-  - NKOColorPickerView (0.5)
   - SDWebImage (5.0.6):
     - SDWebImage/Core (= 5.0.6)
   - SDWebImage/Core (5.0.6)
@@ -96,8 +96,8 @@ DEPENDENCIES:
   - Crashlytics (~> 3.9.3)
   - Fabric (~> 1.7.2)
   - Firebase/Core
+  - FlexColorPicker
   - GDataXML-HTML (~> 1.3.0)
-  - NKOColorPickerView (~> 0.5)
   - SDWebImage (~> 5.0)
   - SDWebImageSVGCoder
   - SideMenu (~> 5.0)
@@ -113,11 +113,11 @@ SPEC REPOS:
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseInstanceID
+    - FlexColorPicker
     - GDataXML-HTML
     - GoogleAppMeasurement
     - GoogleUtilities
     - nanopb
-    - NKOColorPickerView
     - SDWebImage
     - SDWebImageSVGCoder
     - SideMenu
@@ -133,17 +133,17 @@ SPEC CHECKSUMS:
   FirebaseAnalytics: 470ddab7253b21ad5a40bebd4a9903d7ae19386a
   FirebaseCore: 68f8a7f50cdae542715d4e86afa37c4067217dcb
   FirebaseInstanceID: f20243a1d828e0e9a3798b995174dedc16f1b32a
+  FlexColorPicker: 2c6fe41cb33a650d5934fad75ab0e25df4b5af2f
   GDataXML-HTML: 7adc03668cab35c288f1dbb8929a179f0fece898
   GoogleAppMeasurement: a35a645835bae31b6bdc0576396bc23908f12a22
   GoogleUtilities: c7a0b08bda3bf808be823ed151f0e28ac6866e71
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
-  NKOColorPickerView: 895ca86fe5bd16f27c311ce8f5888907efee29ad
   SDWebImage: 920f1a2ff1ca8296ad34f6e0510a1ef1d70ac965
   SDWebImageSVGCoder: 4b354bcdc7d74ce14d9fdb3c9ed9ab2c667f3b57
   SideMenu: 1dcaabce84538c53325c287f7fe62999379a641c
   SVGKit: 652cdf7bef8bec8564d04a8511d3ab50c7595fac
   SwiftMessages: a952f7a9103d9aeab93730a2861d2d8fcdd8758f
 
-PODFILE CHECKSUM: 6759fc294e888165d6fbf8fcb11b62feaa2cf752
+PODFILE CHECKSUM: 2eee60b5469f51105c2dcb8e960de007b09bac83
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.7.5

--- a/openHAB-Bridging-Header.h
+++ b/openHAB-Bridging-Header.h
@@ -1,7 +1,6 @@
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
-#import <NKOColorPickerView/NKOColorPickerView.h>
 #import <AFNetworking/AFNetworking.h>
 #import <GDataXML_HTML/GDataXMLNode.h>
 

--- a/openHAB/Base.lproj/Main.storyboard
+++ b/openHAB/Base.lproj/Main.storyboard
@@ -1263,7 +1263,7 @@
         <!--Color Picker View Controller-->
         <scene sceneID="1cJ-Yb-6jQ">
             <objects>
-                <viewController storyboardIdentifier="ColorPickerViewController" automaticallyAdjustsScrollViewInsets="NO" id="XTW-gz-4RR" customClass="ColorPickerViewController" customModule="openHAB" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ColorPickerViewController" id="XTW-gz-4RR" customClass="ColorPickerViewController" customModule="openHAB" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Nl6-qJ-2g2"/>
                         <viewControllerLayoutGuide type="bottom" id="fDm-8Z-sSa"/>
@@ -1273,7 +1273,6 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" id="AYD-aP-DDS"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="o8x-QB-mZ6" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/openHAB/Base.lproj/Main.storyboard
+++ b/openHAB/Base.lproj/Main.storyboard
@@ -183,6 +183,7 @@
                                                         <constraint firstAttribute="width" constant="30" id="6Un-wa-yZa"/>
                                                         <constraint firstAttribute="height" constant="30" id="Joo-6D-b9d"/>
                                                     </constraints>
+                                                    <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <state key="normal">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>

--- a/openHAB/ColorPickerViewController.swift
+++ b/openHAB/ColorPickerViewController.swift
@@ -8,12 +8,12 @@
 //  Converted to Swift 4 by Tim Müller-Seydlitz and Swiftify on 06/01/18
 //
 
+import FlexColorPicker
 import os.log
 import UIKit
 
-class ColorPickerViewController: UIViewController {
+class ColorPickerViewController: DefaultColorPickerViewController {
     @objc var widget: OpenHABWidget?
-    var colorPickerView: NKOColorPickerView?
 
     required init?(coder: NSCoder) {
         os_log("ColorPickerViewController initWithCoder", log: .viewCycle, type: .info)
@@ -22,40 +22,40 @@ class ColorPickerViewController: UIViewController {
 
     override func viewDidLoad() {
         os_log("ColorPickerViewController viewDidLoad", log: .viewCycle, type: .info)
-        let colorDidChangeBlock: NKOColorPickerDidChangeColorBlock = { color in
-            var (hue, saturation, brightness, alpha): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
-            color?.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
 
-            hue *= 360
-            saturation *= 100
-            brightness *= 100
-            os_log("Color changed to %g %g %g", log: .default, type: .info, hue, saturation, brightness)
+        if let color = widget?.item?.stateAsUIColor() {
+          self.selectedColor = color
+        }
 
-            let command = "\(hue),\(saturation),\(brightness)"
-            self.widget?.sendCommand(command)
+        self.delegate = self
 
-        }
-        let viewFrame: CGRect = view.frame
-        let pickerFrame = CGRect(x: viewFrame.origin.x, y: viewFrame.origin.y + viewFrame.size.height / 10, width: viewFrame.size.width, height: viewFrame.size.height - viewFrame.size.height / 5)
-        colorPickerView = NKOColorPickerView(frame: pickerFrame, color: UIColor.blue, andDidChangeColorBlock: colorDidChangeBlock)
-        if let colorPickerView = colorPickerView {
-            view.addSubview(colorPickerView)
-        }
-        if widget != nil {
-            colorPickerView?.color = widget?.item?.stateAsUIColor()
-        }
         super.viewDidLoad()
-    }
-
-    override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
-        os_log("Rotation!", log: .viewCycle, type: .info)
-        let viewFrame: CGRect = view.frame
-        let pickerFrame = CGRect(x: viewFrame.origin.x, y: viewFrame.origin.y, width: viewFrame.size.width, height: viewFrame.size.height - viewFrame.size.height / 5)
-        colorPickerView?.frame = pickerFrame
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
 
+    func sendColorUpdate(color: UIColor) {
+        var (hue, saturation, brightness, alpha): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
+        color.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+
+        hue *= 360
+        saturation *= 100
+        brightness *= 100
+
+        os_log("Color changed to HSB(%g, %g, %g).", log: .default, type: .info, hue, saturation, brightness)
+
+        self.widget?.sendCommand("\(hue),\(saturation),\(brightness)")
+    }
+}
+
+extension ColorPickerViewController: ColorPickerDelegate {
+    func colorPicker(_ colorPicker: ColorPickerController, selectedColor: UIColor, usingControl: ColorControl) {
+        self.sendColorUpdate(color: selectedColor)
+    }
+
+    func colorPicker(_ colorPicker: ColorPickerController, confirmedColor: UIColor, usingControl: ColorControl) {
+        self.sendColorUpdate(color: confirmedColor)
+    }
 }

--- a/openHAB/OpenHABViewController.swift
+++ b/openHAB/OpenHABViewController.swift
@@ -681,7 +681,9 @@ class OpenHABViewController: UIViewController, UITableViewDelegate, UITableViewD
     func didPressColorButton(_ cell: ColorPickerUITableViewCell?) {
         let colorPickerViewController = storyboard?.instantiateViewController(withIdentifier: "ColorPickerViewController") as? ColorPickerViewController
         if let cell = cell {
-            colorPickerViewController?.widget = relevantPage?.widgets[widgetTableView.indexPath(for: cell)?.row ?? 0]
+            let widget = relevantPage?.widgets[widgetTableView.indexPath(for: cell)?.row ?? 0]
+            colorPickerViewController?.title = widget?.labelText
+            colorPickerViewController?.widget = widget
         }
         if let colorPickerViewController = colorPickerViewController {
             navigationController?.pushViewController(colorPickerViewController, animated: true)


### PR DESCRIPTION
I just signed up for the beta, and noticed the colorpicker is even more broken than in stable:

When I open a colorpicker, it shows up like this:

![IMG_0756](https://user-images.githubusercontent.com/1309829/61824718-045f6e80-ae5f-11e9-979d-64918efcf631.png)

I could get the brightness slider to show up by rotating:

![IMG_0757](https://user-images.githubusercontent.com/1309829/61824751-15a87b00-ae5f-11e9-9bd7-27d16e33756a.png)

Then, when I rotated it back, the slider shows up again in portrait mode, but still conflicts with the bottom bar:

![IMG_0758](https://user-images.githubusercontent.com/1309829/61824847-50121800-ae5f-11e9-9338-8c6ec0669da9.png)

So I updated the colorpicker to this one: https://github.com/RastislavMirek/FlexColorPicker

There's still a bug in the navigation bar, which always has a black background:

![Bildschirmfoto 2019-07-24 um 23 13 02](https://user-images.githubusercontent.com/1309829/61829227-bcdde000-ae68-11e9-8c4b-0c41cc41d3e7.png)
