### PR TITLE
Fix stale rows on scroll after foreground refresh

### DIFF
--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -119,6 +119,11 @@ private struct LinkedPageRowContent: View {
 struct EmbeddingRowInputView: View {
     let rowInput: SitemapRowInput
 
+    // Subscribes to the view model so SwiftUI re-evaluates this view when
+    // rowInputs change — without this, rows that scroll into view after a
+    // foreground refresh may render stale data from a cached render.
+    @EnvironmentObject private var viewModel: SitemapPageViewModel
+
     private var regularRowBackground: Color {
         Color(UIColor.ohSecondarySystemGroupedBackground)
     }


### PR DESCRIPTION
## Summary

- Adds `@EnvironmentObject private var viewModel: SitemapPageViewModel` to `EmbeddingRowInputView`
- SwiftUI can serve a cached render for off-screen list rows even after `rowInputs` changes on a foreground refresh; subscribing to the view model ensures every row is invalidated when it publishes, so scrolling back to an off-screen row shows fresh data

## Test plan
- Open a large sitemap, scroll down past the visible viewport
- Background the app, wait a few seconds, foreground it
- Scroll to rows that were off-screen during the refresh — they should display current values, not stale ones