### PR TITLE
Fixes #734

### DIFF
--- a/openHABWatch Extension/openHABWatch Extension/external/AppMessageService.swift
+++ b/openHABWatch Extension/openHABWatch Extension/external/AppMessageService.swift
@@ -45,7 +45,7 @@ class AppMessageService: NSObject, WCSessionDelegate {
                 ObservableOpenHABDataObject.shared.ignoreSSL = ignoreSSL
             }
 
-            if let trustedCertificates = applicationContext["trustedCertificates"] as? [String: Any] {
+            if let trustedCertificates = applicationContext["trustedCertificates"] as? [String: Data] {
                 NetworkConnection.shared.serverCertificateManager.trustedCertificates = trustedCertificates
                 NetworkConnection.shared.serverCertificateManager.saveTrustedCertificates()
             }


### PR DESCRIPTION
- Migrate trustedCertificates from [String: Any] to [String: Data]
- saveTrustedCertificate() writes with PropertyListEncoder instead of NSKeyedArchiver 
- loadTrustedCertificates() attempts first decoding with PropertyListDecoder() if error is thrown it unarchives with NSKeyedUnarchiver()