### PR TITLE
Fix for #385

### DIFF
--- a/openHAB/NetworkConnection.swift
+++ b/openHAB/NetworkConnection.swift
@@ -64,7 +64,7 @@ class NetworkConnection {
             } else if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic {
                 let prefs = UserDefaults.standard
                 let remoteURL = URL(string: prefs.string(forKey: "remoteUrl") ?? "")
-                let localURL = URL(string: prefs.string(forKey: "localURL") ?? "")
+                let localURL = URL(string: prefs.string(forKey: "localUrl") ?? "")
 
                 if challenge.protectionSpace.host == remoteURL?.host || challenge.protectionSpace.host == localURL?.host {
                     let openHABUsername = prefs.string(forKey: "username") ?? ""

--- a/openHAB/OpenHABTracker.swift
+++ b/openHAB/OpenHABTracker.swift
@@ -66,16 +66,17 @@ class OpenHABTracker: NSObject {
                         startDiscovery()
                     } else {
                         let request = URLRequest(url: URL(string: openHABLocalUrl)!, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 2.0)
-                        #warning("Verify whether this could be switched to Alamofire")
-
-                        URLSession.shared.dataTask(with: request) { _, _, error -> Void in
-                            if error == nil {
-                                self.trackedLocalUrl()
-                            } else {
-                                self.trackedRemoteUrl()
+                        NetworkConnection.shared.manager.request(request)
+                            .validate(statusCode: 200..<300)
+                            .responseData { response in
+                                switch response.result {
+                                case .success:
+                                    self.trackedLocalUrl()
+                                case .failure:
+                                    self.trackedRemoteUrl()
+                                }
                             }
-                        }
-                        .resume()
+                            .resume()
                     }
                 }
             }


### PR DESCRIPTION
Converted direct URLSession usage in OpenHABTracker to use NetworkConnection.shared.manager instead to ensure that auth handling is handled properly - in particular when a 401 is returned from the server.  Also fixed a typo in the "localUrl" property name used in the basic auth handler to determine whether the requested host matched.

Signed-off-by: David O'Neill <ufodone@gmail.com>