### PR TITLE
Fix crash when dataImageBase64Payload receives a non-base64 data URL

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
@@ -192,7 +192,7 @@ public extension String? {
 public extension String {
     var dataImageBase64Payload: String? {
         guard hasPrefix("data:image"),
-              let separatorRange = range(of: ",")
+              let separatorRange = range(of: ";base64,")
         else {
             return nil
         }

--- a/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
@@ -48,6 +48,9 @@ struct StringExtensionTests {
         let pngPayload = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
         #expect("data:image/png;base64,\(pngPayload)".dataImageBase64Payload == pngPayload)
 
+        // Non-base64 data URLs must return nil — passing them to Base64ImageDataProvider
+        // would force-unwrap Data(base64Encoded:) and crash.
+        #expect("data:image/svg+xml,<svg></svg>".dataImageBase64Payload == nil)
         #expect("data:image/svg+xml;base64".dataImageBase64Payload == nil)
         #expect("http://example.com/image.png".dataImageBase64Payload == nil)
         #expect("".dataImageBase64Payload == nil)


### PR DESCRIPTION
## Summary

- `dataImageBase64Payload` split on the first `","`, which matches both `;base64,<payload>` and `,<urlencoded-payload>` (no base64 encoding)
- A data URL like `data:image/svg+xml,<urlencoded-svg>` passed the guard and returned the URL-encoded content as the payload
- `ImageView` passed that string to `Base64ImageDataProvider`, which calls `Data(base64Encoded:)!` — force-unwrapping `nil` and crashing on the main thread
- Same root cause as #1113 on `develop` (`DrawerView` hardcoded the PNG prefix); this is the `openapigen-swiftui` equivalent

## Fix

Search for `";base64,"` instead of `","`. Non-base64 data URLs now return `nil`, so they fall through to the `default` branch in `ImageView` rather than crashing.

## Test plan

- [ ] Widget with `data:image/png;base64,...` icon — loads as before
- [ ] Widget with `data:image/jpeg;base64,...` icon — loads correctly (previously crashed)
- [ ] Widget with `data:image/svg+xml;base64,...` icon — loads correctly (previously crashed)
- [ ] Widget with `data:image/svg+xml,<urlencoded>` icon — shows placeholder gracefully (previously crashed)
- [ ] New test case in `StringExtensionTests` passes