### PR TITLE
fix searchBar workaround

### DIFF
--- a/openHAB/OpenHABViewController.swift
+++ b/openHAB/OpenHABViewController.swift
@@ -171,7 +171,9 @@ class OpenHABViewController: UIViewController {
 
         // NOTE: workaround for https://github.com/openhab/openhab-ios/issues/420
         if navigationItem.searchController == nil {
-            navigationItem.searchController = search
+            DispatchQueue.main.async {
+                self.navigationItem.searchController = self.search
+            }
         }
     }
 


### PR DESCRIPTION
@timbms the workaround causes a crash on iOS 12, should be fixed with this commit

Signed-off-by: weak <weak@fraglab.at>