### PR TITLE
Use commandDescription instead of stateDescription if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Prefer commandDescription options over stateDescription options if an item has them
+
 ## [Version 2.4.59, Build 1580410537] - 2023-08-19Z
 
 - Implement iconify icons

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABCommandDescription.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABCommandDescription.swift
@@ -1,0 +1,32 @@
+// Copyright (c) 2010-2023 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+
+public class OpenHABCommandDescription {
+    public var commandOptions: [OpenHABCommandOptions] = []
+
+    init(commandOptions: [OpenHABCommandOptions]?) {
+        self.commandOptions = commandOptions ?? []
+    }
+}
+
+public extension OpenHABCommandDescription {
+    struct CodingData: Decodable {
+        let commandOptions: [OpenHABCommandOptions]?
+    }
+}
+
+extension OpenHABCommandDescription.CodingData {
+    var openHABCommandDescription: OpenHABCommandDescription {
+        OpenHABCommandDescription(commandOptions: commandOptions)
+    }
+}

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABCommandOptions.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABCommandOptions.swift
@@ -1,0 +1,17 @@
+// Copyright (c) 2010-2023 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+
+public class OpenHABCommandOptions: Decodable {
+    public var command = ""
+    public var label = ""
+}

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
@@ -38,6 +38,7 @@ public final class OpenHABItem: NSObject, CommItem {
     public var link = ""
     public var label = ""
     public var stateDescription: OpenHABStateDescription?
+    public var commandDescription: OpenHABCommandDescription?
     public var readOnly = false
     public var members: [OpenHABItem] = []
     public var category = ""
@@ -52,7 +53,7 @@ public final class OpenHABItem: NSObject, CommItem {
             isOfTypeOrGroupType(ItemType.player)
     }
 
-    public init(name: String, type: String, state: String?, link: String, label: String?, groupType: String?, stateDescription: OpenHABStateDescription?, members: [OpenHABItem], category: String?, options: [OpenHABOptions]?) {
+    public init(name: String, type: String, state: String?, link: String, label: String?, groupType: String?, stateDescription: OpenHABStateDescription?, commandDescription: OpenHABCommandDescription?, members: [OpenHABItem], category: String?, options: [OpenHABOptions]?) {
         self.name = name
         self.type = type.toItemType()
         if let state, state == "NULL" || state == "UNDEF" || state.caseInsensitiveCompare("undefined") == .orderedSame {
@@ -64,6 +65,7 @@ public final class OpenHABItem: NSObject, CommItem {
         self.label = label.orEmpty
         self.groupType = groupType?.toItemType()
         self.stateDescription = stateDescription
+        self.commandDescription = commandDescription
         readOnly = stateDescription?.readOnly ?? false
         self.members = members
         self.category = category.orEmpty
@@ -146,6 +148,7 @@ public extension OpenHABItem {
         let state: String?
         let label: String?
         let stateDescription: OpenHABStateDescription.CodingData?
+        let commandDescription: OpenHABCommandDescription.CodingData?
         let members: [OpenHABItem.CodingData]?
         let category: String?
         let options: [OpenHABOptions]?
@@ -156,7 +159,7 @@ public extension OpenHABItem.CodingData {
     var openHABItem: OpenHABItem {
         let mappedMembers = members?.map(\.openHABItem) ?? []
 
-        return OpenHABItem(name: name, type: type, state: state, link: link, label: label, groupType: groupType, stateDescription: stateDescription?.openHABStateDescription, members: mappedMembers, category: category, options: options)
+        return OpenHABItem(name: name, type: type, state: state, link: link, label: label, groupType: groupType, stateDescription: stateDescription?.openHABStateDescription, commandDescription: commandDescription?.openHABCommandDescription, members: mappedMembers, category: category, options: options)
     }
 }
 

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
@@ -120,8 +120,10 @@ public class OpenHABWidget: NSObject, MKAnnotation, Identifiable {
     }
 
     public var mappingsOrItemOptions: [OpenHABWidgetMapping] {
-        if mappings.isEmpty, let itemOptions = item?.stateDescription?.options {
-            itemOptions.map { OpenHABWidgetMapping(command: $0.value, label: $0.label) }
+        if mappings.isEmpty, let commandOptions = item?.commandDescription?.commandOptions {
+            commandOptions.map { OpenHABWidgetMapping(command: $0.command, label: $0.label) }
+        } else if mappings.isEmpty, let stateOptions = item?.stateDescription?.options {
+            stateOptions.map { OpenHABWidgetMapping(command: $0.value, label: $0.label) }
         } else {
             mappings
         }

--- a/openHABWatch Extension/openHABWatch Extension/Model/ObservableOpenHABWidget.swift
+++ b/openHABWatch Extension/openHABWatch Extension/Model/ObservableOpenHABWidget.swift
@@ -97,8 +97,10 @@ class ObservableOpenHABWidget: NSObject, MKAnnotation, Identifiable, ObservableO
     }
 
     var mappingsOrItemOptions: [OpenHABWidgetMapping] {
-        if mappings.isEmpty, let itemOptions = item?.stateDescription?.options {
-            itemOptions.map { OpenHABWidgetMapping(command: $0.value, label: $0.label) }
+        if mappings.isEmpty, let commandOptions = item?.commandDescription?.commandOptions {
+            commandOptions.map { OpenHABWidgetMapping(command: $0.command, label: $0.label) }
+        } else if mappings.isEmpty, let stateOptions = item?.stateDescription?.options {
+            stateOptions.map { OpenHABWidgetMapping(command: $0.value, label: $0.label) }
         } else {
             mappings
         }


### PR DESCRIPTION
Sometimes they differ (for example, I have a lock that gives a command description with LOCK, UNLOCK, OPEN options, but a state description with LOCKED, UNLOCKED, JAMMED options.