### PR TITLE
Fix icon load hiccups, drawer double-fetch, and tracker double-start

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -395,6 +395,16 @@ extension SitemapPageViewModel {
                            reason: String = "manual",
                            preserveCurrentContent: Bool = false,
                            recreateService: Bool = false) {
+        guard networkTracker.activeConnection != nil || networkTracker.status != .stopped else {
+            logger.info("Deferring page load until NetworkTracker starts (reason: \(reason, privacy: .public))")
+            error = nil
+            if currentPage == nil {
+                isLoading = true
+            }
+            isUpdating = false
+            return
+        }
+
         let pipelineStart = Date()
         let requestedKey = "\(defaultSitemap)|\(pageId)"
         if !forceRestart,

--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -33,6 +33,53 @@ enum DrawerViewError: Error, CustomDebugStringConvertible {
     }
 }
 
+enum DrawerFetchResult<Value> {
+    case value(Value)
+    case cancelled
+    case failed(any Error)
+}
+
+@MainActor
+enum DrawerFetch {
+    static func sitemaps(
+        sortOrder: SortSitemapsOrder,
+        fetch: () async throws -> [OpenHABSitemap]
+    ) async -> DrawerFetchResult<[OpenHABSitemap]> {
+        do {
+            var sitemaps = try await fetch()
+            try Task.checkCancellation()
+            if sitemaps.last?.name == "_default", sitemaps.count > 1 {
+                sitemaps = Array(sitemaps.dropLast())
+            }
+            switch sortOrder {
+            case .label:
+                sitemaps.sort { $0.label < $1.label }
+            case .name:
+                sitemaps.sort { $0.name < $1.name }
+            }
+            try Task.checkCancellation()
+            return .value(sitemaps)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    static func uiTiles(
+        fetch: () async throws -> [OpenHABUiTile]
+    ) async -> DrawerFetchResult<[OpenHABUiTile]> {
+        do {
+            let uiTiles = try await fetch()
+            try Task.checkCancellation()
+            return .value(uiTiles)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            return .failed(error)
+        }
+    }
+}
 
 // Display the connected URL
 struct ConnectionView: View {
@@ -147,15 +194,9 @@ struct DrawerView: View {
                 .padding(.bottom, 5)
         }
         .listStyle(.inset)
-        .task {
-            let activeConnection = networkTracker.activeConnection
-            await updateSitemapsAndUITiles(activeConnection: activeConnection)
+        .task(id: networkTracker.activeConnection) {
+            await updateSitemapsAndUITiles(activeConnection: networkTracker.activeConnection)
             sitemapForWatch = Preferences.shared.currentHomePreferences.sitemapForWatch
-        }
-        .onReceive(networkTracker.$activeConnection) { activeConnection in
-            Task {
-                await updateSitemapsAndUITiles(activeConnection: activeConnection)
-            }
         }
     }
 
@@ -238,32 +279,35 @@ struct DrawerView: View {
         do {
             let openAPIService = try OpenAPIService(connectionConfiguration: activeConnection.configuration)
 
-            do {
-                sitemaps = try await openAPIService.openHABSitemaps()
-                if sitemaps.last?.name == "_default", sitemaps.count > 1 {
-                    sitemaps = Array(sitemaps.dropLast())
-                }
-                let sortSitemapsBy = Preferences.shared.currentHomePreferences.sortSitemapsBy
-                switch SortSitemapsOrder(rawValue: sortSitemapsBy) ?? .label {
-                case .label:
-                    sitemaps.sort { $0.label < $1.label }
-                case .name:
-                    sitemaps.sort { $0.name < $1.name }
-                }
-
-            } catch {
+            let sortSitemapsBy = Preferences.shared.currentHomePreferences.sortSitemapsBy
+            let sortOrder = SortSitemapsOrder(rawValue: sortSitemapsBy) ?? .label
+            switch await DrawerFetch.sitemaps(sortOrder: sortOrder, fetch: {
+                try await openAPIService.openHABSitemaps()
+            }) {
+            case let .value(fetchedSitemaps):
+                sitemaps = fetchedSitemaps
+            case .cancelled:
+                return
+            case let .failed(error):
                 Logger.drawerView.error("Failed to fetch sitemaps: \(error.localizedDescription)")
                 sitemaps = []
             }
 
-            do {
-                uiTiles = try await openAPIService.getUITiles()
+            switch await DrawerFetch.uiTiles(fetch: {
+                try await openAPIService.getUITiles()
+            }) {
+            case let .value(fetchedUITiles):
+                uiTiles = fetchedUITiles
                 Logger.drawerView.info("Fetched UI tiles successfully")
-            } catch {
+            case .cancelled:
+                return
+            case let .failed(error):
                 Logger.drawerView.error("Failed to fetch UI tiles: \(error.localizedDescription)")
                 uiTiles = []
             }
 
+        } catch is CancellationError {
+            return
         } catch {
             Logger.drawerView.error("Failed to initialize OpenAPIService: \(error.localizedDescription)")
             sitemaps = []

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -33,6 +33,52 @@ enum TargetController {
     case homeSelection
 }
 
+private struct TrackerStartupSettings: Equatable {
+    let demomode: Bool
+    let localConnectionConfig: ConnectionConfiguration
+    let remoteConnectionConfig: ConnectionConfiguration
+    let sseCommandItem: String
+
+    @MainActor
+    init(homeSettings: HomePreferences) {
+        demomode = homeSettings.demomode
+        localConnectionConfig = homeSettings.localConnectionConfig
+        remoteConnectionConfig = homeSettings.remoteConnectionConfig
+        sseCommandItem = homeSettings.sseCommandItem
+    }
+
+    static func == (lhs: TrackerStartupSettings, rhs: TrackerStartupSettings) -> Bool {
+        lhs.demomode == rhs.demomode &&
+            lhs.localConnectionConfig.trackerIdentity == rhs.localConnectionConfig.trackerIdentity &&
+            lhs.remoteConnectionConfig.trackerIdentity == rhs.remoteConnectionConfig.trackerIdentity &&
+            lhs.sseCommandItem == rhs.sseCommandItem
+    }
+}
+
+private struct TrackerConnectionIdentity: Equatable {
+    let url: String
+    let username: String
+    let password: String
+    let alwaysSendBasicAuth: Bool
+    let ignoreSSL: Bool
+    let priority: Int
+    let supportsNotifications: Bool
+}
+
+private extension ConnectionConfiguration {
+    var trackerIdentity: TrackerConnectionIdentity {
+        TrackerConnectionIdentity(
+            url: url,
+            username: username,
+            password: password,
+            alwaysSendBasicAuth: alwaysSendBasicAuth,
+            ignoreSSL: ignoreSSL,
+            priority: priority,
+            supportsNotifications: supportsNotifications
+        )
+    }
+}
+
 protocol ModalHandler: AnyObject {
     func modalDismissed(to: TargetController)
 }
@@ -137,6 +183,7 @@ class OpenHABRootViewController: UIViewController {
     }()
 
     private var activeConnection: ConnectionInfo?
+    private var lastTrackerStartupSettings: TrackerStartupSettings?
     private let synthesizer = AVSpeechSynthesizer()
 
     override func viewDidLoad() {
@@ -369,11 +416,20 @@ class OpenHABRootViewController: UIViewController {
         }
 
         serverInfo.debounce(for: .milliseconds(500), scheduler: RunLoop.main) // ensures if multiple values are saved, we get called once
-            .sink { homeSettings in
-                let localConnectionConfig = homeSettings.localConnectionConfig
-                let remoteConnectionConfig = homeSettings.remoteConnectionConfig
-                let demomode = homeSettings.demomode
-                let sseCommandItem = homeSettings.sseCommandItem
+            .sink { [weak self] homeSettings in
+                guard let self else { return }
+
+                let settings = TrackerStartupSettings(homeSettings: homeSettings)
+                guard lastTrackerStartupSettings != settings else {
+                    Logger.viewController.debug("Skipping duplicate tracker startup settings")
+                    return
+                }
+                lastTrackerStartupSettings = settings
+
+                let localConnectionConfig = settings.localConnectionConfig
+                let remoteConnectionConfig = settings.remoteConnectionConfig
+                let demomode = settings.demomode
+                let sseCommandItem = settings.sseCommandItem
 
                 Task {
                     if demomode {

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -103,6 +103,7 @@ struct IconInputView: View {
                     .resizable()
                     .setProcessor(OpenHABImageProcessor(iconColor: processorIconColor(for: iconURL)))
                     .onFailure { error in
+                        guard !error.isTaskCancelled else { return }
                         logger.error("Icon loading failed for icon '\(input.icon, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         logger.error("Failed URL: \(iconURL.absoluteString, privacy: .public)")
                     }
@@ -203,6 +204,7 @@ struct IconView: View {
                     .resizable()
                     .setProcessor(OpenHABImageProcessor(iconColor: processorIconColor(for: iconURL)))
                     .onFailure { error in
+                        guard !error.isTaskCancelled else { return }
                         logger.error("Icon loading failed for icon '\(widget.icon, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         logger.error("Failed URL: \(iconURL.absoluteString, privacy: .public)")
                     }


### PR DESCRIPTION
## Summary

Addresses three issues reported by a tester as UI hiccups on iOS 3.2.34:

- **Icon cancellation noise**: `IconInputView` and `IconView` now silently drop `taskCancelled` failures in `onFailure` (via Kingfisher's `isTaskCancelled` helper). Cancellations are expected whenever a view is recreated by the `.id()` workaround and should not surface as errors.
- **DrawerView double-fetch**: Replaced the `.task` + `.onReceive($activeConnection)` pair with a single `.task(id: networkTracker.activeConnection)`, eliminating the duplicate `updateSitemapsAndUITiles` call every time the side menu opens. Added cancellation-aware `DrawerFetch` helpers so in-flight requests abort cleanly when the connection changes mid-fetch.
- **Tracker double-start on launch**: Added `TrackerStartupSettings` deduplication in the preferences sink in `OpenHABRootViewController` — `startTracking` is only called when the connection settings actually change, preventing the spurious second call seen ~2 s after launch.
- **Page load guard**: `SitemapPageViewModel.startPageHandling` now defers page load until `NetworkTracker` has an active connection or has not been stopped, preventing a premature "Failed to establish connection within timeout" on cold start.

## Test plan

- [ ] Open side menu — confirm `Fetched UI tiles successfully` appears exactly once per open in the log
- [ ] Watch icon log output during active long-polling — confirm no `Icon loading failed` entries for cancellations; genuine failures (bad URL, 404) still log as errors
- [ ] Cold-start the app — confirm no `Failed to establish connection within timeout` before the network tracker has found a connection
- [ ] Confirm no duplicate `NetworkTracker: Network tracking for these connections has already been started` warning on launch