### PR TITLE
fixed spelling of openHAB

### DIFF
--- a/openHAB/openHAB-Info.plist
+++ b/openHAB/openHAB-Info.plist
@@ -12,7 +12,7 @@
 			<key>CFBundleTypeIconFiles</key>
 			<array/>
 			<key>CFBundleTypeName</key>
-			<string>OpenHAB Client Certificate</string>
+			<string>openHAB Client Certificate</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>