### PR TITLE
Basic Auth to use tracked URL instead of remote/local URL setting

### DIFF
--- a/openHAB/OpenHABViewController.swift
+++ b/openHAB/OpenHABViewController.swift
@@ -688,6 +688,7 @@ extension OpenHABViewController: OpenHABTrackerDelegate {
         }
         openHABRootUrl = openHABUrl == nil ? "" : "\(openHABUrl!)"
         appData?.openHABRootUrl = openHABRootUrl
+        NetworkConnection.shared.setRootUrl(openHABRootUrl)
 
         if let pageToLoadUrl = Endpoint.tracker(openHABRootUrl: openHABRootUrl).url {
             var pageRequest = URLRequest(url: pageToLoadUrl)


### PR DESCRIPTION
Changed the Basic Auth challenge handler to check against the tracked URL rather than the remote/local URL from the settings.  This should ensure Basic Auth works in cases where the URL is discovered via Bonjour.

Signed-off-by: David O'Neill <ufodone@gmail.com>