### PR TITLE
Improve diagnostic log visibility

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/ConnectionConfiguration.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ConnectionConfiguration.swift
@@ -92,6 +92,21 @@ public extension ConnectionConfiguration {
     /// The host component of the connection URL, if parseable.
     var host: String? { URL(string: url)?.host }
 
+    /// URL suitable for diagnostics; credentials embedded in the URL are stripped.
+    var publicLogURL: String {
+        guard var components = URLComponents(string: url) else {
+            return url
+        }
+        components.user = nil
+        components.password = nil
+        return components.string ?? url
+    }
+
+    /// Connection details safe to expose in diagnostics.
+    var publicLogDescription: String {
+        "url: \(publicLogURL), priority: \(priority), cloud: \(isCloudConnection), usernameConfigured: \(!username.isEmpty)"
+    }
+
     /// Whether this connection is to an openHAB Cloud instance.
     /// Currently determined by the "openHAB Cloud Service" user preference (`supportsNotifications`).
     var isCloudConnection: Bool { supportsNotifications }

--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -90,8 +90,8 @@ public actor ConnectionFailureTracker {
         let connectionsBefore = failureCounts.keys
         Logger.connectionFailureTracker.info("""
         ConnectionFailureTracker: Setting connections for failure tracker.
-            Old connections: \(connectionsBefore.sorted(by: \.url).map { "\($0)" }, privacy: .private)
-            New connections: \(connections.sorted(by: \.url).map { "\($0)" }, privacy: .private)
+            Old connections: \(connectionsBefore.sorted(by: \.url).map(\.publicLogDescription), privacy: .public)
+            New connections: \(connections.sorted(by: \.url).map(\.publicLogDescription), privacy: .public)
         """)
 
         failureCounts = failureCounts.filter { connections.contains($0.key) }
@@ -101,7 +101,7 @@ public actor ConnectionFailureTracker {
         }
 
         let connectionsAfter = failureCounts.keys
-        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Connections after update: \(connectionsAfter.sorted(by: \.url).map { "\($0)" }, privacy: .private)")
+        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Connections after update: \(connectionsAfter.sorted(by: \.url).map(\.publicLogDescription), privacy: .public)")
     }
 
     func shouldAttempt(_ config: ConnectionConfiguration) -> Bool {
@@ -110,15 +110,15 @@ public actor ConnectionFailureTracker {
 
     func recordFailure(_ config: ConnectionConfiguration) {
         guard enabled else {
-            Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Do not record failure while being disabled for connection url \(config.url) user: \(config.username, privacy: .private)")
+            Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Do not record failure while being disabled for connection \(config.publicLogDescription, privacy: .public)")
             return
         }
-        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Record failure for connection url \(config.url) user: \(config.username, privacy: .private)")
+        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Record failure for connection \(config.publicLogDescription, privacy: .public)")
         failureCounts[config, default: 0] += 1
     }
 
     func reset(_ config: ConnectionConfiguration) {
-        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Reset failures for connection url \(config.url) user: \(config.username)")
+        Logger.connectionFailureTracker.debug("ConnectionFailureTracker: Reset failures for connection \(config.publicLogDescription, privacy: .public)")
         failureCounts[config] = 0
     }
 
@@ -192,11 +192,11 @@ public actor NetworkTracker {
 
     /// Creates a task to start the tracking and returns immediately
     public func startTracking(connectionConfigurations: [ConnectionConfiguration]) async {
-        Logger.networkTracker.info("NetworkTracker: Start Network Tracking for \(connectionConfigurations.sorted(by: \.url).map { "\($0)" }, privacy: .private)")
+        Logger.networkTracker.info("NetworkTracker: Start Network Tracking for \(connectionConfigurations.sorted(by: \.url).map(\.publicLogDescription), privacy: .public)")
 
         let status = status // to prevent linter removing "self" in string interpolation
         guard status == .stopped || Set(connectionConfigurations) != Set(self.connectionConfigurations) else {
-            Logger.networkTracker.warning("NetworkTracker: Network tracking for these connections has already been started, current status: \(status.rawValue)")
+            Logger.networkTracker.warning("NetworkTracker: Network tracking for these connections has already been started, current status: \(status.rawValue, privacy: .public)")
             return
         }
 
@@ -214,7 +214,7 @@ public actor NetworkTracker {
                 do {
                     _ = try await connectionPool.getOrCreateService(for: configuration)
                 } catch {
-                    Logger.networkTracker.error("NetworkTracker: Failed to create service for config: \(configuration.url, privacy: .public) — \(error.localizedDescription)")
+                    Logger.networkTracker.error("NetworkTracker: Failed to create service for config: \(configuration.publicLogDescription, privacy: .public) — \(error.localizedDescription, privacy: .public)")
                     // Optionally: show a UI popup or skip to next config
                 }
             }
@@ -288,7 +288,7 @@ public actor NetworkTracker {
 
         // Check if the active connection is reachable
         await makeBestConnectionActive()
-        Logger.networkTracker.debug("NetworkTracker: Active connection was reevaluated to be: \(activeConnection.configuration.url)")
+        Logger.networkTracker.debug("NetworkTracker: Active connection was reevaluated to be: \(activeConnection.configuration.publicLogDescription, privacy: .public)")
     }
 
     private func attemptConnection(silent: Bool = false) async {
@@ -322,7 +322,7 @@ public actor NetworkTracker {
 
     private func makeBestConnectionActive() async {
         if let bestConnection = await findBestConnection() {
-            Logger.networkTracker.info("NetworkTracker: Best connection url: \(bestConnection.configuration.url) user: \(bestConnection.configuration.username, privacy: .private)")
+            Logger.networkTracker.info("NetworkTracker: Best connection \(bestConnection.configuration.publicLogDescription, privacy: .public)")
             setActiveConnection(bestConnection)
             updateStatus(.connected)
         } else {
@@ -357,17 +357,17 @@ public actor NetworkTracker {
                     guard let connectionInfo else { continue }
 
                     if currentBestConnection == nil {
-                        Logger.networkTracker.debug("NetworkTracker: First working connection found: \(connectionInfo.configuration.url)")
+                        Logger.networkTracker.debug("NetworkTracker: First working connection found: \(connectionInfo.configuration.publicLogDescription, privacy: .public)")
                         currentBestConnection = connectionInfo
                         // give the other connections a short time to be found, otherwise cancel early
                         timeoutController.expire(seconds: NetworkTracker.slowConnectionTimeout)
                     } else if let bestConnection = currentBestConnection, connectionInfo.configuration.priority < bestConnection.configuration.priority {
-                        Logger.networkTracker.debug("NetworkTracker: Better connection found: \(connectionInfo.configuration.url)")
+                        Logger.networkTracker.debug("NetworkTracker: Better connection found: \(connectionInfo.configuration.publicLogDescription, privacy: .public)")
                         currentBestConnection = connectionInfo
                     }
 
                     if currentBestConnection?.configuration.priority == 0 {
-                        Logger.networkTracker.debug("NetworkTracker: Most prioritized connection with url: \(connectionInfo.configuration.url) and user: \(connectionInfo.configuration.username, privacy: .private) tested successfully")
+                        Logger.networkTracker.debug("NetworkTracker: Most prioritized connection \(connectionInfo.configuration.publicLogDescription, privacy: .public) tested successfully")
                         // Stop further tasks if we found the highest-priority connection and return it
                         group.cancelAll()
                         return
@@ -375,8 +375,8 @@ public actor NetworkTracker {
                 }
             }
 
-            let bestConnectionUrl = currentBestConnection?.configuration.url ?? "none"
-            Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionUrl)")
+            let bestConnectionDescription = currentBestConnection?.configuration.publicLogDescription ?? "none"
+            Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionDescription, privacy: .public)")
             return currentBestConnection
         }
     }
@@ -411,39 +411,39 @@ public actor NetworkTracker {
         let reevaluating = activeConnection != nil
         // attempt the other possibly frequently failed connection, too, when reevaluating best connection
         if !(reevaluating || shouldTry) {
-            Logger.networkTracker.info("NetworkTracker: Skipping \(configuration.url) due to repeated failures.")
+            Logger.networkTracker.info("NetworkTracker: Skipping \(configuration.publicLogDescription, privacy: .public) due to repeated failures.")
             return nil
         }
 
         do {
-            Logger.networkTracker.info("NetworkTracker: testConnection for url: \(configuration.url) user: \(configuration.username, privacy: .private)")
+            Logger.networkTracker.info("NetworkTracker: testConnection for \(configuration.publicLogDescription, privacy: .public)")
             let connection = try await connectionPool.getOrCreateService(for: configuration)
             let version = try await connection.getRootVersion()
             let proxyURL = await fetchProxyURL(for: configuration)
             let connectionInfo = ConnectionInfo(configuration: configuration, version: version, proxyURL: proxyURL)
 
             await failureTracker.reset(configuration) // Reset on success
-            Logger.networkTracker.info("NetworkTracker: testConnection successful for \(configuration.url)")
+            Logger.networkTracker.info("NetworkTracker: testConnection successful for \(configuration.publicLogDescription, privacy: .public), version: \(version, privacy: .public)")
             return connectionInfo
         } catch is CancellationError {
-            Logger.networkTracker.debug("NetworkTracker: Cancelled connection attempt to \(configuration.url)")
+            Logger.networkTracker.debug("NetworkTracker: Cancelled connection attempt to \(configuration.publicLogDescription, privacy: .public)")
         } catch NetworkTrackerError.invalidServerVersion {
             await failureTracker.recordFailure(configuration)
-            Logger.networkTracker.info("NetworkTracker: testConnection error - Invalid server version from \(configuration.url)")
+            Logger.networkTracker.info("NetworkTracker: testConnection error - Invalid server version from \(configuration.publicLogDescription, privacy: .public)")
         } catch let error as OpenAPIServiceError {
             await failureTracker.recordFailure(configuration)
             switch error {
             case let .undocumented(statusCode, payload):
-                Logger.networkTracker.info("NetworkTracker: Undocumented status code: \(statusCode), payload: \(String(describing: payload))")
+                Logger.networkTracker.info("NetworkTracker: Undocumented status code: \(statusCode, privacy: .public), payload: \(String(describing: payload), privacy: .public)")
             default: break
             }
         } catch let openAPIError as OpenAPIRuntime.ClientError {
             await failureTracker.recordFailure(configuration)
-            Logger.networkTracker.info("Networktracker: testConnection error - OpenAPIRuntime.RuntimeError encountered for \(configuration.url)")
-            Logger.networkTracker.debug("OpenAPIRuntime.RuntimeError is \(openAPIError)")
+            Logger.networkTracker.info("Networktracker: testConnection error - OpenAPIRuntime.RuntimeError encountered for \(configuration.publicLogDescription, privacy: .public)")
+            Logger.networkTracker.debug("OpenAPIRuntime.RuntimeError is \(String(describing: openAPIError), privacy: .public)")
         } catch {
             await failureTracker.recordFailure(configuration)
-            Logger.networkTracker.info("NetworkTracker: testConnection error - Failed to connect to \(configuration.url) \(error.localizedDescription)")
+            Logger.networkTracker.info("NetworkTracker: testConnection error - Failed to connect to \(configuration.publicLogDescription, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
 
         return nil
@@ -460,7 +460,7 @@ public actor NetworkTracker {
             let backoffMultiplier = UInt64(failureCount)
             let safeBackoff = min(backoffMultiplier, 10) // 2^10 = 1024
             let delay = min(initialRetryInterval * (1 << safeBackoff), 300)
-            Logger.networkTracker.info("NetworkTracker: Retrying connection in \(delay) seconds based on failure count of \(failureCount).")
+            Logger.networkTracker.info("NetworkTracker: Retrying connection in \(delay, privacy: .public) seconds based on failure count of \(failureCount, privacy: .public).")
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else {
                 return
@@ -477,7 +477,7 @@ public actor NetworkTracker {
             return
         }
 
-        Logger.networkTracker.info("NetworkTracker: Networkmonitor status: \(isConnected ? "connected" : "disconnected")")
+        Logger.networkTracker.info("NetworkTracker: Networkmonitor status: \(isConnected ? "connected" : "disconnected", privacy: .public)")
         await checkActiveConnection()
 
         if activeConnection == nil {
@@ -503,7 +503,7 @@ public actor NetworkTracker {
     private func updateStatus(_ newStatus: NetworkStatus) {
         guard status != newStatus else { return } // Prevent redundant updates
         status = newStatus
-        Logger.networkTracker.info("NetworkTracker: status updated: \(newStatus.rawValue)")
+        Logger.networkTracker.info("NetworkTracker: status updated: \(newStatus.rawValue, privacy: .public)")
     }
 }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
@@ -139,7 +139,7 @@ public extension OpenAPIService {
         // swiftformat:disable:next redundantSelf
         guard let url else { throw OpenAPIServiceError.noRootURL }
 
-        Logger.openAPIService.log("Trying to getSitemaps for : \(url.debugDescription)")
+        Logger.openAPIService.log("Trying to getSitemaps for: \(url.debugDescription, privacy: .public)")
         let response = try await client.getSitemaps(.init())
         switch response {
         case let .ok(okresponse):

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -840,13 +840,13 @@ extension SitemapPageViewModel {
             if let sitemap = sitemaps.first(where: { $0.name == defaultSitemap }) {
                 defaultSitemapLabel = sitemap.label
                 // swiftformat:disable:next redundantSelf
-                logger.info("Found label '\(self.defaultSitemapLabel)' for sitemap '\(self.defaultSitemap)'")
+                logger.info("Found label '\(self.defaultSitemapLabel, privacy: .public)' for sitemap '\(self.defaultSitemap, privacy: .public)'")
             } else {
                 // swiftformat:disable:next redundantSelf
-                logger.warning("Could not find sitemap '\(self.defaultSitemap)' in available sitemaps")
+                logger.warning("Could not find sitemap '\(self.defaultSitemap, privacy: .public)' in available sitemaps")
             }
         } catch {
-            logger.warning("Failed to fetch sitemap label: \(error)")
+            logger.warning("Failed to fetch sitemap label: \(error.localizedDescription, privacy: .public)")
             // Don't set error here as this is not critical - we can continue without the label
         }
     }
@@ -870,7 +870,7 @@ extension SitemapPageViewModel {
                 defaultSitemap = filteredSitemaps[0].name
                 defaultSitemapLabel = filteredSitemaps[0].label
                 // swiftformat:disable:next redundantSelf
-                logger.info("Auto-selected single sitemap: \(self.defaultSitemap)")
+                logger.info("Auto-selected single sitemap: \(self.defaultSitemap, privacy: .public)")
 
                 // Save as default for future launches
                 Preferences.shared.modifyActiveHome { homePreferences in
@@ -881,7 +881,7 @@ extension SitemapPageViewModel {
                 defaultSitemap = filteredSitemaps[0].name
                 defaultSitemapLabel = filteredSitemaps[0].label
                 // swiftformat:disable:next redundantSelf
-                logger.info("Auto-selected first sitemap from \(filteredSitemaps.count) available: \(self.defaultSitemap)")
+                logger.info("Auto-selected first sitemap from \(filteredSitemaps.count, privacy: .public) available: \(self.defaultSitemap, privacy: .public)")
 
                 // Save as default for future launches
                 Preferences.shared.modifyActiveHome { homePreferences in
@@ -892,7 +892,7 @@ extension SitemapPageViewModel {
                 error = SitemapPageError.serviceUnavailable
             }
         } catch {
-            logger.error("Failed to discover sitemaps: \(error)")
+            logger.error("Failed to discover sitemaps: \(error.localizedDescription, privacy: .public)")
             self.error = error as? any LocalizedError ?? SitemapPageError.serviceUnavailable
         }
     }
@@ -900,7 +900,7 @@ extension SitemapPageViewModel {
     func handleActiveConnectionChange(_ activeConnection: ConnectionInfo?) {
         guard let activeConnection else { return }
 
-        logger.info("SitemapPageViewModel tracker URL \(activeConnection.configuration.url)")
+        logger.info("SitemapPageViewModel tracker connection \(activeConnection.configuration.publicLogDescription, privacy: .public)")
 
         // Skip if already connected to this URL — avoids restarting long-polling
         // when the NetworkTracker re-evaluates to the same connection
@@ -1060,10 +1060,10 @@ extension SitemapPageViewModel {
                     sourcePrefix: nil,
                     deviceId: deviceId
                 )
-                logger.info("Successfully sent command \(command) to \(itemname)")
+                logger.info("Successfully sent command \(command, privacy: .private(mask: .hash)) to \(itemname, privacy: .public)")
                 handleCommandSuccess(for: itemname, version: version)
             } catch {
-                logger.info("Failed to send command\(command) to \(itemname): \(error.localizedDescription)")
+                logger.info("Failed to send command \(command, privacy: .private(mask: .hash)) to \(itemname, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 handleCommandFailure(for: itemname, version: version, errorDescription: error.localizedDescription)
             }
         }

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -305,7 +305,7 @@ class OpenHABRootViewController: UIViewController {
                 guard let self, let currentView else {
                     return
                 }
-                Logger.viewController.info("OpenHABWebViewController tracker status \(status.rawValue)")
+                Logger.viewController.info("OpenHABWebViewController tracker status \(status.rawValue, privacy: .public)")
                 let retryButtonTitle: String = String(localized: "retry", comment: "retry connection")
                 switch status {
                 case .started:
@@ -607,12 +607,12 @@ class OpenHABRootViewController: UIViewController {
         let openhabConnectionSubscription = differences.sink { [weak self] diff in
             Logger.viewController.info("openhabConnectionSubscription updated")
             for newHome in diff.newValues {
-                Logger.viewController.info("openhabConnectionSubscription uuid \(newHome.uuid) registering for push notifications ")
+                Logger.viewController.info("openhabConnectionSubscription registering home for push notifications")
                 self?.registerHome(uuid: newHome.uuid, connection: newHome.connection)
             }
             for deletedHome in diff.deletedValues {
                 // TODO: implement deregistration
-                Logger.viewController.warning("APNS Deregistration is missing (wanted to deregister \(deletedHome.connection.url))")
+                Logger.viewController.warning("APNS Deregistration is missing (wanted to deregister \(deletedHome.connection.publicLogURL, privacy: .public))")
             }
         }
 
@@ -629,7 +629,7 @@ class OpenHABRootViewController: UIViewController {
               let deviceName = apsRegistrationData["deviceName"] as? String else {
             return
         }
-        Logger.viewController.info("Registering notifications with \(connection.url)")
+        Logger.viewController.info("Registering notifications with \(connection.publicLogURL, privacy: .public)")
         _ = registerHome(uuid, connection, deviceToken, deviceId, deviceName)
     }
 


### PR DESCRIPTION
## Summary

This PR improves diagnostic logging for connection and sitemap flows by marking operationally useful values as public while keeping sensitive values private.

## Changes

- Add sanitized connection logging helpers that strip URL-embedded credentials.
- Expose safe connection details such as URL, priority, cloud flag, and whether a username is configured.
- Mark useful NetworkTracker, sitemap discovery, notification registration, and getSitemaps diagnostics as public.
- Keep command payloads private via hashed privacy and avoid logging home UUIDs in push-registration flow.

## Validation

- `xcodebuild -workspace openHAB.xcworkspace -scheme openHAB -destination generic/platform=iOS build`

Build passed locally. Xcode emitted unrelated locked-device warnings during validation.