### PR TITLE
Declare NSPrivacyTracking false in privacy manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
         <dict>


### PR DESCRIPTION
## Summary

- Adds `NSPrivacyTracking = false` to `PrivacyInfo.xcprivacy` to explicitly declare the app does not use data for tracking under the App Tracking Transparency framework
- Without this key, Instruments flags `firebaselogging-pa.googleapis.com` (used by Firebase Crashlytics for crash/diagnostic reporting) as an undeclared tracking domain

## Test plan

- [ ] Build and run the app
- [ ] Open Instruments and verify the privacy warning for `firebaselogging-pa.googleapis.com` no longer appears