### PR TITLE
Webview caching enhancements

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagCache.swift
@@ -1,0 +1,121 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+import os.log
+
+/// Persistent storage for HTTP ETags used for change detection in our Webviews which our MainUI uses extensively for asset caching
+public actor ETagCache {
+    public static let shared = ETagCache()
+
+    private var etags: [String: String] = [:]
+    private let persistencePath: URL?
+
+    public init() {
+        // Calculate the default persistence path
+        let path: URL
+        // Maybe this could be used for the watch? We will keep it compatable just in case.
+        #if os(watchOS)
+        let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        path = URL(fileURLWithPath: documentsDirectory).appendingPathComponent("etagCache")
+        #else
+        // Try app group container first, fall back to documents directory for testing
+        if let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.openhab.app") {
+            path = appGroupURL.appendingPathComponent("etagCache")
+        } else {
+            // Fallback for test environment where app group may not be available
+            let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+            path = URL(fileURLWithPath: documentsDirectory).appendingPathComponent("etagCache")
+        }
+        #endif
+
+        persistencePath = path
+        let loadedETags = Self.loadETags(from: path)
+        etags = loadedETags
+        Logger.etagCache.info("ETagCache initialized with \(loadedETags.count) cached ETags")
+    }
+
+    /// Creates an ETagCache for testing with an optional custom persistence path.
+    /// Pass `nil` for in-memory only operation (no file I/O).
+    public init(persistencePath: URL?) {
+        self.persistencePath = persistencePath
+        if let path = persistencePath {
+            etags = Self.loadETags(from: path)
+        } else {
+            etags = [:]
+        }
+    }
+
+    // MARK: - Type Methods
+
+    private static func loadETags(from path: URL) -> [String: String] {
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            Logger.etagCache.debug("No existing ETag cache file found")
+            return [:]
+        }
+
+        do {
+            let data = try Data(contentsOf: path)
+            let decoded = try PropertyListDecoder().decode([String: String].self, from: data)
+            Logger.etagCache.info("Loaded \(decoded.count) ETags from disk")
+            return decoded
+        } catch {
+            Logger.etagCache.error("Failed to load ETags: \(error.localizedDescription)")
+            return [:]
+        }
+    }
+
+    // MARK: - Instance Methods
+
+    /// Retrieves the cached ETag for a given URL
+    public func getETag(for url: String) -> String? {
+        etags[url]
+    }
+
+    /// Stores an ETag for a given URL and persists to disk
+    public func storeETag(_ etag: String, for url: String) async {
+        etags[url] = etag
+        await saveETags()
+        Logger.etagCache.debug("Stored ETag for \(url): \(etag)")
+    }
+
+    /// Removes the cached ETag for a given URL
+    public func clearETag(for url: String) async {
+        etags.removeValue(forKey: url)
+        await saveETags()
+        Logger.etagCache.debug("Cleared ETag for \(url)")
+    }
+
+    /// Clears all cached ETags
+    public func clearAll() async {
+        etags.removeAll()
+        await saveETags()
+        Logger.etagCache.info("Cleared all cached ETags")
+    }
+
+    // MARK: - Persistence
+
+    private func saveETags() async {
+        guard let path = persistencePath else {
+            Logger.etagCache.debug("No persistence path, skipping save")
+            return
+        }
+
+        do {
+            let etagsToSave = etags
+            let data = try PropertyListEncoder().encode(etagsToSave)
+            try data.write(to: path, options: [.atomic])
+            Logger.etagCache.debug("Saved \(etagsToSave.count) ETags to disk")
+        } catch {
+            Logger.etagCache.error("Failed to save ETags: \(error.localizedDescription)")
+        }
+    }
+}

