### PR TITLE
Skip re-render of unchanged sitemap rows via .equatable()

### DIFF
--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,6 +43,7 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
+                        .equatable()
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `SitemapRowInput` is already `Equatable`, but without `.equatable()` SwiftUI evaluates `EmbeddingRowInputView`'s body for every row on every long-poll update, even when only a handful of rows changed.
- With `.equatable()`, SwiftUI short-circuits body evaluation for any row whose `SitemapRowInput` value is unchanged — typically 118 out of 122 rows per update cycle.

## Test plan

- [ ] Open a sitemap with many rows and observe smooth scrolling / no visual regression
- [ ] Verify that row state updates (toggle, text, linked) still render correctly when the underlying value changes