### PR TITLE
Properly handle scientific notation when parsing quantities.

### DIFF
--- a/openHABCore/Sources/Util/StringExtension.swift
+++ b/openHABCore/Sources/Util/StringExtension.swift
@@ -39,9 +39,9 @@ extension String {
      */
     var numberValue: NSNumber? {
         let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
+        formatter.numberStyle = .scientific
         formatter.decimalSeparator = "."
-        return formatter.number(from: filter("01234567890.-".contains))
+        return formatter.number(from: filter("01234567890E.+-".contains))
     }
 
     var asDouble: Double {


### PR DESCRIPTION
## Description

Quantity values can sometimes contain scientific notation. For example `7E+1 °F` (70 degrees Fahrenheit).

To calculate the up/down steps, we of course have to parse this value. The current logic fails to parse the scientific notation, resulting in parsing the above as "71" (after stripping out the `E` and `+`). This of course leads to weird behavior when using the "up" and "down" buttons--e.g. hitting "up" on 70 skips 71 and jumps to 72.

This fixes the parser to accept scientific notation. There appears to be no negative effects on non-scientific notation strings, which happily parse as well.

## Changes

- Update `numberValue` in `StringExtension.swift` to accept scientific notation

## Testing

Validated correct behavior on my iPhone 11 Pro running iOS 14.2 (18B92). The changes were tested against my local openHAB 2.5.10 instance.