### PR TITLE
Improve on formatting issue #752

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
@@ -23,6 +23,7 @@ public struct NumberState: CustomStringConvertible, Equatable {
     public var intValue: Int {
         Int(value)
     }
+
     public var stringValue: String {
         String(value)
     }
@@ -38,16 +39,15 @@ public struct NumberState: CustomStringConvertible, Equatable {
         if let format, !format.isEmpty {
             let actualFormat = format
                 .replacingOccurrences(of: "%unit%", with: unit ?? "")
-            // %s in Java is for Strings, but does not work in Swift, see
-            // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)
+                // %s in Java is for Strings, but does not work in Swift, see
+                // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)
                 .replacingOccurrences(of: "%s", with: "%@")
-            let formatValue: CVarArg
-            if format.contains("%d") {
-                formatValue = intValue
+            let formatValue: CVarArg = if format.contains("%d") {
+                intValue
             } else if format.contains("%s") {
-                formatValue = stringValue
+                stringValue
             } else {
-                formatValue = value
+                value
             }
             return String(format: actualFormat, locale: locale, formatValue)
         }

--- a/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
@@ -20,6 +20,13 @@ public struct NumberState: CustomStringConvertible, Equatable {
     private(set) var unit: String? = ""
     private(set) var format: String? = ""
 
+    public var intValue: Int {
+        Int(value)
+    }
+    public var stringValue: String {
+        String(value)
+    }
+
     // Access to default memberwise initializer not permitted outside of package
     public init(value: Double, unit: String? = "", format: String? = "") {
         self.value = value
@@ -28,28 +35,32 @@ public struct NumberState: CustomStringConvertible, Equatable {
     }
 
     public func toString(locale: Locale?) -> String {
-        if let format, format.isEmpty == false {
-            let actualFormat = format.replacingOccurrences(of: "%unit%", with: unit ?? "")
-            if format.contains("%d") == true {
-                return String(format: actualFormat, locale: locale, Int(value))
+        if let format, !format.isEmpty {
+            let actualFormat = format
+                .replacingOccurrences(of: "%unit%", with: unit ?? "")
+            // %s in Java is for Strings, but does not work in Swift, see
+            // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)
+                .replacingOccurrences(of: "%s", with: "%@")
+            let formatValue: CVarArg
+            if format.contains("%d") {
+                formatValue = intValue
+            } else if format.contains("%s") {
+                formatValue = stringValue
             } else {
-                return String(format: actualFormat, locale: locale, value)
+                formatValue = value
             }
+            return String(format: actualFormat, locale: locale, formatValue)
         }
-        if let unit, unit.isEmpty == false {
-            return "\(formatValue()) \(unit)"
+        if let unit, !unit.isEmpty {
+            return "\(stringValue) \(unit)"
         } else {
-            return formatValue()
+            return stringValue
         }
-    }
-
-    public func formatValue() -> String {
-        String(value)
     }
 
     private func getActualValue() -> NSNumber {
         if format?.contains("%d") == true {
-            NSNumber(value: Int(value))
+            NSNumber(value: intValue)
         } else {
             NSNumber(value: value)
         }

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
@@ -155,7 +155,7 @@ public class OpenHABWidget: NSObject, MKAnnotation, Identifiable {
             sendCommand(state.toString(locale: Locale(identifier: "US")))
         } else {
             // For all other items, send the plain value
-            sendCommand(state.formatValue())
+            sendCommand(state.stringValue)
         }
     }
 

--- a/openHAB/SetpointUITableViewCell.swift
+++ b/openHAB/SetpointUITableViewCell.swift
@@ -42,7 +42,8 @@ class SetpointUITableViewCell: GenericUITableViewCell {
         var numberState = widget?.stateValueAsNumberState
         let stateValue = numberState?.value ?? widget.minValue
         let newValue: Double = down ? stateValue - widget.step : stateValue + widget.step
-        let limitedNewValue = max(widget.minValue, min(widget.maxValue, newValue))
+
+        let limitedNewValue = newValue.clamped(to: widget.minValue ... widget.maxValue)
 
         guard limitedNewValue != stateValue else {
             // nothing to update, skip sending value

--- a/openHAB/SetpointUITableViewCell.swift
+++ b/openHAB/SetpointUITableViewCell.swift
@@ -41,21 +41,21 @@ class SetpointUITableViewCell: GenericUITableViewCell {
     private func handleUpDown(down: Bool) {
         var numberState = widget?.stateValueAsNumberState
         let stateValue = numberState?.value ?? widget.minValue
-        let newValue: Double = switch down {
-        case true:
-            stateValue - widget.step
-        case false:
-            stateValue + widget.step
-        }
-        if newValue >= widget.minValue, newValue <= widget.maxValue {
-            if numberState != nil {
-                numberState?.value = newValue
-            } else {
-                numberState = NumberState(value: newValue)
-            }
+        let newValue: Double = down ? stateValue - widget.step : stateValue + widget.step
+        let limitedNewValue = max(widget.minValue, min(widget.maxValue, newValue))
 
-            widget.sendItemUpdate(state: numberState)
+        guard limitedNewValue != stateValue else {
+            // nothing to update, skip sending value
+            return
         }
+
+        if numberState != nil {
+            numberState?.value = newValue
+        } else {
+            numberState = NumberState(value: newValue)
+        }
+
+        widget.sendItemUpdate(state: numberState)
     }
 
     @objc

--- a/openHABWatch Extension/openHABWatch Extension/Model/ObservableOpenHABWidget.swift
+++ b/openHABWatch Extension/openHABWatch Extension/Model/ObservableOpenHABWidget.swift
@@ -180,7 +180,7 @@ class ObservableOpenHABWidget: NSObject, MKAnnotation, Identifiable, ObservableO
             sendCommand(state.toString(locale: Locale(identifier: "US")))
         } else {
             // For all other items, send the plain value
-            sendCommand(state.formatValue())
+            sendCommand(state.stringValue)
         }
     }
 


### PR DESCRIPTION
In the app there are crashes due to formatting issues. 

Reason: Java placeholders (https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax) as intended to be used by the OpenHab Sitemap specification (https://www.openhab.org/docs/configuration/items.html#state-presentation) were used in String.format in Swift, which uses the CString format specifiers (https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFStrings/formatSpecifiers.html). 

The solution adds support for the %s format specifier. In the future, a java-placeholder-compatible format method should be introduced.