### PR TITLE
Fix slider commands sending 36.0 instead of 36 for Number items

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
@@ -35,13 +35,22 @@ public struct NumberState: CustomStringConvertible, Equatable {
     }
 
     /// Value string suitable for sending as a command to the server.
-    /// Preserves full numeric precision (never truncated by display format)
-    /// and appends the unit when present.
+    /// Sends integers without decimal suffix (36 not 36.0) so HTTP binding
+    /// string substitution (%2$s) passes clean values to downstream devices.
+    /// Fractional values are preserved (30.3 is never truncated to 30).
     public var commandString: String {
-        if let unit, !unit.isEmpty {
-            return "\(stringValue) \(unit)"
+        let valueString: String
+        if value.truncatingRemainder(dividingBy: 1) == 0,
+           value >= Double(Int.min),
+           value <= Double(Int.max) {
+            valueString = String(Int(value))
+        } else {
+            valueString = String(value)
         }
-        return stringValue
+        if let unit, !unit.isEmpty {
+            return "\(valueString) \(unit)"
+        }
+        return valueString
     }
 
     // Access to default memberwise initializer not permitted outside of package

--- a/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
@@ -34,14 +34,18 @@ struct NumberStateTests {
         #expect(NumberState(value: 100.4, unit: "°C", format: "%.1f / %.1f %unit%").toString(locale: Locale(identifier: "de")) == "100.4 °C")
     }
 
-    @Test("commandString preserves full precision regardless of display format")
+    @Test("commandString preserves fractional values but strips .0 from whole numbers")
     func commandString() {
+        // Fractional values must not be truncated by display format
         #expect(NumberState(value: 30.3, format: "%d").commandString == "30.3")
         #expect(NumberState(value: 30.3, unit: "°C", format: "%d %unit%").commandString == "30.3 °C")
         #expect(NumberState(value: 30.3, unit: "°C", format: "%.1f %unit%").commandString == "30.3 °C")
-        #expect(NumberState(value: 30.0, format: "%d").commandString == "30.0")
         #expect(NumberState(value: 30.3, unit: nil, format: "%d").commandString == "30.3")
         #expect(NumberState(value: 30.3, unit: "", format: "%d").commandString == "30.3")
+        // Whole numbers must be sent without decimal suffix so HTTP binding %2$s passes clean values
+        #expect(NumberState(value: 30.0, format: "%d").commandString == "30")
+        #expect(NumberState(value: 36.0, format: "%d").commandString == "36")
+        #expect(NumberState(value: 100.0, unit: "°C", format: "%d %unit%").commandString == "100 °C")
     }
 
     @Test("setpoint formatter prefers server label when idle")


### PR DESCRIPTION
## Summary

- `NumberState.commandString` used `String(Double)` which always produces `"36.0"` for whole numbers in Swift
- The openHAB HTTP binding's `%2$s` string substitution passes the command value literally into device URLs, so `"36.0"` was reaching downstream HTTP devices that expect plain integers
- Whole-number doubles are now formatted as integers (`36`, not `36.0`); true fractional values like `30.3` are still preserved — keeping the fix from 3f7d778e intact

## Reported scenario

`Number` item on a `Slider` widget backed by an HTTP binding thing using `commandExtension="...&goto=%2$s"`. Moving the slider sent `goto=36.0`; the device rejected it and the item reverted to its previous state. The identical slider worked in Basic UI (which sends `goto=36`).

## Test plan

- [ ] `NumberStateTests/commandString` — covers both fractional preservation and whole-number integer format
- [ ] Run with `xcodebuild -workspace openHAB.xcworkspace -scheme openHABTestsSwift -testPlan openHABTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
- [ ] Manual: move a slider on a `Number` item backed by an HTTP binding and verify the command URL receives a plain integer