### PR TITLE
Restore sitemap page context in command source

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -1125,13 +1125,14 @@ extension SitemapPageViewModel {
     private func sendCommandNow(itemname: String, command: String, version: Int) {
         setCommandState(.sending, for: itemname)
         let deviceId = UIDevice.current.identifierForVendor?.uuidString
+        let sourcePrefix = pageId.isEmpty ? nil : "org.openhab.ui.basic$\(defaultSitemap):\(pageId)"
         Task { [weak self] in
             guard let self else { return }
             do {
                 try await openAPIService?.sendItemCommand(
                     itemname: itemname,
                     command: command,
-                    sourcePrefix: nil,
+                    sourcePrefix: sourcePrefix,
                     deviceId: deviceId
                 )
                 logger.info("Successfully sent command \(command, privacy: .private(mask: .hash)) to \(itemname, privacy: .public)")

--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -405,10 +405,11 @@ final class UserData: ObservableObject {
 
     func sendCommand(_ item: OpenHABItem?, command: String?) async {
         guard let item, let command else { return }
+        let sitemapName = AppSettings.shared.sitemapForWatch
+        let pageId = openHABSitemapPage?.pageId ?? ""
+        let sourcePrefix = (!sitemapName.isEmpty && !pageId.isEmpty) ? "org.openhab.ui.basic$\(sitemapName):\(pageId)" : nil
         do {
-            // Watch commands currently rely on server defaults for `source`.
-            // Explicit source formatting can be rejected by some deployments.
-            try await NetworkTracker.shared.send(to: item, command: command)
+            try await NetworkTracker.shared.send(to: item, command: command, sourcePrefix: sourcePrefix, deviceId: AppSettings.deviceId)
         } catch {
             Logger.userData.error("Failed to send command '\(command)' to '\(item.name)': \(error.localizedDescription)")
         }

--- a/openHABWatch/Model/AppSettings.swift
+++ b/openHABWatch/Model/AppSettings.swift
@@ -114,4 +114,16 @@ final class AppSettings: ObservableObject {
         self.init()
         self.openHABRootUrl = openHABRootUrl
     }
+
+    /// Stable per-install identifier, analogous to UIDevice.identifierForVendor on iOS.
+    static var deviceId: String {
+        let key = "watchDeviceId"
+        let store = UserDefaults.standard
+        if let existing = store.string(forKey: key) {
+            return existing
+        }
+        let new = UUID().uuidString
+        store.set(new, forKey: key)
+        return new
+    }
 }


### PR DESCRIPTION
## Summary

- After the SwiftUI rewrite (#892), `sourcePrefix` was left as `nil` in `SitemapPageViewModel`, so item commands were sent as `org.openhab.ios$DEVICEID` instead of the intended `org.openhab.ui.basic$SITEMAP:PAGEID=>org.openhab.ios$DEVICEID`
- Restores the correct source chain for both iOS and watchOS
- watchOS uses a lazily generated UUID persisted in `UserDefaults` as the device identifier (equivalent to `UIDevice.identifierForVendor` on iOS, which is unavailable on watchOS)
- App Intents and WidgetKit commands are unaffected — they have no sitemap page context and correctly send only `org.openhab.ios$DEVICEID`

Discussed in #1064 (comment).

## Test plan

- [ ] Send a command from a sitemap page on iOS and verify the `source` query parameter is `org.openhab.ui.basic$<sitemap>:<pageId>=>org.openhab.ios$<deviceId>`
- [ ] Send a command from a linked (child) sitemap page and verify the correct page ID appears in the source
- [ ] Send a command from the watchOS app and verify `org.openhab.ui.basic$<sitemap>:<pageId>=>org.openhab.watchos$<deviceId>`
- [ ] Trigger an App Intent and verify the source is just `org.openhab.ios$<deviceId>` (no `ui.basic` component)