### PR TITLE
watchOS depreciation fixes for ComplicationController & MapView

### DIFF
--- a/openHABWatch Extension/ComplicationController.swift
+++ b/openHABWatch Extension/ComplicationController.swift
@@ -14,6 +14,21 @@ import DeviceKit
 import WatchKit
 
 class ComplicationController: NSObject, CLKComplicationDataSource {
+    // MARK: - Complication Configuration
+
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        // watchOS7: replacing depreciated CLKComplicationSupportedFamilies
+        let descriptors = [
+            CLKComplicationDescriptor(identifier: "complication", displayName: Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String, supportedFamilies: CLKComplicationFamily.allCases)
+            // Multiple complication support can be added here with more descriptors
+        ]
+        handler(descriptors)
+    }
+
+    func handleSharedComplicationDescriptors(_ complicationDescriptors: [CLKComplicationDescriptor]) {
+        // Do any necessary work to support these newly shared complication descriptors
+    }
+
     // MARK: - Timeline Configuration
 
     func getSupportedTimeTravelDirections(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationTimeTravelDirections) -> Void) {
@@ -69,37 +84,20 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
 
         switch complication.family {
         case .modularSmall:
-            template = CLKComplicationTemplateModularSmallRingImage()
-            (template as! CLKComplicationTemplateModularSmallRingImage).imageProvider =
-                CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage())
+            template = CLKComplicationTemplateModularSmallRingImage(imageProvider: CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage()), fillFraction: 1, ringStyle: CLKComplicationRingStyle.closed)
         case .utilitarianSmall:
-            template = CLKComplicationTemplateUtilitarianSmallRingImage()
-            (template as! CLKComplicationTemplateUtilitarianSmallRingImage).imageProvider =
-                CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage())
+            template = CLKComplicationTemplateUtilitarianSmallRingImage(imageProvider: CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage()), fillFraction: 1, ringStyle: CLKComplicationRingStyle.closed)
         case .circularSmall:
-            template = CLKComplicationTemplateCircularSmallRingImage()
-            (template as! CLKComplicationTemplateCircularSmallRingImage).imageProvider =
-                CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage())
+            template = CLKComplicationTemplateCircularSmallRingImage(imageProvider: CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage()), fillFraction: 1, ringStyle: CLKComplicationRingStyle.closed)
         case .extraLarge:
-            template = CLKComplicationTemplateExtraLargeSimpleImage()
-            (template as! CLKComplicationTemplateExtraLargeSimpleImage).imageProvider =
-                CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage())
+            template = CLKComplicationTemplateExtraLargeSimpleImage(imageProvider: CLKImageProvider(onePieceImage: UIImage(named: "OHTemplateIcon") ?? UIImage()))
         case .graphicCorner:
-            let modTemplate = CLKComplicationTemplateGraphicCornerTextImage()
-            modTemplate.imageProvider = CLKFullColorImageProvider(fullColorImage: getGraphicCornerImage())
-            modTemplate.textProvider = CLKSimpleTextProvider(text: "openHAB")
-            template = modTemplate
+            template = CLKComplicationTemplateGraphicCornerTextImage(textProvider: CLKSimpleTextProvider(text: "openHAB"), imageProvider: CLKFullColorImageProvider(fullColorImage: getGraphicCornerImage()))
         case .graphicBezel:
-            let modTemplate = CLKComplicationTemplateGraphicBezelCircularText()
-            let image = CLKComplicationTemplateGraphicCircularImage()
-            image.imageProvider = CLKFullColorImageProvider(fullColorImage: getGraphicCircularImage())
-            modTemplate.circularTemplate = image
-            modTemplate.textProvider = CLKSimpleTextProvider(text: "openHAB")
-            template = modTemplate
+            let modTemplate = CLKComplicationTemplateGraphicCircularImage(imageProvider: CLKFullColorImageProvider(fullColorImage: getGraphicCornerImage()))
+            template = CLKComplicationTemplateGraphicBezelCircularText(circularTemplate: modTemplate, textProvider: CLKSimpleTextProvider(text: "openHAB"))
         case .graphicCircular:
-            let modTemplate = CLKComplicationTemplateGraphicCircularImage()
-            modTemplate.imageProvider = CLKFullColorImageProvider(fullColorImage: getGraphicCircularImage())
-            template = modTemplate
+            template = CLKComplicationTemplateGraphicCircularImage(imageProvider: CLKFullColorImageProvider(fullColorImage: getGraphicCircularImage()))
         default: break
         }
 

--- a/openHABWatch Extension/Info.plist
+++ b/openHABWatch Extension/Info.plist
@@ -22,16 +22,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
-	<key>CLKComplicationSupportedFamilies</key>
-	<array>
-		<string>CLKComplicationFamilyCircularSmall</string>
-		<string>CLKComplicationFamilyExtraLarge</string>
-		<string>CLKComplicationFamilyGraphicBezel</string>
-		<string>CLKComplicationFamilyGraphicCircular</string>
-		<string>CLKComplicationFamilyGraphicCorner</string>
-		<string>CLKComplicationFamilyModularSmall</string>
-		<string>CLKComplicationFamilyUtilitarianSmall</string>
-	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/openHABWatch Extension/Views/Utils/MapView.swift
+++ b/openHABWatch Extension/Views/Utils/MapView.swift
@@ -12,39 +12,29 @@
 import MapKit
 import OpenHABCoreWatch
 import SwiftUI
-import UIKit
 
-struct MapView: WKInterfaceObjectRepresentable {
+struct MapView: View {
     @ObservedObject var widget: ObservableOpenHABWidget
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(
+            latitude: 40,
+            longitude: -5
+        ),
+        span: MKCoordinateSpan(
+            latitudeDelta: 0.02,
+            longitudeDelta: 0.02
+        )
+    )
 
-    func makeWKInterfaceObject(context: WKInterfaceObjectRepresentableContext<MapView>) -> WKInterfaceMap {
-        WKInterfaceMap()
-    }
-
-    func updateWKInterfaceObject(_ map: WKInterfaceMap, context: WKInterfaceObjectRepresentableContext<MapView>) {
-        if widget.item?.stateAsLocation() != nil {
-            map.addAnnotation(widget.coordinate, with: WKInterfaceMapPinColor.red)
-
-            let region = MKCoordinateRegion(
+    var body: some View {
+        Map(coordinateRegion: .constant(
+            MKCoordinateRegion(
                 center: widget.coordinate,
                 latitudinalMeters: 1000.0,
                 longitudinalMeters: 1000.0
             )
-            map.setRegion(region)
-
-        } else {
-            let span = MKCoordinateSpan(
-                latitudeDelta: 0.02,
-                longitudeDelta: 0.02
-            )
-
-            let region = MKCoordinateRegion(
-                center: CLLocationCoordinate2D(latitude: 40, longitude: -5),
-                span: span
-            )
-
-            map.setRegion(region)
-        }
+        )
+        )
     }
 }
 


### PR DESCRIPTION
original comment from @dirkbe:

> Fixing watchOS 7 depreciation warnings for ComplicationController.swift, mainly initializing functions with arguments using Xcode 13, Closes #632

see #637