### PR TITLE
Fix connection detection, icon stability, and scroll performance

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -340,27 +340,52 @@ public actor NetworkTracker {
     /// Search for available connections among connectionConfigurations
     /// When the first one was found, we wait a small grace period if there is a preferred one that also works
     private func findBestConnection() async -> ConnectionInfo? {
-        await withTaskGroup(of: ConnectionInfo?.self, returning: ConnectionInfo?.self) { group in
+        enum ConnectionSearchResult: Sendable {
+            case connection(ConnectionInfo?)
+            case gracePeriodExpired
+            case networkTimeoutExpired
+        }
+
+        return await withTaskGroup(of: ConnectionSearchResult.self, returning: ConnectionInfo?.self) { group in
             let sortedConfigs = connectionConfigurations.sorted { $0.priority < $1.priority }
 
             for config in sortedConfigs {
                 _ = group.addTaskUnlessCancelled {
                     let connection = await self.testConnection(configuration: config)
-                    return connection
+                    return .connection(connection)
                 }
             }
 
-            var currentBestConnection: ConnectionInfo?
+            group.addTask {
+                try? await Task.sleep(for: .seconds(self.networkTimeout))
+                return .networkTimeoutExpired
+            }
 
-            try? await withThrowingTimeout(seconds: networkTimeout) { timeoutController in
-                for await connectionInfo in group {
+            var currentBestConnection: ConnectionInfo?
+            var gracePeriodStarted = false
+
+            while let result = await group.next() {
+                switch result {
+                case let .connection(connectionInfo):
                     guard let connectionInfo else { continue }
 
                     if currentBestConnection == nil {
                         Logger.networkTracker.debug("NetworkTracker: First working connection found: \(connectionInfo.configuration.publicLogDescription, privacy: .public)")
                         currentBestConnection = connectionInfo
-                        // give the other connections a short time to be found, otherwise cancel early
-                        timeoutController.expire(seconds: NetworkTracker.slowConnectionTimeout)
+                        if connectionInfo.configuration.priority == 0 {
+                            Logger.networkTracker.debug("NetworkTracker: Most prioritized connection \(connectionInfo.configuration.publicLogDescription, privacy: .public) tested successfully")
+                            group.cancelAll()
+                            let bestConnectionDescription = currentBestConnection?.configuration.publicLogDescription ?? "none"
+                            Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionDescription, privacy: .public)")
+                            return currentBestConnection
+                        }
+                        if !gracePeriodStarted {
+                            gracePeriodStarted = true
+                            group.addTask {
+                                try? await Task.sleep(for: .seconds(NetworkTracker.slowConnectionTimeout))
+                                return .gracePeriodExpired
+                            }
+                        }
                     } else if let bestConnection = currentBestConnection, connectionInfo.configuration.priority < bestConnection.configuration.priority {
                         Logger.networkTracker.debug("NetworkTracker: Better connection found: \(connectionInfo.configuration.publicLogDescription, privacy: .public)")
                         currentBestConnection = connectionInfo
@@ -370,8 +395,23 @@ public actor NetworkTracker {
                         Logger.networkTracker.debug("NetworkTracker: Most prioritized connection \(connectionInfo.configuration.publicLogDescription, privacy: .public) tested successfully")
                         // Stop further tasks if we found the highest-priority connection and return it
                         group.cancelAll()
-                        return
+                        let bestConnectionDescription = currentBestConnection?.configuration.publicLogDescription ?? "none"
+                        Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionDescription, privacy: .public)")
+                        return currentBestConnection
                     }
+                case .gracePeriodExpired:
+                    guard currentBestConnection != nil else { continue }
+                    Logger.networkTracker.debug("NetworkTracker: Preferred connection grace period expired")
+                    group.cancelAll()
+                    let bestConnectionDescription = currentBestConnection?.configuration.publicLogDescription ?? "none"
+                    Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionDescription, privacy: .public)")
+                    return currentBestConnection
+                case .networkTimeoutExpired:
+                    Logger.networkTracker.debug("NetworkTracker: Connection search timeout expired")
+                    group.cancelAll()
+                    let bestConnectionDescription = currentBestConnection?.configuration.publicLogDescription ?? "none"
+                    Logger.networkTracker.debug("NetworkTracker: Best connection: \(bestConnectionDescription, privacy: .public)")
+                    return currentBestConnection
                 }
             }
 

--- a/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
@@ -29,11 +29,16 @@ final actor MockOpenAPIService: OpenAPIServiceProtocol {
 
     var shouldFail = false
     var returnedVersion = 123
+    var rootVersionDelay: Duration?
     var mockServerProperties = OpenHABServerProperties(version: "", links: [])
 
-    init(returnedVersion: Int = 123, shouldFail: Bool = false, mockServerProperties: OpenHABServerProperties = .init(version: "", links: [])) {
+    init(returnedVersion: Int = 123,
+         shouldFail: Bool = false,
+         rootVersionDelay: Duration? = nil,
+         mockServerProperties: OpenHABServerProperties = .init(version: "", links: [])) {
         self.returnedVersion = returnedVersion
         self.shouldFail = shouldFail
+        self.rootVersionDelay = rootVersionDelay
         self.mockServerProperties = mockServerProperties
     }
 
@@ -81,6 +86,9 @@ final actor MockOpenAPIService: OpenAPIServiceProtocol {
     }
 
     func getRootVersion() async throws -> Int {
+        if let rootVersionDelay {
+            try await Task.sleep(for: rootVersionDelay)
+        }
         if shouldFail {
             throw networkTrackerError
         }
@@ -221,6 +229,46 @@ final class NetworkTrackerTests: XCTestCase {
 
         await fulfillment(of: [connectedExpectation], timeout: 2.0)
         statusTask.cancel()
+    }
+
+    func testFallbackConnectionBecomesActiveBeforePreferredConnectionTimesOut() async {
+        let localConfig = ConnectionConfiguration(
+            url: "http://local",
+            username: "",
+            password: "",
+            priority: 0
+        )
+        let remoteConfig = ConnectionConfiguration(
+            url: "https://remote",
+            username: "",
+            password: "",
+            priority: 1
+        )
+
+        let localService = MockOpenAPIService(shouldFail: true, rootVersionDelay: .seconds(5))
+        let remoteService = MockOpenAPIService(returnedVersion: 8)
+        let mockPool = ConnectionPool { configuration in
+            if configuration == localConfig {
+                return localService
+            }
+            return remoteService
+        }
+        let mockMonitor = MockPathMonitor()
+        let networkTracker = NetworkTracker(
+            monitor: mockMonitor,
+            connectionPool: mockPool,
+            failureTracker: ConnectionFailureTracker(),
+            timeout: 5
+        )
+
+        let startedAt = Date()
+        await networkTracker.startTracking(connectionConfigurations: [localConfig, remoteConfig])
+
+        let activeConnection = await networkTracker.waitForActiveConnection()
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        #expect(activeConnection?.configuration == remoteConfig)
+        #expect(elapsed < 2.5)
     }
 
 //    @MainActor

--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -47,6 +47,13 @@ enum RowLayoutPolicy {
         }
     }
 
+    static let frameBackground = Color(UIColor.ohSystemGroupedBackground)
+    static let regularBackground = Color(UIColor.ohSecondarySystemGroupedBackground)
+
+    static func rowBackground(for rowInput: SitemapRowInput) -> Color {
+        backgroundKind(for: rowInput) == .frame ? frameBackground : regularBackground
+    }
+
     static func backgroundKind(for rowInput: SitemapRowInput) -> RowBackgroundKind {
         switch rowInput {
         case .frame:
@@ -120,15 +127,7 @@ struct EmbeddingRowInputView: View, Equatable {
     // foreground refresh may render stale data from a cached render.
     @EnvironmentObject private var viewModel: SitemapPageViewModel
 
-    private var regularRowBackground: Color {
-        Color(UIColor.ohSecondarySystemGroupedBackground)
-    }
-
-    private var frameRowBackground: Color {
-        Color(UIColor.ohSystemGroupedBackground)
-    }
-
-    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+    nonisolated static func ==(lhs: Self, rhs: Self) -> Bool {
         lhs.rowInput == rhs.rowInput
     }
 
@@ -137,78 +136,48 @@ struct EmbeddingRowInputView: View, Equatable {
         case let .frame(_, input):
             FrameRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.rowInsets(for: rowInput))
-                .listRowBackground(frameRowBackground)
         case let .linked(_, input):
             LinkedPageRowInputView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.rowInsets(for: rowInput))
-                .listRowBackground(RowLayoutPolicy.backgroundKind(for: rowInput) == .frame ? frameRowBackground : regularRowBackground)
         case let .slider(_, input):
             SliderRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .selection(_, input):
             SelectionRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .segmented(_, input):
             SegmentedRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .setpoint(_, input):
             SetpointRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .text(_, input):
             TextRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .toggle(_, input):
             SwitchRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .rollershutter(_, input):
             RollershutterRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .input(_, input):
             InputRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .colorPicker(_, input):
             ColorPickerRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .media(_, input):
             MediaRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .colorTemperature(_, input):
             ColorTemperaturePickerRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .buttonGrid(_, input):
             ButtonGridRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         case let .generic(_, input):
             GenericRowView(input: input)
                 .contentShape(Rectangle())
-                .listRowInsets(RowLayoutPolicy.regularInsets)
-                .listRowBackground(regularRowBackground)
         }
     }
 }

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -67,11 +67,15 @@ struct IconInputView: View {
         guard
             let activeConnection = networkTracker.activeConnection,
             !activeConnection.configuration.url.isEmpty else {
+            recordIconResolutionFailure(
+                reason: networkTracker.activeConnection == nil ? "no-active-connection" : "empty-connection-url",
+                connectionDescription: networkTracker.activeConnection?.configuration.publicLogDescription ?? "none"
+            )
             logger.debug("No active connection to fetch icon")
             return nil
         }
 
-        return Endpoint.icon(
+        guard let endpoint = Endpoint.icon(
             rootUrl: activeConnection.configuration.url,
             version: activeConnection.version,
             icon: input.icon,
@@ -79,7 +83,14 @@ struct IconInputView: View {
             iconType: iconType,
             iconColor: iconColorHex,
             staticIcon: input.staticIcon
-        )?.url
+        )?.url else {
+            recordIconResolutionFailure(
+                reason: "endpoint-url-build-failed",
+                connectionDescription: activeConnection.configuration.publicLogDescription
+            )
+            return nil
+        }
+        return endpoint
     }
 
     var body: some View {
@@ -107,7 +118,7 @@ struct IconInputView: View {
                             recordIconCancellation(url: iconURL)
                             return
                         }
-                        recordIconFailure(url: iconURL)
+                        recordIconFailure(url: iconURL, reason: error.localizedDescription)
                         logger.error("Icon loading failed for icon '\(input.icon, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         logger.error("Failed URL: \(iconURL.absoluteString, privacy: .public)")
                     }
@@ -148,6 +159,12 @@ struct IconInputView: View {
 
     private func recordIconStart(url: URL) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconStart(
+            rowIdentity: rowIdentity,
+            icon: input.icon,
+            url: url,
+            cacheKey: url.absoluteString
+        )
         Task {
             await IconLoadDiagnostics.shared.recordStart(url: url, rowIdentity: rowIdentity)
         }
@@ -155,6 +172,12 @@ struct IconInputView: View {
 
     private func recordIconSuccess(url: URL, cacheType: CacheType) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconSuccess(
+            rowIdentity: rowIdentity,
+            icon: input.icon,
+            url: url,
+            cacheType: cacheType.diagnosticsName
+        )
         Task {
             await IconLoadDiagnostics.shared.recordSuccess(
                 url: url,
@@ -166,15 +189,43 @@ struct IconInputView: View {
 
     private func recordIconCancellation(url: URL) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconFailure(
+            rowIdentity: rowIdentity,
+            icon: input.icon,
+            url: url,
+            reason: "task-cancelled",
+            cancelled: true
+        )
         Task {
             await IconLoadDiagnostics.shared.recordCancellation(url: url, rowIdentity: rowIdentity)
         }
     }
 
-    private func recordIconFailure(url: URL) {
+    private func recordIconFailure(url: URL, reason: String) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconFailure(
+            rowIdentity: rowIdentity,
+            icon: input.icon,
+            url: url,
+            reason: reason,
+            cancelled: false
+        )
         Task {
             await IconLoadDiagnostics.shared.recordFailure(url: url, rowIdentity: rowIdentity)
+        }
+    }
+
+    private func recordIconResolutionFailure(reason: String, connectionDescription: String) {
+        guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconResolutionFailure(
+            rowIdentity: rowIdentity,
+            icon: input.icon,
+            reason: reason,
+            trackerStatus: networkTracker.status.rawValue,
+            connectionDescription: connectionDescription
+        )
+        Task {
+            await IconLoadDiagnostics.shared.recordResolutionFailure(rowIdentity: rowIdentity)
         }
     }
 }
@@ -207,11 +258,15 @@ struct IconView: View {
         guard
             let activeConnection = networkTracker.activeConnection,
             !activeConnection.configuration.url.isEmpty else {
+            recordIconResolutionFailure(
+                reason: networkTracker.activeConnection == nil ? "no-active-connection" : "empty-connection-url",
+                connectionDescription: networkTracker.activeConnection?.configuration.publicLogDescription ?? "none"
+            )
             logger.debug("No active connection to fetch icon")
             return nil
         }
 
-        return Endpoint.icon(
+        guard let endpoint = Endpoint.icon(
             rootUrl: activeConnection.configuration.url,
             version: activeConnection.version,
             icon: widget.icon,
@@ -219,7 +274,14 @@ struct IconView: View {
             iconType: iconType,
             iconColor: iconColorHex,
             staticIcon: widget.staticIcon
-        )?.url
+        )?.url else {
+            recordIconResolutionFailure(
+                reason: "endpoint-url-build-failed",
+                connectionDescription: activeConnection.configuration.publicLogDescription
+            )
+            return nil
+        }
+        return endpoint
     }
 
     var body: some View {
@@ -248,7 +310,7 @@ struct IconView: View {
                             recordIconCancellation(url: iconURL)
                             return
                         }
-                        recordIconFailure(url: iconURL)
+                        recordIconFailure(url: iconURL, reason: error.localizedDescription)
                         logger.error("Icon loading failed for icon '\(widget.icon, privacy: .public)': \(error.localizedDescription, privacy: .public)")
                         logger.error("Failed URL: \(iconURL.absoluteString, privacy: .public)")
                     }
@@ -285,6 +347,12 @@ struct IconView: View {
 
     private func recordIconStart(url: URL) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconStart(
+            rowIdentity: widget.id,
+            icon: widget.icon,
+            url: url,
+            cacheKey: url.absoluteString
+        )
         Task {
             await IconLoadDiagnostics.shared.recordStart(url: url, rowIdentity: widget.id)
         }
@@ -292,6 +360,12 @@ struct IconView: View {
 
     private func recordIconSuccess(url: URL, cacheType: CacheType) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconSuccess(
+            rowIdentity: widget.id,
+            icon: widget.icon,
+            url: url,
+            cacheType: cacheType.diagnosticsName
+        )
         Task {
             await IconLoadDiagnostics.shared.recordSuccess(
                 url: url,
@@ -303,15 +377,43 @@ struct IconView: View {
 
     private func recordIconCancellation(url: URL) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconFailure(
+            rowIdentity: widget.id,
+            icon: widget.icon,
+            url: url,
+            reason: "task-cancelled",
+            cancelled: true
+        )
         Task {
             await IconLoadDiagnostics.shared.recordCancellation(url: url, rowIdentity: widget.id)
         }
     }
 
-    private func recordIconFailure(url: URL) {
+    private func recordIconFailure(url: URL, reason: String) {
         guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconFailure(
+            rowIdentity: widget.id,
+            icon: widget.icon,
+            url: url,
+            reason: reason,
+            cancelled: false
+        )
         Task {
             await IconLoadDiagnostics.shared.recordFailure(url: url, rowIdentity: widget.id)
+        }
+    }
+
+    private func recordIconResolutionFailure(reason: String, connectionDescription: String) {
+        guard SitemapDiagnostics.isEnabled else { return }
+        SitemapDiagnostics.logIconResolutionFailure(
+            rowIdentity: widget.id,
+            icon: widget.icon,
+            reason: reason,
+            trackerStatus: networkTracker.status.rawValue,
+            connectionDescription: connectionDescription
+        )
+        Task {
+            await IconLoadDiagnostics.shared.recordResolutionFailure(rowIdentity: widget.id)
         }
     }
 }

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -47,7 +47,6 @@ struct IconInputView: View {
     let fallbackSymbol: SFSymbol?
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject var viewModel: SitemapPageViewModel
 
     let size: CGSize
     let iconType: IconType = .svg
@@ -137,7 +136,7 @@ struct IconInputView: View {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(viewModel.pageId)-\(rowIdentity)-\(colorScheme)")
+                    .id("\(iconURL.absoluteString)-\(colorScheme)")
                     .onAppear {
                         recordIconStart(url: iconURL)
                     }
@@ -235,7 +234,6 @@ struct IconView: View {
     @ObservedObject var widget: OpenHABWidget
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject var viewModel: SitemapPageViewModel
 
     let size: CGSize
     let iconType: IconType = .svg
@@ -330,7 +328,7 @@ struct IconView: View {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(viewModel.pageId)-\(widget.id)-\(colorScheme)")
+                    .id("\(iconURL.absoluteString)-\(colorScheme)")
                     .onAppear {
                         recordIconStart(url: iconURL)
                     }
@@ -464,5 +462,4 @@ extension IconView {
     widget.icon = "switch"
     widget.label = "Test Switch"
     return IconView(widget: widget, fallbackSymbol: .switch2)
-        .environmentObject(SitemapPageViewModel())
 }

--- a/openHAB/UI/SwiftUI/RowViewWithIcon.swift
+++ b/openHAB/UI/SwiftUI/RowViewWithIcon.swift
@@ -31,7 +31,7 @@ struct RowViewWithIcon<Content: View>: View {
     }
 
     init(input: any RowWithIconInput,
-         fallbackSymbol: SFSymbol? = .questionmark,
+         fallbackSymbol: SFSymbol? = nil,
          alignment: VerticalAlignment = .center,
          spacing: CGFloat? = nil,
          @ViewBuilder content: @escaping () -> Content) {

--- a/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
+++ b/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
@@ -14,6 +14,7 @@ import OpenHABCore
 import os.log
 
 struct IconLoadDiagnosticsSnapshot {
+    let resolutionFailures: Int
     let starts: Int
     let successes: Int
     let memoryHits: Int
@@ -25,7 +26,8 @@ struct IconLoadDiagnosticsSnapshot {
     let distinctRows: Int
 
     var isEmpty: Bool {
-        starts == 0 &&
+        resolutionFailures == 0 &&
+            starts == 0 &&
             successes == 0 &&
             memoryHits == 0 &&
             diskHits == 0 &&
@@ -39,6 +41,7 @@ actor IconLoadDiagnostics {
     static let shared = IconLoadDiagnostics()
 
     private var starts = 0
+    private var resolutionFailures = 0
     private var successes = 0
     private var memoryHits = 0
     private var diskHits = 0
@@ -47,6 +50,11 @@ actor IconLoadDiagnostics {
     private var failures = 0
     private var distinctURLs: Set<String> = []
     private var distinctRows: Set<String> = []
+
+    func recordResolutionFailure(rowIdentity: String) {
+        resolutionFailures += 1
+        distinctRows.insert(rowIdentity)
+    }
 
     func recordStart(url: URL, rowIdentity: String) {
         starts += 1
@@ -82,6 +90,7 @@ actor IconLoadDiagnostics {
 
     func snapshotAndReset() -> IconLoadDiagnosticsSnapshot {
         let snapshot = IconLoadDiagnosticsSnapshot(
+            resolutionFailures: resolutionFailures,
             starts: starts,
             successes: successes,
             memoryHits: memoryHits,
@@ -92,6 +101,7 @@ actor IconLoadDiagnostics {
             distinctURLs: distinctURLs.count,
             distinctRows: distinctRows.count
         )
+        resolutionFailures = 0
         starts = 0
         successes = 0
         memoryHits = 0
@@ -161,7 +171,41 @@ enum SitemapDiagnostics {
     static func logIconSummary(_ snapshot: IconLoadDiagnosticsSnapshot) {
         guard isEnabled, !snapshot.isEmpty else { return }
         logger.info(
-            "icons starts=\(snapshot.starts, privacy: .public) successes=\(snapshot.successes, privacy: .public) memoryHits=\(snapshot.memoryHits, privacy: .public) diskHits=\(snapshot.diskHits, privacy: .public) networkLoads=\(snapshot.networkLoads, privacy: .public) cancellations=\(snapshot.cancellations, privacy: .public) failures=\(snapshot.failures, privacy: .public) distinctURLs=\(snapshot.distinctURLs, privacy: .public) distinctRows=\(snapshot.distinctRows, privacy: .public)"
+            "icons resolutionFailures=\(snapshot.resolutionFailures, privacy: .public) starts=\(snapshot.starts, privacy: .public) successes=\(snapshot.successes, privacy: .public) memoryHits=\(snapshot.memoryHits, privacy: .public) diskHits=\(snapshot.diskHits, privacy: .public) networkLoads=\(snapshot.networkLoads, privacy: .public) cancellations=\(snapshot.cancellations, privacy: .public) failures=\(snapshot.failures, privacy: .public) distinctURLs=\(snapshot.distinctURLs, privacy: .public) distinctRows=\(snapshot.distinctRows, privacy: .public)"
+        )
+    }
+
+    static func logIconResolutionFailure(
+        rowIdentity: String,
+        icon: String,
+        reason: String,
+        trackerStatus: String,
+        connectionDescription: String
+    ) {
+        guard isEnabled else { return }
+        logger.info(
+            "iconResolutionFailure row=\(rowIdentity, privacy: .private(mask: .hash)) icon=\(icon, privacy: .public) reason=\(reason, privacy: .public) trackerStatus=\(trackerStatus, privacy: .public) connection=\(connectionDescription, privacy: .public)"
+        )
+    }
+
+    static func logIconStart(rowIdentity: String, icon: String, url: URL, cacheKey: String) {
+        guard isEnabled else { return }
+        logger.debug(
+            "iconStart row=\(rowIdentity, privacy: .private(mask: .hash)) icon=\(icon, privacy: .public) url=\(url.absoluteString, privacy: .public) cacheKey=\(cacheKey, privacy: .public)"
+        )
+    }
+
+    static func logIconSuccess(rowIdentity: String, icon: String, url: URL, cacheType: String) {
+        guard isEnabled else { return }
+        logger.info(
+            "iconSuccess row=\(rowIdentity, privacy: .private(mask: .hash)) icon=\(icon, privacy: .public) url=\(url.absoluteString, privacy: .public) cacheType=\(cacheType, privacy: .public)"
+        )
+    }
+
+    static func logIconFailure(rowIdentity: String, icon: String, url: URL, reason: String, cancelled: Bool) {
+        guard isEnabled else { return }
+        logger.info(
+            "iconFailure row=\(rowIdentity, privacy: .private(mask: .hash)) icon=\(icon, privacy: .public) url=\(url.absoluteString, privacy: .public) cancelled=\(cancelled, privacy: .public) reason=\(reason, privacy: .public)"
         )
     }
 

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,6 +43,9 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
+                        .equatable()
+                        .listRowInsets(RowLayoutPolicy.rowInsets(for: rowInput))
+                        .listRowBackground(RowLayoutPolicy.rowBackground(for: rowInput))
                 }
             }
         }

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,6 +43,7 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
+                        .equatable()
                 }
             }
         }

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -43,7 +43,6 @@ struct SitemapPageView: View {
             } else {
                 List(viewModel.rowInputs) { rowInput in
                     EmbeddingRowInputView(rowInput: rowInput)
-                        .equatable()
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Faster connection detection over VPN**: Refactors `NetworkTracker.findBestConnection()` to use a task group with explicit `ConnectionSearchResult` cases instead of `withThrowingTimeout`. Priority-0 connections return immediately on success; fallback connections become active after the grace period without waiting for the full network timeout. Adds a test covering the case where the preferred local connection is slow and the remote fallback should win quickly.

- **Richer icon load diagnostics**: Adds `resolutionFailures` counter and per-event debug logging to `IconView`/`SitemapDiagnostics` to explain the `starts=N, successes=0` pattern seen in logs. Tracks when `iconURL` resolves to `nil` (no active connection or endpoint build failure) separately from load failures.

- **Stable icon identity**: Replaces `.id("\(viewModel.pageId)-\(rowIdentity)-\(colorScheme)")` with `.id("\(iconURL.absoluteString)-\(colorScheme)")` in both `IconInputView` and `IconView`. `KFImage` is now recreated only when the actual icon request changes, not on every page navigation. Row identity stays diagnostic-only. Removes the `@EnvironmentObject var viewModel` from both icon views as it was only needed for `pageId`.

- **Blank space instead of question mark**: Changes the `fallbackSymbol` default in `RowViewWithIcon` from `.questionmark` to `nil` — shows empty space while icons load rather than a prominent placeholder.

- **Scroll performance via `.equatable()`**: Applies `.equatable()` to list rows so SwiftUI uses `EmbeddingRowInputView`'s existing `Equatable` conformance to skip body re-evaluation for unchanged rows on each long-poll update. Lifts `listRowInsets` and `listRowBackground` out of `EmbeddingRowInputView` into the `List` closure so the `List` can read them through the `EquatableView` wrapper. Adds `RowLayoutPolicy.rowBackground(for:)` to keep background color logic centralised.

## Test plan

- [ ] Scroll through a large sitemap over VPN — verify reduced hiccups
- [ ] Connect with local URL unavailable — verify fallback to remote happens within grace period rather than full network timeout
- [ ] Wake app after extended background — verify icons load without question marks
- [ ] Toggle dark/light mode — verify icons reload with correct colours
- [ ] Navigate into a subpage and back — verify icons are stable (not reloaded unnecessarily)
- [ ] Verify row heights and backgrounds are correct for frame, linked-as-frame, and regular rows