### PR TITLE
Fix stale row rendering on scroll and foreground refresh

### DIFF
--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -119,6 +119,11 @@ private struct LinkedPageRowContent: View {
 struct EmbeddingRowInputView: View {
     let rowInput: SitemapRowInput
 
+    // Subscribes to the view model so SwiftUI re-evaluates this view when
+    // rowInputs change — without this, rows that scroll into view after a
+    // foreground refresh may render stale data from a cached render.
+    @EnvironmentObject private var viewModel: SitemapPageViewModel
+
     private var regularRowBackground: Color {
         Color(UIColor.ohSecondarySystemGroupedBackground)
     }

--- a/openHAB/UI/SwiftUI/Rows/GenericRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/GenericRowView.swift
@@ -13,15 +13,6 @@ import CommonUI
 import OpenHABCore
 import SwiftUI
 
-private struct GenericRowConfig {
-    let input: GenericRowInput
-}
-
-@MainActor
-private func makeGenericRowContent(_ config: GenericRowConfig) -> GenericRowContent {
-    GenericRowContent(input: config.input)
-}
-
 private struct GenericRowContent: View {
     let input: GenericRowInput
 
@@ -46,7 +37,7 @@ private struct GenericRowContent: View {
 struct GenericRowView: View {
     let input: GenericRowInput
     var body: some View {
-        makeGenericRowContent(GenericRowConfig(input: input))
+        GenericRowContent(input: input)
     }
 }
 

--- a/openHAB/UI/SwiftUI/Rows/TextRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/TextRowView.swift
@@ -10,19 +10,9 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import CommonUI
-import Flow
 import OpenHABCore
 import SFSafeSymbols
 import SwiftUI
-
-private struct TextRowConfig {
-    let input: TextRowInput
-}
-
-@MainActor
-private func makeTextRowContent(_ config: TextRowConfig) -> TextRowContent {
-    TextRowContent(input: config.input)
-}
 
 private struct TextRowContent: View {
     let input: TextRowInput
@@ -36,7 +26,7 @@ private struct TextRowContent: View {
                 Text(displayState.labelText)
                     .ohTextToken(.rowLabel)
                     .foregroundStyle(input.labelColor.isEmpty ? .primary : Color(fromString: input.labelColor))
-                    
+
                     Spacer(minLength: 8)
                 }
 
@@ -68,7 +58,7 @@ struct TextRowView: View {
     let input: TextRowInput
 
     var body: some View {
-        makeTextRowContent(TextRowConfig(input: input))
+        TextRowContent(input: input)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `@EnvironmentObject private var viewModel: SitemapPageViewModel` to `EmbeddingRowInputView` so SwiftUI re-evaluates off-screen rows when `rowInputs` change after a foreground refresh
- Remove `@MainActor` factory functions (`makeTextRowContent`, `makeGenericRowContent`) from `TextRowView` and `GenericRowView` — these bypassed SwiftUI's structural identity diffing, causing unnecessary re-renders when labels or values changed

## Background

Two related stale-render bugs:

1. **Stale rows on scroll** (`EmbeddingRowInputView`): After a foreground refresh updates `rowInputs`, rows that were off-screen held cached SwiftUI renders. When scrolled back into view they showed outdated state. The fix subscribes `EmbeddingRowInputView` to the view model so SwiftUI re-evaluates the view body alongside the rest of the list.

2. **Text/generic row re-render suppression** (`TextRowView`, `GenericRowView`): The `@MainActor` factory pattern broke structural identity — SwiftUI could not diff the returned view tree and skipped re-renders when the row input changed in place. Removing the factory and calling `TextRowContent`/`GenericRowContent` directly restores normal diffing.

## Test plan

- [ ] Open a sitemap with several pages and text/generic rows
- [ ] Background the app, change item states on the server, foreground — verify rows update correctly
- [ ] Scroll down past the visible area and back up — verify no stale values appear
- [ ] Verify label and value text update correctly in-place without full row flicker