### PR TITLE
docs: remove github handle from signoff example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ By making a contribution to this project, I certify that:
 
 then you just add a line to every git commit message:
 
-    Signed-off-by: Joe Smith <joe.smith@email.com> (github: github_handle)
+    Signed-off-by: Joe Smith <joe.smith@email.com>
 
 using your real name (sorry, no pseudonyms or anonymous contributions.)
 


### PR DESCRIPTION
Adding the github handle to the signoff line fails the DCO check in github

Signed-off-by: Dennis Sänger <github@mail.ds82.de>