### PR TITLE
Include home name in item search

### DIFF
--- a/AppIntents/ItemEntityQuery.swift
+++ b/AppIntents/ItemEntityQuery.swift
@@ -116,11 +116,23 @@ extension ItemEntityQuery {
 
     func entities(matching string: String) async throws -> [EntityType] {
         let selectedHomeId = await resolvedSelectedHomeId()
-        let searchResults = await OpenHABItemCache.instance.searchCachedOrPersistedItems(
-            searchTerm: string,
-            types: allowedTypes.isEmpty ? nil : allowedTypes,
-            homes: selectedHomeId.map { [$0] }
-        )
+        let searchResults: [UUID: [OpenHABItem]]
+        if let selectedHomeId {
+            searchResults = await OpenHABItemCache.instance.searchCachedOrPersistedItems(
+                searchTerm: string,
+                types: allowedTypes.isEmpty ? nil : allowedTypes,
+                homes: [selectedHomeId]
+            )
+        } else {
+            let storedHomes = await Preferences.shared.listStoredHomes()
+            let homeNames = await homeNames(for: storedHomes)
+            searchResults = await homeAwareSearchResults(
+                matching: string,
+                types: allowedTypes.isEmpty ? nil : allowedTypes,
+                homes: storedHomes,
+                homeNames: homeNames
+            )
+        }
 
         // If the user selected a Home in the intent UI, scope results to that home.
         if selectedHomeId != nil {
@@ -141,5 +153,45 @@ extension ItemEntityQuery {
         let hasExactNameMatch = item.name.localizedCaseInsensitiveCompare(searchTerm) == .orderedSame
         let hasExactLabelMatch = item.label.localizedCaseInsensitiveCompare(searchTerm) == .orderedSame
         return hasExactNameMatch || hasExactLabelMatch
+    }
+
+    @MainActor
+    func homeNames(for homeIds: [UUID]) -> [UUID: String] {
+        let storedHomes = Preferences.shared.storedHomes
+        return Dictionary(uniqueKeysWithValues: homeIds.compactMap { homeId in
+            storedHomes[homeId].map { (homeId, $0.homeName) }
+        })
+    }
+
+    func homeAwareSearchResults(
+        matching string: String,
+        types: [OpenHABItem.ItemType]?,
+        homes: [UUID],
+        homeNames: [UUID: String]
+    ) async -> [UUID: [OpenHABItem]] {
+        let itemsByHome = await OpenHABItemCache.instance.getCachedOrPersistedItems(types: types, homes: homes)
+        var result: [UUID: [OpenHABItem]] = [:]
+
+        for homeId in homes {
+            let homeName = homeNames[homeId]
+            let filtered = (itemsByHome[homeId] ?? [])
+                .ranked(searchTerm: string, for: types) { item in
+                    guard let homeName else {
+                        return []
+                    }
+                    return [
+                        homeName,
+                        "\(item.name) \(homeName)",
+                        "\(item.label) \(homeName)"
+                    ]
+                }
+                .map(\.item)
+
+            if !filtered.isEmpty {
+                result[homeId] = filtered
+            }
+        }
+
+        return result
     }
 }

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -244,8 +244,8 @@ public extension OpenHABItem {
         types == nil || (type.flatMap { types?.contains($0) } == true)
     }
 
-    func searchScore(for searchTerm: String) -> Int? {
-        ItemSearchRanker.score(for: self, searchTerm: searchTerm)
+    func searchScore(for searchTerm: String, additionalCandidates: [String] = []) -> Int? {
+        ItemSearchRanker.score(for: self, searchTerm: searchTerm, additionalCandidates: additionalCandidates)
     }
 }
 
@@ -254,7 +254,11 @@ public extension [OpenHABItem] {
         ranked(searchTerm: searchTerm, for: types).map(\.item)
     }
 
-    func ranked(searchTerm: String? = nil, for types: [OpenHABItem.ItemType]? = nil) -> [(item: OpenHABItem, score: Int)] {
+    func ranked(
+        searchTerm: String? = nil,
+        for types: [OpenHABItem.ItemType]? = nil,
+        additionalCandidates: (OpenHABItem) -> [String] = { _ in [] }
+    ) -> [(item: OpenHABItem, score: Int)] {
         compactMap { item in
             guard item.matches(types: types) else {
                 return nil
@@ -264,7 +268,7 @@ public extension [OpenHABItem] {
                 return (item: item, score: 0)
             }
 
-            guard let score = item.searchScore(for: searchTerm) else {
+            guard let score = item.searchScore(for: searchTerm, additionalCandidates: additionalCandidates(item)) else {
                 return nil
             }
 
@@ -359,13 +363,13 @@ public extension OpenHABItemCache {
 }
 
 private enum ItemSearchRanker {
-    static func score(for item: OpenHABItem, searchTerm: String) -> Int? {
+    static func score(for item: OpenHABItem, searchTerm: String, additionalCandidates: [String] = []) -> Int? {
         let tokens = normalizedTokens(in: searchTerm)
         guard !tokens.isEmpty else {
             return 0
         }
 
-        let candidates = [item.name, item.label]
+        let candidates = [item.name, item.label] + additionalCandidates
         return candidates.enumerated().compactMap { index, candidate in
             score(candidate: candidate, tokens: tokens).map { ($0 * 10) + index }
         }.min()

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABItemCacheSearchTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABItemCacheSearchTests.swift
@@ -43,6 +43,17 @@ struct OpenHABItemCacheSearchTests {
         #expect(ranked.map(\.item.name) == ["KitchenSwitch"])
     }
 
+    @Test
+    func rankedSearchMatchesAdditionalCandidates() {
+        let officeSensor = makeItem(name: "TemperatureSensorOffice", label: "Office Sensor", type: "Number")
+
+        let ranked = [officeSensor].ranked(searchTerm: "main temp", for: nil) { item in
+            ["\(item.name) Main Home", "\(item.label) Main Home"]
+        }
+
+        #expect(ranked.map(\.item.name) == ["TemperatureSensorOffice"])
+    }
+
     private func makeItem(name: String, label: String, type: String = "Switch") -> OpenHABItem {
         OpenHABItem(
             name: name,

--- a/openHABTestsSwift/AppIntentsTests.swift
+++ b/openHABTestsSwift/AppIntentsTests.swift
@@ -297,6 +297,21 @@ struct HomeResolverTests {
     }
 }
 
+// MARK: - Item Search Ranking
+
+@Suite("Item search ranking")
+struct ItemSearchRankingTests {
+    @Test func homeNameCanContributeToItemSearch() {
+        let officeSensor = makeItem(name: "TemperatureSensorOffice", type: "Number", label: "Office Sensor")
+
+        let ranked = [officeSensor].ranked(searchTerm: "main temp", for: nil) { item in
+            ["\(item.name) Main Home", "\(item.label) Main Home"]
+        }
+
+        #expect(ranked.map(\.item.name) == ["TemperatureSensorOffice"])
+    }
+}
+
 // MARK: - Error Descriptions
 
 @Suite("Intent error descriptions")


### PR DESCRIPTION
## Summary

- Extended item search ranking so callers can include additional searchable strings.
- Included the selected item's home name when searching across all homes.
- Added focused coverage for matching item search terms through home-name candidates.

## Why

When no home is selected, Shortcuts can show items from multiple homes. Including the home name in search makes it possible to narrow item results by the home they belong to while preserving the existing fast path when a home is selected.

## Validation

- `xcodebuild -workspace /Users/tms/Developer/openhab-ios/openHAB.xcworkspace -scheme openHAB -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild test -workspace /Users/tms/Developer/openhab-ios/openHAB.xcworkspace -scheme openHABTestsSwift -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:openHABTestsSwift/ItemSearchRankingTests/homeNameCanContributeToItemSearch`
- `git diff --check`