--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagCache.swift
@@ -22,7 +22,7 @@ public actor ETagCache {
     public init() {
         // Calculate the default persistence path
         let path: URL
-        // Maybe this could be used for the watch? We will keep it compatable just in case.
+        // Maybe this could be used for the watch? We will keep it compatible just in case.
         #if os(watchOS)
         let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
         path = URL(fileURLWithPath: documentsDirectory).appendingPathComponent("etagCache")

--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
@@ -22,10 +22,17 @@ public enum ETagCheckResult: Sendable {
 /// Service for checking if remote content has changed using HTTP ETags
 public actor ETagChecker {
     private let httpClient: HTTPClient
-    private let cache = ETagCache.shared
+    private let cache: ETagCache
 
     public init(httpClient: HTTPClient) {
         self.httpClient = httpClient
+        cache = ETagCache.shared
+    }
+
+    // Internal initializer for testing - allows cache injection
+    init(httpClient: HTTPClient, cache: ETagCache) {
+        self.httpClient = httpClient
+        self.cache = cache
     }
 
     /// Checks if content at the given URL has changed since last check

--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
@@ -1,0 +1,100 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+import os.log
+
+/// Result of an ETag check operation
+public enum ETagCheckResult: Sendable {
+    case unchanged // Content hasn't changed, skip reloading and depend on the webview's cache
+    case changed // Content has changed, reload
+    case failed(any Error) // Check failed, reload
+}
+
+/// Service for checking if remote content has changed using HTTP ETags
+public actor ETagChecker {
+    private let httpClient: HTTPClient
+    private let cache = ETagCache.shared
+
+    public init(httpClient: HTTPClient) {
+        self.httpClient = httpClient
+    }
+
+    /// Checks if content at the given URL has changed since last check
+    /// - Parameter url: The URL to check
+    /// - Returns: ETagCheckResult indicating whether content changed
+    public func checkIfChanged(url: URL) async -> ETagCheckResult {
+        let urlString = url.absoluteString
+
+        // Get cached ETag
+        let cachedETag = await cache.getETag(for: urlString)
+
+        do {
+            // Perform HEAD request with 5 second timeout, worst case we reload, but lets not delay stuff
+            let (_, response): (Data, URLResponse) = try await httpClient.doRequest(
+                baseURL: url,
+                timeout: 5.0,
+                method: "HEAD",
+                type: .data
+            )
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                Logger.etagChecker.warning("Response is not HTTPURLResponse")
+                return .changed
+            }
+
+            var newETag: String?
+            for (key, value) in httpResponse.allHeaderFields {
+                if let keyString = key as? String, keyString.lowercased() == "etag", let valueString = value as? String {
+                    newETag = valueString
+                    break
+                }
+            }
+
+            guard let newETag else {
+                Logger.etagChecker.debug("No ETag header in response for \(urlString)")
+                return .changed // Server doesn't support ETags, always reload
+            }
+
+            let normalizedNewETag = normalizeETag(newETag)
+            Logger.etagChecker.debug("Received ETag for \(urlString): \(normalizedNewETag)")
+
+            // First time checking this URL - store and reload
+            guard let cachedETag else {
+                Logger.etagChecker.info("First time checking \(urlString), storing ETag and reloading")
+                await cache.storeETag(normalizedNewETag, for: urlString)
+                return .changed
+            }
+
+            let normalizedCachedETag = normalizeETag(cachedETag)
+
+            if normalizedNewETag == normalizedCachedETag {
+                Logger.etagChecker.info("ETag unchanged for \(urlString)")
+                return .unchanged
+            } else {
+                Logger.etagChecker.info("ETag changed for \(urlString): \(normalizedCachedETag) -> \(normalizedNewETag)")
+                await cache.storeETag(normalizedNewETag, for: urlString)
+                return .changed
+            }
+
+        } catch {
+            Logger.etagChecker.warning("ETag check failed for \(urlString): \(error.localizedDescription)")
+            return .failed(error)
+        }
+    }
+
+    /// Normalizes an ETag by removing surrounding quotes
+    /// - Parameter etag: The raw ETag from HTTP header
+    /// - Returns: Normalized ETag without quotes
+    private func normalizeETag(_ etag: String) -> String {
+        etag.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+}

--- a/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
@@ -355,6 +355,7 @@ public final class HTTPClient: NSObject, Sendable {
                              headers: [String: String]? = nil,
                              timeout: TimeInterval = 60.0,
                              body: String? = nil,
+                             method: String = "GET",
                              type: SessionType,
                              cacheingPolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) async throws -> (T, URLResponse) {
         guard var url = baseURL ?? self.baseURL else {
@@ -367,7 +368,7 @@ public final class HTTPClient: NSObject, Sendable {
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        request.httpMethod = method
         request.timeoutInterval = timeout
 
         if let headers {

--- a/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
@@ -30,6 +30,10 @@ public extension Logger {
 
     static let endpoint = Logger(subsystem: subsystem, category: "EndPoint")
 
+    static let etagCache = Logger(subsystem: subsystem, category: "ETagCache")
+
+    static let etagChecker = Logger(subsystem: subsystem, category: "ETagChecker")
+
     static let httpClient = Logger(subsystem: subsystem, category: "HTTPClient")
 
     static let httpClientDelegate = Logger(subsystem: subsystem, category: "HTTPClientDelegate")

--- a/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
@@ -1,0 +1,312 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+@testable import OpenHABCore
+import Testing
+
+@Suite("ETagChecker Tests", .serialized)
+struct ETagCheckerTests {
+    @Test("First run stores ETag and returns changed")
+    func firstRunStoresETag() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/index.html")!
+        let etagValue = "\"abc123\""
+
+        // Setup mock
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": etagValue])
+
+        // Create test instance
+        let cache = makeInMemoryCache()
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        // First check should return .changed
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .changed = result else {
+            Issue.record("Expected .changed, got \(result)")
+            return
+        }
+
+        // Verify ETag was stored (normalized without quotes)
+        let storedETag = await cache.getETag(for: testURL.absoluteString)
+        #expect(storedETag == "abc123")
+    }
+
+    @Test("Returns unchanged when ETag matches")
+    func unchangedWhenETagMatches() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/data.json")!
+        let etagValue = "\"def456\""
+
+        // Pre-populate cache
+        let cache = makeInMemoryCache()
+        await cache.storeETag(etagValue, for: testURL.absoluteString)
+
+        // Mock returns same ETag
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": etagValue])
+
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .unchanged = result else {
+            Issue.record("Expected .unchanged, got \(result)")
+            return
+        }
+    }
+
+    @Test("Returns changed when ETag differs")
+    func changedWhenETagDiffers() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/api/v1/data")!
+        let oldETag = "\"old123\""
+        let newETag = "\"new456\""
+
+        // Pre-populate cache with old ETag
+        let cache = makeInMemoryCache()
+        await cache.storeETag(oldETag, for: testURL.absoluteString)
+
+        // Mock returns different ETag
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": newETag])
+
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .changed = result else {
+            Issue.record("Expected .changed, got \(result)")
+            return
+        }
+
+        // Verify cache was updated with new ETag (normalized without quotes)
+        let storedETag = await cache.getETag(for: testURL.absoluteString)
+        #expect(storedETag == "new456")
+    }
+
+    @Test("Returns failed when network request fails")
+    func failedOnNetworkError() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/fail")!
+
+        // Configure mock to fail
+        MockURLProtocol.shouldFail = true
+        MockURLProtocol.error = URLError(.networkConnectionLost)
+
+        let cache = makeInMemoryCache()
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .failed = result else {
+            Issue.record("Expected .failed, got \(result)")
+            return
+        }
+    }
+
+    @Test("Returns changed when no ETag header present")
+    func changedWhenNoETagHeader() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/no-etag")!
+
+        // Mock response without ETag header
+        MockURLProtocol.mockResponses[testURL] = (200, [:])
+
+        let cache = makeInMemoryCache()
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .changed = result else {
+            Issue.record("Expected .changed (no ETag), got \(result)")
+            return
+        }
+    }
+
+    @Test("Normalizes quoted ETags")
+    func normalizesQuotedETags() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/normalize")!
+        let quotedETag = "\"abc123\""
+        let unquotedETag = "abc123"
+
+        // Store quoted version
+        let cache = makeInMemoryCache()
+        await cache.storeETag(quotedETag, for: testURL.absoluteString)
+
+        // Mock returns unquoted (after normalization they should match)
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": unquotedETag])
+
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        // Should recognize as unchanged (normalized comparison)
+        guard case .unchanged = result else {
+            Issue.record("Expected .unchanged (normalized), got \(result)")
+            return
+        }
+    }
+
+    @Test("Handles case-insensitive ETag header")
+    func caseInsensitiveETagHeader() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/case-test")!
+        let etagValue = "\"xyz789\""
+
+        // Mock with lowercase "etag" (not "ETag")
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": etagValue])
+
+        let cache = makeInMemoryCache()
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .changed = result else {
+            Issue.record("Expected .changed, got \(result)")
+            return
+        }
+
+        // Verify it found and stored the ETag (normalized without quotes)
+        let storedETag = await cache.getETag(for: testURL.absoluteString)
+        #expect(storedETag == "xyz789")
+    }
+
+    @Test("Weak ETags are supported")
+    func weakETagsSupported() async throws {
+        MockURLProtocol.reset()
+
+        let testURL = URL(string: "https://example.com/weak-etag")!
+        let weakETag = "W/\"abc123\""
+
+        // Store weak ETag
+        let cache = makeInMemoryCache()
+        await cache.storeETag(weakETag, for: testURL.absoluteString)
+
+        // Mock returns same weak ETag
+        MockURLProtocol.mockResponses[testURL] = (200, ["etag": weakETag])
+
+        let httpClient = makeMockHTTPClient()
+        let checker = ETagChecker(httpClient: httpClient, cache: cache)
+
+        let result = await checker.checkIfChanged(url: testURL)
+
+        guard case .unchanged = result else {
+            Issue.record("Expected .unchanged (weak ETag match), got \(result)")
+            return
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func makeInMemoryCache() -> ETagCache {
+        ETagCache(persistencePath: nil)
+    }
+
+    private func makeMockHTTPClient() -> HTTPClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+
+        // Create ConnectionConfiguration with dummy values
+        let connConfig = ConnectionConfiguration(
+            url: "https://example.com",
+            username: "",
+            password: "",
+            alwaysSendBasicAuth: false,
+            ignoreSSL: false,
+            priority: 0
+        )
+
+        return HTTPClient(
+            baseURL: nil,
+            connectionConfiguration: connConfig,
+            sessionConfiguration: config
+        )
+    }
+}
+
+// MARK: - Mock URLProtocol
+
+class MockURLProtocol: URLProtocol {
+    // Use nonisolated(unsafe) to suppress concurrency warnings
+    // Safe because tests run with .serialized, ensuring sequential execution
+    nonisolated(unsafe) static var mockResponses: [URL: (statusCode: Int, headers: [String: String])] = [:]
+    nonisolated(unsafe) static var shouldFail: Bool = false
+    nonisolated(unsafe) static var error: Error?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        if MockURLProtocol.shouldFail {
+            let error = MockURLProtocol.error ?? URLError(.badServerResponse)
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        guard let mock = MockURLProtocol.mockResponses[url] else {
+            // Return 404 if no mock configured
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 404,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data())
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: mock.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: mock.headers
+        )!
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        mockResponses.removeAll()
+        shouldFail = false
+        error = nil
+    }
+}

--- a/openHAB/DrawerView.swift
+++ b/openHAB/DrawerView.swift
@@ -17,6 +17,10 @@ import SafariServices
 import SFSafeSymbols
 import SwiftUI
 
+class CurrentViewState: ObservableObject {
+    @Published var isWebViewActive = false
+}
+
 enum DrawerViewError: Error, CustomDebugStringConvertible {
     case noRootURL
 
@@ -85,6 +89,7 @@ struct DrawerView: View {
     @State private var connectedUrl = "Not connected" // Default label text
 
     @EnvironmentObject private var networkTracker: MainActorNetworkTracker
+    @EnvironmentObject private var currentViewState: CurrentViewState
 
     var onDismiss: (TargetController) -> Void
     @Environment(\.dismiss) private var dismiss
@@ -96,7 +101,13 @@ struct DrawerView: View {
     var mainSection: some View {
         Section(header: Text("Main")) {
             menuEntry(image: Image("openHABIcon").resizable(), goTo: .webview) {
-                Text("Home").accessibilityIdentifier("Home")
+                HStack {
+                    Text("Home").accessibilityIdentifier("Home")
+                    if currentViewState.isWebViewActive {
+                        Spacer()
+                        Image(systemSymbol: .arrowClockwise)
+                    }
+                }
             }
         }
     }
@@ -280,8 +291,20 @@ struct DrawerView: View {
     }
 }
 
-#Preview {
+#Preview("WebView Active") {
     let networkTracker = MainActorNetworkTracker.shared
-    DrawerView { _ in }
+    let currentViewState = CurrentViewState()
+    currentViewState.isWebViewActive = true
+    return DrawerView { _ in }
         .environmentObject(networkTracker)
+        .environmentObject(currentViewState)
+}
+
+#Preview("WebView Inactive") {
+    let networkTracker = MainActorNetworkTracker.shared
+    let currentViewState = CurrentViewState()
+    currentViewState.isWebViewActive = false
+    return DrawerView { _ in }
+        .environmentObject(networkTracker)
+        .environmentObject(currentViewState)
 }

--- a/openHAB/DrawerView.swift
+++ b/openHAB/DrawerView.swift
@@ -106,6 +106,7 @@ struct DrawerView: View {
                     if currentViewState.isWebViewActive {
                         Spacer()
                         Image(systemSymbol: .arrowClockwise)
+                            .accessibilityHidden(true)
                     }
                 }
             }

--- a/openHAB/OpenHABRootViewController.swift
+++ b/openHAB/OpenHABRootViewController.swift
@@ -41,6 +41,7 @@ class OpenHABRootViewController: UIViewController {
     var currentView: OpenHABViewController!
     var isDemoMode = false
     var cancellables = Set<AnyCancellable>()
+    private let currentViewState = CurrentViewState()
     private var streamTask: Task<Void, Never>?
 
     private var apsRegistrationData: [AnyHashable: Any]?
@@ -315,6 +316,7 @@ class OpenHABRootViewController: UIViewController {
             self.handleDismiss(mode: mode)
         }
         .environmentObject(networkTracker)
+        .environmentObject(currentViewState)
         let hostingController = UIHostingController(rootView: drawerView)
         let menu = SideMenuNavigationController(rootViewController: hostingController)
 
@@ -790,6 +792,9 @@ class OpenHABRootViewController: UIViewController {
             }
             addView(viewController: targetView)
             currentView = targetView
+
+            // Update webview active state
+            currentViewState.isWebViewActive = (targetView == webViewController)
 
             // Don't save our view in demo mode
             if !Preferences.shared.currentHomePreferences.demomode {

--- a/openHAB/OpenHABWebViewController.swift
+++ b/openHAB/OpenHABWebViewController.swift
@@ -30,6 +30,9 @@ class OpenHABWebViewController: OpenHABViewController {
     private var views: [UUID: WKWebView] = [:]
     // TODO: remove myOhViews when we drop iOS 16 support
     private var myOhViews: [UUID: WKWebView] = [:]
+    private var etagChecker: ETagChecker?
+    private var etagCheckerConfigURL: String? // Track which config the checker was created for
+    private var lastLoadedURL: String? // Track the last successfully loaded URL from didFinish
 
     private var js = """
     (function() {
@@ -108,6 +111,15 @@ class OpenHABWebViewController: OpenHABViewController {
                 }
             }
             .store(in: &trackerCancellables)
+
+        // Listen for app becoming active to check for content updates
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
         startTracker()
     }
 
@@ -118,12 +130,20 @@ class OpenHABWebViewController: OpenHABViewController {
         navigationController?.setNavigationBarHidden(false, animated: animated)
         navigationController?.navigationBar.prefersLargeTitles = true
         trackerCancellables.removeAll()
+
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     func startTracker() {
         if currentTarget.isEmpty {
             showActivityIndicator(show: true)
         }
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        // When app returns from background, check if content has changed
+        Logger.viewController.info("App became active, checking for content updates")
+        loadWebView(force: false)
     }
 
     @MainActor
@@ -134,16 +154,44 @@ class OpenHABWebViewController: OpenHABViewController {
         let authStr = "\(activeConfig.username):\(activeConfig.password)"
         let newTarget = "\(activeConfig.url):\(authStr)"
 
-        if !force, currentTarget == newTarget {
-            showActivityIndicator(show: false)
+        // If force reload, skip ETag check and always reload
+        if force {
+            Task {
+                await performLoadWebView(newTarget: newTarget, path: path, force: true)
+            }
             return
         }
+
+        // Check ETag before loading (even if target hasn't changed - content might have updated)
+        Task {
+            await loadWebViewWithETagCheck(newTarget: newTarget, path: path)
+        }
+    }
+
+    @MainActor
+    private func performLoadWebView(newTarget: String, path: String?, force: Bool) async {
+        guard let activeConfig else { return }
         currentTarget = newTarget
         let url = URL(string: activeConfig.url)
 
         if let modifiedUrl = modifyUrl(orig: url, path: path) {
             acceptsCommands = false
-            let request = URLRequest(url: modifiedUrl)
+            var request = URLRequest(url: modifiedUrl)
+
+            // When force reloading, bypass ALL caches (both URLRequest and WKWebView)
+            if force {
+                // Clear WKWebView's internal cache
+                let dataStore = webView.configuration.websiteDataStore
+                let websiteDataTypes: Set<String> = [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache]
+                let date = Date(timeIntervalSince1970: 0)
+
+                Logger.viewController.info("Force reload: clearing WKWebView cache")
+                await dataStore.removeData(ofTypes: websiteDataTypes, modifiedSince: date)
+
+                // Set aggressive cache policy for URLRequest
+                request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            }
+
             // TODO: remove this check once iOS 16 is dropped
             let isMyOh = url?.host?.contains("myopenhab.org") ?? false
             // create new (or resuse existing)
@@ -162,6 +210,91 @@ class OpenHABWebViewController: OpenHABViewController {
             Logger.viewController.info("Loading URL: \(modifiedUrl)")
             webView.load(request)
         }
+    }
+
+    @MainActor
+    private func loadWebViewWithETagCheck(newTarget: String, path: String?) async {
+        guard let activeConfig,
+              let url = URL(string: activeConfig.url),
+              let fullURL = modifyUrl(orig: url, path: path) else {
+            Logger.viewController.info("ETag check skipped: invalid configuration")
+            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            return
+        }
+
+        // Create checker if needed (lazy initialization) or if config changed
+        let configKey = "\(activeConfig.url):\(activeConfig.username)"
+        if etagChecker == nil || etagCheckerConfigURL != configKey {
+            let httpClient = HTTPClient(baseURL: nil, connectionConfiguration: activeConfig)
+            etagChecker = ETagChecker(httpClient: httpClient)
+            etagCheckerConfigURL = configKey
+            Logger.viewController.debug("Created new ETagChecker for config: \(configKey)")
+        }
+
+        guard let checker = etagChecker else {
+            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            return
+        }
+
+        // Check if content changed
+        let result = await checker.checkIfChanged(url: fullURL)
+
+        switch result {
+        case .unchanged:
+            // When ETag is unchanged, the base resource (HTML/JS) hasn't changed
+            // Compare base URLs (origin) only, since paths are handled by client-side routing
+            let normalizedTarget = normalizeURLForComparison(fullURL.absoluteString, includeBasePath: false)
+            let normalizedLoaded = normalizeURLForComparison(lastLoadedURL, includeBasePath: false)
+
+            Logger.viewController.debug("ETag unchanged - comparing base URLs: loaded=\(normalizedLoaded ?? "nil") vs target=\(normalizedTarget ?? "nil")")
+
+            if let normalizedTarget, let normalizedLoaded, normalizedLoaded == normalizedTarget {
+                Logger.viewController.info("ETag unchanged and same base URL, skipping load")
+                currentTarget = newTarget
+                showActivityIndicator(show: false)
+                // Don't load - same server, same content version, already displayed
+            } else {
+                Logger.viewController.info("ETag unchanged but different base URL, loading \(fullURL.absoluteString)")
+                await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            }
+
+        case .changed:
+            Logger.viewController.info("ETag changed, loading \(fullURL.absoluteString)")
+            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+
+        case let .failed(error):
+            Logger.viewController.info("ETag check failed: \(error.localizedDescription), loading anyway")
+            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+        }
+    }
+
+    /// Normalizes URLs for comparison
+    /// - Parameters:
+    ///   - urlString: The URL string to normalize
+    ///   - includeBasePath: If true, includes the path component; if false, returns only the base URL (origin)
+    /// - Returns: Normalized URL string
+    private func normalizeURLForComparison(_ urlString: String?, includeBasePath: Bool = false) -> String? {
+        guard let urlString, let url = URL(string: urlString) else { return nil }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+        // Always remove fragment (everything after #)
+        components?.fragment = nil
+
+        // For base URL comparison (when includeBasePath == false), remove the path entirely
+        if !includeBasePath {
+            components?.path = ""
+            components?.query = nil
+        }
+
+        guard var normalized = components?.url?.absoluteString else { return nil }
+
+        // Remove trailing slash for consistent comparison
+        if normalized.hasSuffix("/") {
+            normalized = String(normalized.dropLast())
+        }
+
+        return normalized
     }
 
     func modifyUrl(orig: URL?, path: String? = nil) -> URL? {
@@ -425,6 +558,9 @@ extension OpenHABWebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Logger.viewController.info("didFinish - webView.url: \(String(describing: webView.url?.description))")
+
+        // Track the successfully loaded URL for ETag comparison
+        lastLoadedURL = webView.url?.absoluteString
 
         setHideNavigationBar(shouldHide: true)
         showActivityIndicator(show: false)


### PR DESCRIPTION
Agressively clears the cache when reloading
uses Etag headers to determine if a new version of the web app is needed when the view becomes active Adds the "reload" icon back to the Drawer menu when the webview is active

Fixes #1063