### PR TITLE
Use lazy navigationDestination to avoid eager SitemapPageViewModel creation

### DIFF
--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -81,11 +81,7 @@ private struct LinkedPageRowInputView: View {
     let input: LinkedPageRowInput
 
     var body: some View {
-        NavigationLink(
-            destination: SitemapPageView(
-                viewModel: SitemapPageViewModel(pageUrl: input.linkedPageLink, title: input.linkedPageTitle)
-            )
-        ) {
+        NavigationLink(value: LinkedPageNavigation(pageLink: input.linkedPageLink, pageTitle: input.linkedPageTitle)) {
             LinkedPageRowContent(input: input)
         }
         .buttonStyle(.plain)
@@ -116,7 +112,7 @@ private struct LinkedPageRowContent: View {
 }
 
 /// Transitional adapter: drives list from immutable row inputs while reusing existing widget-driven rows.
-struct EmbeddingRowInputView: View {
+struct EmbeddingRowInputView: View, Equatable {
     let rowInput: SitemapRowInput
 
     // Subscribes to the view model so SwiftUI re-evaluates this view when
@@ -130,6 +126,10 @@ struct EmbeddingRowInputView: View {
 
     private var frameRowBackground: Color {
         Color(UIColor.ohSystemGroupedBackground)
+    }
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.rowInput == rhs.rowInput
     }
 
     var body: some View {

--- a/openHAB/UI/SwiftUI/SitemapNavigationView.swift
+++ b/openHAB/UI/SwiftUI/SitemapNavigationView.swift
@@ -25,6 +25,9 @@ struct SitemapNavigationView: View {
     var body: some View {
         NavigationStack {
             sitemapContent
+                .navigationDestination(for: LinkedPageNavigation.self) { nav in
+                    SitemapPageView(viewModel: SitemapPageViewModel(pageUrl: nav.pageLink, title: nav.pageTitle))
+                }
         }
         .onChange(of: scenePhase) { newPhase in
             switch newPhase {

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,6 +43,7 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
+                        .equatable()
                 }
             }
         }

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,7 +43,6 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
-                        .equatable()
                 }
             }
         }

--- a/openHAB/UI/SwiftUI/SitemapRowInput.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowInput.swift
@@ -24,6 +24,14 @@ struct RowID: Hashable, Sendable {
     }
 }
 
+/// Navigation value pushed onto the NavigationStack when a linked-page row is tapped.
+/// Declared here so both EmbeddingRowInputView (producer) and SitemapNavigationView
+/// (navigationDestination handler) can reference it without a shared module dependency.
+struct LinkedPageNavigation: Hashable {
+    let pageLink: String
+    let pageTitle: String
+}
+
 /// Draft immutable row union for a list-driven SwiftUI pipeline.
 /// Each row case carries a dedicated typed input.
 enum SitemapRowInput: Identifiable, Equatable, Sendable {


### PR DESCRIPTION
## Problem

`LinkedPageRowInputView` created a `SitemapPageViewModel` as an inline argument to `NavigationLink(destination:)`:

```swift
NavigationLink(
    destination: SitemapPageView(
        viewModel: SitemapPageViewModel(pageUrl: input.linkedPageLink, title: input.linkedPageTitle)
    )
)
```

Because `destination:` is a regular Swift function argument, it is evaluated **eagerly** — every time `LinkedPageRowInputView.body` is computed. With 42 linked rows on a 122-widget sitemap and long-poll updates arriving every 1–3 seconds, this produced up to 42 fresh `SitemapPageViewModel` instances per update cycle. Each instance:

- Called `startObservers()` → spawned a `foregroundObserverTask` registered for `UIApplication.didBecomeActiveNotification`
- Was eventually released by ARC, but lingered long enough to accumulate

After a prolonged background session with network disruption, this pool of instances — combined with the per-instance `0.75s` coalescing guard — produced a burst of simultaneous foreground-refresh attempts when the app returned to the foreground, manifesting as UI hiccups.

## Fix

- Replace `NavigationLink(destination:)` with `NavigationLink(value:)` + `.navigationDestination(for: LinkedPageNavigation.self)` in `SitemapNavigationView`
- The destination `SitemapPageView` and its `SitemapPageViewModel` are now created **only when the user actually navigates to the page**
- Add `LinkedPageNavigation: Hashable` in `SitemapRowInput.swift` as the navigation value type (lightweight — `pageLink` + `pageTitle` only)
- Also add `Equatable` conformance to `EmbeddingRowInputView` with a `rowInput`-based `==`, ready for `.equatable()` to be re-enabled

## Test plan

- [ ] Tap a linked-page row and verify navigation works
- [ ] Navigate several levels deep and back — each page loads correctly
- [ ] Verify no regression on the root sitemap long-polling
- [ ] Background the app for several minutes with a deep navigation stack, return to foreground — should see a single foreground refresh, not a burst