### PR TITLE
Lazy-load linked sitemap page navigation

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -59,7 +59,7 @@ enum RowInteractionState: Equatable {
 
 @MainActor
 class SitemapPageViewModel: ObservableObject {
-    @Published var currentPage: OpenHABPage?
+    var currentPage: OpenHABPage?
     @Published var searchText = "" {
         didSet {
             rebuildRowInputs()
@@ -69,6 +69,7 @@ class SitemapPageViewModel: ObservableObject {
     @Published var error: (any LocalizedError)?
     @Published var isLoading = true
     @Published var isUpdating = false
+    @Published private(set) var pageTitle = ""
     @Published var openHABRootUrl: String?
     @Published var showSearchField = false
     @Published private(set) var commandStates: [String: WidgetCommandLifecycleState] = [:]
@@ -87,8 +88,7 @@ class SitemapPageViewModel: ObservableObject {
     private var defaultSitemap = ""
     private var defaultSitemapLabel = ""
     private var fallbackTitle = ""
-    @Published var pageId = ""
-    private var isLinkedPage = false
+    var pageId = ""
     private var pageNetworkStatus: NetworkStatus?
     private var pageNetworkStatusAvailable = false
     private var activePageHandlingKey: String?
@@ -108,7 +108,7 @@ class SitemapPageViewModel: ObservableObject {
         }
     }
 
-    var pageTitle: String {
+    private func computePageTitle() -> String {
         // Strip bracket content from title (e.g., "Living Room[2]" becomes "Living Room")
         let title = currentPage?.title.components(separatedBy: "[")[0].trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !title.isEmpty {
@@ -123,8 +123,11 @@ class SitemapPageViewModel: ObservableObject {
         }
     }
 
-    var isLinked: Bool {
-        isLinkedPage
+    private func refreshPageTitle() {
+        let newTitle = computePageTitle()
+        if pageTitle != newTitle {
+            pageTitle = newTitle
+        }
     }
 
     var commandLifecycleSummary: CommandLifecycleSummary {
@@ -183,7 +186,6 @@ class SitemapPageViewModel: ObservableObject {
     init(pageUrl: String, title: String, pageId: String = "") {
         loadSettings()
         startObservers()
-        isLinkedPage = true
         fallbackTitle = title
         defaultSitemapLabel = title
 
@@ -201,11 +203,11 @@ class SitemapPageViewModel: ObservableObject {
         } else {
             self.pageId = pageId
         }
+        refreshPageTitle()
     }
 
     /// Initializes the view model with a fixed set of widgets, without loading or polling
     init(pageUrl: String = "", title: String = "Preview Page", pageId: String = "", widgets: [OpenHABWidget]) {
-        isLinkedPage = !pageUrl.isEmpty
         fallbackTitle = title
         self.pageId = pageId
         currentPage = OpenHABPage(
@@ -216,6 +218,7 @@ class SitemapPageViewModel: ObservableObject {
             widgets: widgets,
             icon: ""
         )
+        refreshPageTitle()
         rebuildRowInputs()
     }
 
@@ -299,7 +302,6 @@ class SitemapPageViewModel: ObservableObject {
         guard let itemname, !itemname.isEmpty else { return }
         sliderOverrideResetTasks[itemname]?.cancel()
         sliderOverrideResetTasks[itemname] = nil
-        objectWillChange.send()
         sliderValueOverrides[itemname] = value
     }
 
@@ -325,6 +327,7 @@ extension SitemapPageViewModel {
     func loadSettings() {
         defaultSitemap = Preferences.shared.currentHomePreferences.defaultSitemap
         showSearchField = Preferences.shared.applicationPreferences.showSearchField
+        refreshPageTitle()
     }
 
     func stopPageHandling() {
@@ -548,12 +551,13 @@ extension SitemapPageViewModel {
 
         // Replace currentPage wholesale — no in-place widget reconciliation.
         currentPage = page
+        refreshPageTitle()
 
         _ = clearSyncedSliderOverrides(using: page.widgets)
 
         if inputsChanged {
             bumpWidgetVersions(from: rowInputs, to: previewInputs)
-            rowInputs = previewInputs
+            rowInputs = previewInputs.map { $0.applyingWidgetVersions(widgetUpdateVersions) }
         }
     }
 
@@ -628,6 +632,7 @@ extension SitemapPageViewModel {
         }
 
         currentPage = page
+        refreshPageTitle()
         rebuildRowInputs()
     }
 
@@ -658,6 +663,7 @@ extension SitemapPageViewModel {
         defaultSitemap = name
         defaultSitemapLabel = "" // Clear old label so it gets fetched for the new sitemap
         pageId = path ?? ""
+        refreshPageTitle()
         error = nil // Clear any previous errors when switching sitemaps
         startPageHandling(forceRestart: true, reason: "push-sitemap")
     }
@@ -674,6 +680,7 @@ extension SitemapPageViewModel {
             // Find the sitemap matching our defaultSitemap name and get its label
             if let sitemap = sitemaps.first(where: { $0.name == defaultSitemap }) {
                 defaultSitemapLabel = sitemap.label
+                refreshPageTitle()
                 // swiftformat:disable:next redundantSelf
                 logger.info("Found label '\(self.defaultSitemapLabel)' for sitemap '\(self.defaultSitemap)'")
             } else {
@@ -704,6 +711,7 @@ extension SitemapPageViewModel {
                 // Auto-select the only available sitemap
                 defaultSitemap = filteredSitemaps[0].name
                 defaultSitemapLabel = filteredSitemaps[0].label
+                refreshPageTitle()
                 // swiftformat:disable:next redundantSelf
                 logger.info("Auto-selected single sitemap: \(self.defaultSitemap)")
 
@@ -715,6 +723,7 @@ extension SitemapPageViewModel {
                 // Multiple sitemaps available - select the first one
                 defaultSitemap = filteredSitemaps[0].name
                 defaultSitemapLabel = filteredSitemaps[0].label
+                refreshPageTitle()
                 // swiftformat:disable:next redundantSelf
                 logger.info("Auto-selected first sitemap from \(filteredSitemaps.count) available: \(self.defaultSitemap)")
 
@@ -1072,7 +1081,6 @@ private extension SitemapPageViewModel {
         guard sliderValueOverrides[itemname] != nil else { return }
         sliderOverrideResetTasks[itemname]?.cancel()
         sliderOverrideResetTasks[itemname] = nil
-        objectWillChange.send()
         sliderValueOverrides.removeValue(forKey: itemname)
     }
 }

--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -98,7 +98,7 @@ private struct LinkedPageRowContent: View {
     var body: some View {
         let displayState = input.displayState
         HStack {
-            IconInputView(input: input.icon, rowIdentity: input.widgetId, size: CGSize(width: 32, height: 32))
+            IconInputView(input: input.icon, rowIdentity: input.linkedPageLink, size: CGSize(width: 32, height: 32))
 
             Text(displayState.labelText)
                 .ohTextToken(.rowLabel)

--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -81,11 +81,7 @@ private struct LinkedPageRowInputView: View {
     let input: LinkedPageRowInput
 
     var body: some View {
-        NavigationLink(
-            destination: SitemapPageView(
-                viewModel: SitemapPageViewModel(pageUrl: input.linkedPageLink, title: input.linkedPageTitle)
-            )
-        ) {
+        NavigationLink(value: input.destination) {
             LinkedPageRowContent(input: input)
         }
         .buttonStyle(.plain)
@@ -98,7 +94,7 @@ private struct LinkedPageRowContent: View {
     var body: some View {
         let displayState = input.displayState
         HStack {
-            IconInputView(input: input.icon, rowIdentity: input.linkedPageLink, size: CGSize(width: 32, height: 32))
+            IconInputView(input: input.icon, rowIdentity: input.destination.pageUrl, size: CGSize(width: 32, height: 32))
 
             Text(displayState.labelText)
                 .ohTextToken(.rowLabel)

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -46,8 +46,6 @@ struct IconInputView: View {
     let fallbackSymbol: SFSymbol?
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject var viewModel: SitemapPageViewModel
-
     let size: CGSize
     let iconType: IconType = .svg
 
@@ -119,7 +117,7 @@ struct IconInputView: View {
                     .cancelOnDisappear(true)
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(viewModel.pageId)-\(rowIdentity)-\(colorScheme)")
+                    .id("\(rowIdentity)-\(colorScheme)")
             }
         }
     }
@@ -142,8 +140,6 @@ struct IconView: View {
     @ObservedObject var widget: OpenHABWidget
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject var viewModel: SitemapPageViewModel
-
     let size: CGSize
     let iconType: IconType = .svg
     /// Optional SF Symbol to show as fallback when network icon is unavailable (useful for previews)
@@ -220,7 +216,7 @@ struct IconView: View {
                     .cancelOnDisappear(true)
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(viewModel.pageId)-\(widget.id)-\(colorScheme)")
+                    .id("\(widget.id)-\(colorScheme)")
             }
         }
     }

--- a/openHAB/UI/SwiftUI/RowViewWithIcon.swift
+++ b/openHAB/UI/SwiftUI/RowViewWithIcon.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// caller-provided content inside an `HStack`.
 struct RowViewWithIcon<Content: View>: View {
     let input: any RowWithIconInput
+    let rowIdentity: String
     let fallbackSymbol: SFSymbol?
     let alignment: VerticalAlignment
     let spacing: CGFloat?
@@ -24,18 +25,20 @@ struct RowViewWithIcon<Content: View>: View {
     var body: some View {
         HStack(alignment: alignment, spacing: spacing) {
             if input.icon.showIcon {
-                IconInputView(input: input.icon, rowIdentity: input.widgetId, size: CGSize(width: 32, height: 32), fallbackSymbol: fallbackSymbol)
+                IconInputView(input: input.icon, rowIdentity: rowIdentity, size: CGSize(width: 32, height: 32), fallbackSymbol: fallbackSymbol)
             }
             content()
         }
     }
 
     init(input: any RowWithIconInput,
+         rowIdentity: String? = nil,
          fallbackSymbol: SFSymbol? = .questionmark,
          alignment: VerticalAlignment = .center,
          spacing: CGFloat? = nil,
          @ViewBuilder content: @escaping () -> Content) {
         self.input = input
+        self.rowIdentity = rowIdentity ?? input.widgetId
         self.fallbackSymbol = fallbackSymbol
         self.alignment = alignment
         self.spacing = spacing

--- a/openHAB/UI/SwiftUI/Rows/FrameRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/FrameRowView.swift
@@ -54,6 +54,5 @@ struct FrameRowView: View {
     List([widget]) { widget in
         FrameRowView(input: FrameRowInput.from(widget: widget))
     }
-    .environmentObject(SitemapPageViewModel())
 }
 #endif

--- a/openHAB/UI/SwiftUI/Rows/GenericRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/GenericRowView.swift
@@ -56,6 +56,5 @@ struct GenericRowView: View {
     List([widget]) { widget in
         GenericRowView(input: GenericRowInput.from(widget: widget))
     }
-    .environmentObject(SitemapPageViewModel())
 }
 #endif

--- a/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
@@ -34,7 +34,7 @@ private struct SegmentedRowContent: View {
 
     var body: some View {
         let selectedIndex = effectiveSelectedIndex(displayState: input.displayState, mappings: input.mappings)
-        RowViewWithIcon(input: input, fallbackSymbol: fallbackSymbol, spacing: 0) {
+        RowViewWithIcon(input: input, rowIdentity: input.rowID.rawValue, fallbackSymbol: fallbackSymbol, spacing: 0) {
             if !input.displayState.labelText.isEmpty {
                 let labelText = input.displayState.labelText
                 Text(labelText)
@@ -338,17 +338,16 @@ private struct SegmentedRowContent: View {
 struct SegmentedRowView: View {
     let input: SegmentedRowInput
     var fallbackSymbol: SFSymbol?
-
-    @EnvironmentObject var viewModel: SitemapPageViewModel
+    @Environment(\.sitemapRowActions) private var rowActions
 
     var body: some View {
         SegmentedRowContent(
             input: input,
-            widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID),
+            widgetVersion: input.widgetVersion,
             fallbackSymbol: fallbackSymbol
         ) { command, policy, phase in
             guard let itemName = input.itemName else { return }
-            viewModel.sendCommand(command, for: itemName, policy: policy, phase: phase)
+            rowActions.sendCommand(itemName, command, policy, phase)
         }
     }
 }

--- a/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
@@ -58,7 +58,7 @@ private struct SelectionRowContent: View {
 
     @ViewBuilder
     private func rowContent(displayedCommand: String) -> some View {
-        RowViewWithIcon(input: input) {
+        RowViewWithIcon(input: input, rowIdentity: input.rowID.rawValue) {
             if !input.displayState.labelText.isEmpty {
                 let labelText = input.displayState.labelText
                 Text(labelText)
@@ -172,16 +172,15 @@ private struct SelectionRowContent: View {
 
 struct SelectionRowView: View {
     let input: SelectionRowInput
-
-    @EnvironmentObject var viewModel: SitemapPageViewModel
+    @Environment(\.sitemapRowActions) private var rowActions
 
     var body: some View {
         SelectionRowContent(
             input: input,
-            widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID)
+            widgetVersion: input.widgetVersion
         ) { command in
             guard let itemName = input.itemName else { return }
-            viewModel.sendCommand(command, for: itemName)
+            rowActions.sendCommand(itemName, command, .immediate, .change)
         }
     }
 }

--- a/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
@@ -16,36 +16,35 @@ import SwiftUI
 
 private struct SliderRowConfig {
     let input: SliderRowInput
-    let widgetVersion: Int
-    let overrideValue: Double?
     let fallbackSymbol: SFSymbol?
-    let viewModel: SitemapPageViewModel
+    let rowActions: SitemapRowActions
 }
 
 @MainActor
 private func makeSliderRowContent(_ config: SliderRowConfig) -> SliderRowContent {
     SliderRowContent(
         input: config.input,
-        widgetVersion: config.widgetVersion,
-        overrideValue: config.overrideValue,
+        widgetVersion: config.input.widgetVersion,
         fallbackSymbol: config.fallbackSymbol,
         onToggleSwitch: { command in
             guard let itemName = config.input.itemName else { return }
-            config.viewModel.sendCommand(command, for: itemName)
+            config.rowActions.sendCommand(itemName, command, .immediate, .change)
         },
         onCancelPending: { key in
             guard let itemName = config.input.itemName else { return }
-            config.viewModel.cancelPendingCommand(for: itemName, key: key)
+            config.rowActions.cancelPendingCommand(itemName, key)
         },
         onSendValue: { value, policy, phase, key in
             guard let itemName = config.input.itemName else { return }
-            config.viewModel.setSliderOverrideValue(value, for: itemName)
-            let numberState = NumberState(
-                value: value,
-                unit: config.input.unit,
-                format: config.input.numberPattern
+            config.rowActions.sendNumericUpdate(
+                itemName,
+                value,
+                config.input.unit,
+                config.input.numberPattern,
+                policy,
+                phase,
+                key
             )
-            config.viewModel.sendToUpdate(itemname: itemName, state: numberState, policy: policy, phase: phase, key: key)
         }
     )
 }
@@ -53,7 +52,6 @@ private func makeSliderRowContent(_ config: SliderRowConfig) -> SliderRowContent
 private struct SliderRowContent: View {
     let input: SliderRowInput
     let widgetVersion: Int
-    let overrideValue: Double?
     let fallbackSymbol: SFSymbol?
     let onToggleSwitch: (String) -> Void
     let onCancelPending: (String?) -> Void
@@ -148,7 +146,7 @@ private struct SliderRowContent: View {
     private func labelContent(state: SliderRowInput) -> some View {
         let displayedValue = effectiveValue(state: state)
         let currentValueText = currentValueText(state: state, value: displayedValue)
-        RowViewWithIcon(input: state, fallbackSymbol: fallbackSymbol) {
+        RowViewWithIcon(input: state, rowIdentity: state.rowID.rawValue, fallbackSymbol: fallbackSymbol) {
             if !state.displayState.labelText.isEmpty {
                 let labelText = state.displayState.labelText
                 Text(labelText)
@@ -190,7 +188,7 @@ private struct SliderRowContent: View {
         if isEditing {
             return dragValue ?? state.serverValue
         }
-        return overrideValue ?? state.serverValue
+        return state.serverValue
     }
 
     private func currentValueText(state: SliderRowInput, value: Double) -> String {
@@ -211,17 +209,14 @@ private struct SliderRowContent: View {
 struct SliderRowView: View {
     let input: SliderRowInput
     var fallbackSymbol: SFSymbol?
-
-    @EnvironmentObject var viewModel: SitemapPageViewModel
+    @Environment(\.sitemapRowActions) private var rowActions
 
     var body: some View {
         makeSliderRowContent(
             SliderRowConfig(
                 input: input,
-                widgetVersion: viewModel.widgetUpdateVersion(for: input.rowID),
-                overrideValue: viewModel.sliderOverrideValue(for: input.itemName),
                 fallbackSymbol: fallbackSymbol,
-                viewModel: viewModel
+                rowActions: rowActions
             )
         )
     }

--- a/openHAB/UI/SwiftUI/Rows/TextRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/TextRowView.swift
@@ -77,6 +77,5 @@ struct TextRowView: View {
         TextRowView(input: TextRowInput.from(widget: widget))
         Spacer()
     }
-    .environmentObject(SitemapPageViewModel())
 }
 #endif

--- a/openHAB/UI/SwiftUI/SitemapNavigationView.swift
+++ b/openHAB/UI/SwiftUI/SitemapNavigationView.swift
@@ -44,8 +44,6 @@ struct SitemapNavigationView: View {
     @ViewBuilder
     private var sitemapContent: some View {
         let page = SitemapPageView(viewModel: viewModel)
-            .navigationTitle(viewModel.pageTitle)
-            .navigationBarTitleDisplayMode(.automatic)
             .toolbar {
                 if !isInteractionIdle {
                     ToolbarItem(placement: .navigationBarLeading) {

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -76,6 +76,14 @@ struct SitemapPageView: View {
                 UIApplication.shared.isIdleTimerDisabled = false
             }
         }
+        .navigationDestination(for: LinkedPageDestination.self) { destination in
+            SitemapPageView(
+                viewModel: SitemapPageViewModel(
+                    pageUrl: destination.pageUrl,
+                    title: destination.title
+                )
+            )
+        }
         .navigationTitle(viewModel.pageTitle)
         .navigationBarTitleDisplayMode(.large)
         .alert("Error", isPresented: Binding(

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -18,10 +18,6 @@ struct SitemapPageView: View {
     @StateObject var viewModel = SitemapPageViewModel()
     @State private var idleTimerDisabled = false
 
-    private var isLinkedPage: Bool {
-        viewModel.isLinked
-    }
-
     var body: some View {
         Group {
             if viewModel.isLoading, viewModel.rowInputs.isEmpty {
@@ -40,6 +36,22 @@ struct SitemapPageView: View {
             }
         }
         .environmentObject(viewModel)
+        .environment(\.sitemapRowActions, SitemapRowActions(
+            sendCommand: { itemName, command, policy, phase in
+                viewModel.sendCommand(command, for: itemName, policy: policy, phase: phase)
+            },
+            cancelPendingCommand: { itemName, key in
+                viewModel.cancelPendingCommand(for: itemName, key: key)
+            },
+            sendNumericUpdate: { itemName, value, unit, format, policy, phase, key in
+                let state = NumberState(
+                    value: value,
+                    unit: unit,
+                    format: format
+                )
+                viewModel.sendToUpdate(itemname: itemName, state: state, policy: policy, phase: phase, key: key)
+            }
+        ))
         .listStyle(.plain)
         .listRowSpacing(0)
         .environment(\.defaultMinListRowHeight, 32)

--- a/openHAB/UI/SwiftUI/SitemapRowActions.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowActions.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import OpenHABCore
+import SwiftUI
+
+struct SitemapRowActions: Sendable {
+    var sendCommand: @MainActor @Sendable (_ itemName: String, _ command: String, _ policy: WidgetCommandPolicy, _ phase: WidgetCommandPhase) -> Void
+    var cancelPendingCommand: @MainActor @Sendable (_ itemName: String, _ key: String?) -> Void
+    var sendNumericUpdate: @MainActor @Sendable (_ itemName: String, _ value: Double, _ unit: String?, _ format: String?, _ policy: WidgetCommandPolicy, _ phase: WidgetCommandPhase, _ key: String?) -> Void
+
+    static let noop = SitemapRowActions(
+        sendCommand: { _, _, _, _ in },
+        cancelPendingCommand: { _, _ in },
+        sendNumericUpdate: { _, _, _, _, _, _, _ in }
+    )
+}
+
+private struct SitemapRowActionsKey: EnvironmentKey {
+    static let defaultValue = SitemapRowActions.noop
+}
+
+extension EnvironmentValues {
+    var sitemapRowActions: SitemapRowActions {
+        get { self[SitemapRowActionsKey.self] }
+        set { self[SitemapRowActionsKey.self] = newValue }
+    }
+}

--- a/openHAB/UI/SwiftUI/SitemapRowInput.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowInput.swift
@@ -68,3 +68,77 @@ enum SitemapRowInput: Identifiable, Equatable, Sendable {
         }
     }
 }
+
+extension SitemapRowInput {
+    func applyingWidgetVersions(_ versions: [String: Int]) -> SitemapRowInput {
+        let version = versions[rowID.rawValue] ?? 0
+
+        switch self {
+        case let .slider(rowID, input):
+            return .slider(
+                rowID,
+                SliderRowInput(
+                    rowID: input.rowID,
+                    widgetVersion: version,
+                    widgetId: input.widgetId,
+                    displayState: input.displayState,
+                    numberPattern: input.numberPattern,
+                    unit: input.unit,
+                    readOnly: input.readOnly,
+                    switchSupport: input.switchSupport,
+                    step: input.step,
+                    labelColor: input.labelColor,
+                    valueColor: input.valueColor,
+                    shouldSendUpdatesDuringMove: input.shouldSendUpdatesDuringMove,
+                    serverValue: input.serverValue,
+                    icon: input.icon,
+                    itemName: input.itemName
+                )
+            )
+        case let .selection(rowID, input):
+            return .selection(
+                rowID,
+                SelectionRowInput(
+                    rowID: input.rowID,
+                    widgetVersion: version,
+                    displayState: input.displayState,
+                    mappings: input.mappings,
+                    labelColor: input.labelColor,
+                    valueColor: input.valueColor,
+                    readOnly: input.readOnly,
+                    widgetId: input.widgetId,
+                    icon: input.icon,
+                    itemName: input.itemName
+                )
+            )
+        case let .segmented(rowID, input):
+            return .segmented(
+                rowID,
+                SegmentedRowInput(
+                    rowID: input.rowID,
+                    widgetVersion: version,
+                    displayState: input.displayState,
+                    mappings: input.mappings,
+                    labelColor: input.labelColor,
+                    valueColor: input.valueColor,
+                    widgetId: input.widgetId,
+                    icon: input.icon,
+                    itemName: input.itemName
+                )
+            )
+        case .frame,
+             .linked,
+             .text,
+             .setpoint,
+             .rollershutter,
+             .toggle,
+             .input,
+             .colorPicker,
+             .media,
+             .colorTemperature,
+             .buttonGrid,
+             .generic:
+            return self
+        }
+    }
+}

--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -16,6 +16,11 @@ protocol RowWithIconInput {
     var icon: RowIconInput { get }
 }
 
+struct LinkedPageDestination: Hashable, Sendable {
+    let pageUrl: String
+    let title: String
+}
+
 struct RowIconInput: Equatable, Sendable {
     let icon: String
     let iconColor: String
@@ -348,8 +353,7 @@ struct LinkedPageRowInput: Equatable, RowWithIconInput {
     let labelColor: String
     let valueColor: String
     let icon: RowIconInput
-    let linkedPageLink: String
-    let linkedPageTitle: String
+    let destination: LinkedPageDestination
     let isFrame: Bool
 
     static func from(widget: OpenHABWidget) -> LinkedPageRowInput? {
@@ -360,8 +364,10 @@ struct LinkedPageRowInput: Equatable, RowWithIconInput {
             labelColor: widget.labelcolor,
             valueColor: widget.valuecolor,
             icon: RowIconInput.from(widget: widget),
-            linkedPageLink: linkedPage.link,
-            linkedPageTitle: linkedPage.title,
+            destination: LinkedPageDestination(
+                pageUrl: linkedPage.link,
+                title: linkedPage.title
+            ),
             isFrame: widget.type == .frame
         )
     }

--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -45,6 +45,7 @@ struct RowIconInput: Equatable, Sendable {
 
 struct SelectionRowInput: Equatable, RowWithIconInput {
     let rowID: RowID
+    let widgetVersion: Int
     let displayState: WidgetDisplayState
     let mappings: [OpenHABWidgetMapping]
     let labelColor: String
@@ -58,6 +59,7 @@ struct SelectionRowInput: Equatable, RowWithIconInput {
         let displayState = widget.displayState
         return SelectionRowInput(
             rowID: rowID,
+            widgetVersion: 0,
             displayState: displayState,
             mappings: displayState.mappings,
             labelColor: widget.labelcolor,
@@ -72,6 +74,7 @@ struct SelectionRowInput: Equatable, RowWithIconInput {
 
 struct SegmentedRowInput: Equatable, RowWithIconInput {
     let rowID: RowID
+    let widgetVersion: Int
     let displayState: WidgetDisplayState
     let mappings: [OpenHABWidgetMapping]
     let labelColor: String
@@ -84,6 +87,7 @@ struct SegmentedRowInput: Equatable, RowWithIconInput {
         let displayState = widget.displayState
         return SegmentedRowInput(
             rowID: rowID,
+            widgetVersion: 0,
             displayState: displayState,
             mappings: displayState.mappings,
             labelColor: widget.labelcolor,
@@ -485,6 +489,7 @@ struct TextRowInput: Equatable, RowWithIconInput {
 
 struct SliderRowInput: Equatable, RowWithIconInput {
     let rowID: RowID
+    let widgetVersion: Int
     let widgetId: String
     let displayState: WidgetDisplayState
     let numberPattern: String?
@@ -523,6 +528,7 @@ struct SliderRowInput: Equatable, RowWithIconInput {
 
         return SliderRowInput(
             rowID: rowID,
+            widgetVersion: 0,
             widgetId: widget.widgetId,
             displayState: displayState,
             numberPattern: numberPattern,

--- a/openHABTestsSwift/SitemapRowInputMapperTests.swift
+++ b/openHABTestsSwift/SitemapRowInputMapperTests.swift
@@ -42,8 +42,8 @@ struct SitemapRowInputMapperTests {
             }
             #expect(mappedRowID == rowID)
             #expect(input.widgetId == widget.widgetId)
-            #expect(input.linkedPageLink == "https://example.invalid/linked")
-            #expect(input.linkedPageTitle == "Linked")
+            #expect(input.destination.pageUrl == "https://example.invalid/linked")
+            #expect(input.destination.title == "Linked")
         }
     }
 


### PR DESCRIPTION
## Summary
- move linked sitemap rows to typed value-based navigation
- keep linked row bodies snapshot-driven and free of destination construction
- lazily create the linked page view model only when navigation is activated

## Notes
- stacked on top of #1140
- this PR is focused on linked-page navigation only

## Testing
- not run