### PR TITLE
Handle iconcolor in basicui for iconify icons

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
@@ -310,7 +310,7 @@ public extension OpenHABWidget {
         let refresh: Int?
         let height: Double?
         let isLeaf: Bool?
-        let iconColor: String?
+        let iconcolor: String?
         let labelcolor: String?
         let valuecolor: String?
         let service: String?
@@ -333,7 +333,7 @@ public extension OpenHABWidget {
 extension OpenHABWidget.CodingData {
     var openHABWidget: OpenHABWidget {
         let mappedWidgets = widgets.map(\.openHABWidget)
-        return OpenHABWidget(widgetId: widgetId, label: label, icon: icon, type: type, url: url, period: period, minValue: minValue, maxValue: maxValue, step: step, refresh: refresh, height: height, isLeaf: isLeaf, iconColor: iconColor, labelColor: labelcolor, valueColor: valuecolor, service: service, state: state, text: text, legend: legend, encoding: encoding, item: item?.openHABItem, linkedPage: linkedPage, mappings: mappings, widgets: mappedWidgets, visibility: visibility, switchSupport: switchSupport, forceAsItem: forceAsItem)
+        return OpenHABWidget(widgetId: widgetId, label: label, icon: icon, type: type, url: url, period: period, minValue: minValue, maxValue: maxValue, step: step, refresh: refresh, height: height, isLeaf: isLeaf, iconColor: iconcolor, labelColor: labelcolor, valueColor: valuecolor, service: service, state: state, text: text, legend: legend, encoding: encoding, item: item?.openHABItem, linkedPage: linkedPage, mappings: mappings, widgets: mappedWidgets, visibility: visibility, switchSupport: switchSupport, forceAsItem: forceAsItem)
     }
 }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
@@ -147,7 +147,7 @@ public extension Endpoint {
         return endpoint
     }
 
-    static func icon(rootUrl: String, version: Int, icon: String?, state: String, iconType: IconType) -> Endpoint {
+    static func icon(rootUrl: String, version: Int, icon: String?, state: String, iconType: IconType, iconColor: String) -> Endpoint {
         guard var icon, !icon.isEmpty else {
             return Endpoint(baseURL: "", path: "", queryItems: [])
         }
@@ -171,10 +171,14 @@ public extension Endpoint {
                     icon = components[2]
                 }
                 if source == "if" || source == "iconify" {
+                    queryItems = [URLQueryItem(name: "height", value: "64")]
+                    if !iconColor.isEmpty {
+                        queryItems.append(URLQueryItem(name: "color", value: iconColor))
+                    }
                     return Endpoint(
                         baseURL: "https://api.iconify.design/",
                         path: "/\(set)/\(icon).svg",
-                        queryItems: [URLQueryItem(name: "height", value: "64")]
+                        queryItems: queryItems
                     )
                 }
             }

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABCoreGeneralTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABCoreGeneralTests.swift
@@ -22,7 +22,8 @@ final class OpenHABCoreGeneralTests: XCTestCase {
             version: 2,
             icon: "switch",
             state: "OFF",
-            iconType: .svg
+            iconType: .svg,
+            iconColor: ""
         ).url
         XCTAssertEqual(urlc, URL(string: "http://192.169.2.1/icon/switch?state=OFF&format=SVG"), "Check endpoint creation")
     }

--- a/openHAB/OpenHABNotificationsViewController.swift
+++ b/openHAB/OpenHABNotificationsViewController.swift
@@ -100,7 +100,8 @@ class OpenHABNotificationsViewController: UITableViewController {
             version: appData!.openHABVersion,
             icon: notification.icon,
             state: "",
-            iconType: .png
+            iconType: .png,
+            iconColor: ""
         ).url {
             cell?.imageView?.kf.setImage(
                 with: iconUrl,

--- a/openHAB/OpenHABSitemapViewController.swift
+++ b/openHAB/OpenHABSitemapViewController.swift
@@ -679,6 +679,10 @@ extension OpenHABSitemapViewController: UITableViewDelegate, UITableViewDataSour
             cell = tableView.dequeueReusableCell(for: indexPath) as GenericUITableViewCell
         }
 
+        var iconColor = widget?.iconColor
+        if (iconColor == nil || iconColor!.isEmpty), traitCollection.userInterfaceStyle == .dark {
+            iconColor = "white"
+        }
         // No icon is needed for image, video, frame and web widgets
         if widget?.icon != nil, !((cell is NewImageUITableViewCell) || (cell is VideoUITableViewCell) || (cell is FrameUITableViewCell) || (cell is WebUITableViewCell)) {
             if let urlc = Endpoint.icon(
@@ -686,7 +690,8 @@ extension OpenHABSitemapViewController: UITableViewDelegate, UITableViewDataSour
                 version: appData?.openHABVersion ?? 2,
                 icon: widget?.icon,
                 state: widget?.iconState() ?? "",
-                iconType: iconType
+                iconType: iconType,
+                iconColor: iconColor!
             ).url {
                 var imageRequest = URLRequest(url: urlc)
                 imageRequest.timeoutInterval = 10.0

--- a/openHABWatch Extension/Views/Rows/ImageRow.swift
+++ b/openHABWatch Extension/Views/Rows/ImageRow.swift
@@ -43,7 +43,8 @@ struct ImageRow_Previews: PreviewProvider {
             version: 2,
             icon: "Switch",
             state: "ON",
-            iconType: .png
+            iconType: .png,
+            iconColor: ""
         ).url
         // let widget = UserData().widgets[8]
         return ImageRow(URL: iconURL)

--- a/openHABWatch Extension/Views/Utils/IconView.swift
+++ b/openHABWatch Extension/Views/Utils/IconView.swift
@@ -24,7 +24,8 @@ struct IconView: View {
             version: 2,
             icon: widget.icon,
             state: widget.item?.state ?? "",
-            iconType: .png
+            iconType: .png,
+            iconColor: ""
         ).url
     }
 


### PR DESCRIPTION
And for dark mode, if no color is specified, use white.

Note that for icons that are already colored, they won't change. Iconify only modifies icons with `fill="currentColor"`.