### PR TITLE
Refactor onReceiveSessionTaskChallenge and onReceiveSessionTaskChallenge

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkConnection.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkConnection.swift
@@ -13,9 +13,7 @@ import Alamofire
 import Foundation
 import os.log
 
-// https://medium.com/@AladinWay/write-a-networking-layer-in-swift-4-using-alamofire-5-and-codable-part-2-perform-request-and-b5c7ee2e012d
-
-public let onReceiveSessionTaskChallenge = { (_: URLSession, _: URLSessionTask, challenge: URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?) in
+public func onReceiveSessionTaskChallenge(with challenge: URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
     os_log("onReceiveSessionTaskChallenge host:'%{PUBLIC}@'", log: .default, type: .error, challenge.protectionSpace.host)
     var disposition: URLSession.AuthChallengeDisposition = .performDefaultHandling
     var credential: URLCredential?
@@ -34,7 +32,7 @@ public let onReceiveSessionTaskChallenge = { (_: URLSession, _: URLSessionTask, 
     return (disposition, credential)
 }
 
-public let onReceiveSessionChallenge = { (_: URLSession, challenge: URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?) in
+public func onReceiveSessionChallenge(with challenge: URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
     os_log("onReceiveSessionChallenge host:'%{PUBLIC}@'", log: .default, type: .error, challenge.protectionSpace.host)
     var disposition: URLSession.AuthChallengeDisposition = .performDefaultHandling
     var credential: URLCredential?

--- a/openHAB/OpenHABSitemapViewController.swift
+++ b/openHAB/OpenHABSitemapViewController.swift
@@ -811,7 +811,7 @@ extension OpenHABSitemapViewController: AuthenticationChallengeResponsible {
                     task: URLSessionTask,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let (disposition, credential) = onReceiveSessionTaskChallenge(URLSession(configuration: .default), task, challenge)
+        let (disposition, credential) = onReceiveSessionTaskChallenge(with: challenge)
         completionHandler(disposition, credential)
     }
 
@@ -819,7 +819,7 @@ extension OpenHABSitemapViewController: AuthenticationChallengeResponsible {
     func downloader(_ downloader: ImageDownloader,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let (disposition, credential) = onReceiveSessionChallenge(URLSession(configuration: .default), challenge)
+        let (disposition, credential) = onReceiveSessionChallenge(with: challenge)
         completionHandler(disposition, credential)
     }
 }

--- a/openHAB/OpenHABWebViewController.swift
+++ b/openHAB/OpenHABWebViewController.swift
@@ -297,9 +297,9 @@ extension OpenHABWebViewController: WKNavigationDelegate {
                 var disposition: URLSession.AuthChallengeDisposition = .performDefaultHandling
                 var credential: URLCredential?
                 if challenge.protectionSpace.authenticationMethod.isAny(of: NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodDefault) {
-                    (disposition, credential) = onReceiveSessionTaskChallenge(URLSession(configuration: .default), URLSessionDataTask(), challenge)
+                    (disposition, credential) = onReceiveSessionTaskChallenge(with: challenge)
                 } else {
-                    (disposition, credential) = onReceiveSessionChallenge(URLSession(configuration: .default), challenge)
+                    (disposition, credential) = onReceiveSessionChallenge(with: challenge)
                 }
                 completionHandler(disposition, credential)
             }

--- a/openHAB/WebUITableViewCell.swift
+++ b/openHAB/WebUITableViewCell.swift
@@ -105,7 +105,7 @@ extension WebUITableViewCell: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let (disposition, credential) = onReceiveSessionChallenge(URLSession(configuration: .default), challenge)
+        let (disposition, credential) = onReceiveSessionChallenge(with: challenge)
         completionHandler(disposition, credential)
     }
 }

--- a/openHABWatch Extension/ExtensionDelegate.swift
+++ b/openHABWatch Extension/ExtensionDelegate.swift
@@ -106,7 +106,7 @@ extension ExtensionDelegate: AuthenticationChallengeResponsible {
                     task: URLSessionTask,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let (disposition, credential) = onReceiveSessionTaskChallenge(URLSession(configuration: .default), task, challenge)
+        let (disposition, credential) = onReceiveSessionTaskChallenge(with: challenge)
         completionHandler(disposition, credential)
     }
 
@@ -114,7 +114,7 @@ extension ExtensionDelegate: AuthenticationChallengeResponsible {
     func downloader(_ downloader: ImageDownloader,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let (disposition, credential) = onReceiveSessionChallenge(URLSession(configuration: .default), challenge)
+        let (disposition, credential) = onReceiveSessionChallenge(with: challenge)
         completionHandler(disposition, credential)
     }
 }


### PR DESCRIPTION
Migrate onReceiveSessionTaskChallenge and onReceiveSessionTaskChallenge from closure to function (in the past this allowed reuse code for challenge responses between Kingfisher and Alamofire libraries), simplified their signature as the first two parameters were ignored, avoids useless initializers for URLSession and URLSessionDataTask

This started as a fix for the build warning for URLSessionDataTask and revealed a refactoring opportunity.