### PR TITLE
Fix submenu navigation title briefly flashing item value

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Model/WidgetRendering.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/WidgetRendering.swift
@@ -44,7 +44,7 @@ private func _widgetAdjustStep(_ raw: Double, minValue: Double, maxValue: Double
 public extension WidgetRendering {
     /// Text portion of the label (everything before the first "[").
     var labelText: String {
-        label.components(separatedBy: "[")[0].trimmingCharacters(in: .whitespaces)
+        label.labelText
     }
 
     /// Value portion of the label (content of the first "[…]"), if present.

--- a/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
@@ -172,6 +172,12 @@ public extension String {
     func removeTrailingSlashes() -> String {
         replacing(/\/+$/, with: "")
     }
+
+    /// The text portion of an openHAB label — everything before the first "[".
+    /// e.g. "Living Room [21°C]" → "Living Room"
+    var labelText: String {
+        components(separatedBy: "[")[0].trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }
 
 public extension String? {

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -120,14 +120,13 @@ class SitemapPageViewModel: ObservableObject {
     }
 
     var pageTitle: String {
-        // Strip bracket content from title (e.g., "Living Room[2]" becomes "Living Room")
-        let title = currentPage?.title.components(separatedBy: "[")[0].trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let title = currentPage?.title.labelText ?? ""
         if !title.isEmpty {
             return title
         } else if !fallbackTitle.isEmpty {
-            return fallbackTitle
+            return fallbackTitle.labelText
         } else if !defaultSitemapLabel.isEmpty {
-            return defaultSitemapLabel
+            return defaultSitemapLabel.labelText
         } else {
             // Return empty — SitemapPageView shows a redacted placeholder title when loading
             return ""


### PR DESCRIPTION
## Summary

- When navigating into a submenu, `pageTitle` fell back to the raw `fallbackTitle` (e.g. `"Living Room [21°C]"`) during the ~800ms before the first page response arrived, then snapped to the stripped form once `currentPage` was set — causing the visible flash of the item value.
- Fixed by applying the same bracket-stripping logic to `fallbackTitle` and `defaultSitemapLabel` in `pageTitle`, not just to `currentPage?.title`.
- Centralised the logic as `String.labelText` in `StringExtension.swift` so `WidgetRendering.labelText` delegates to the same implementation instead of duplicating it.

## Test plan

- [ ] Navigate into a submenu whose linked-page title includes an item value (e.g. `"Room [21°C]"`): navigation bar should show only `"Room"` from the moment the screen appears
- [ ] Verify the submenu title still resolves correctly once the page loads
- [ ] Verify `WidgetRendering.labelText` still strips brackets correctly in list rows