### PR TITLE
Add haptic feedback to SegmentedRowView, watchOS SegmentRow, and ColorPickerRowView

### DIFF
--- a/openHAB/UI/SwiftUI/HapticFeedback.swift
+++ b/openHAB/UI/SwiftUI/HapticFeedback.swift
@@ -1,0 +1,41 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func sensoryHeavyFeedbackIfAvailable(trigger: Bool) -> some View {
+        if #available(iOS 17.0, *) {
+            sensoryFeedback(.impact(weight: .heavy, intensity: 0.9), trigger: trigger)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func sensoryStopFeedbackIfAvailable(trigger: Bool) -> some View {
+        if #available(iOS 17.0, *) {
+            sensoryFeedback(.impact(flexibility: .rigid), trigger: trigger)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func sensorySelectionFeedbackIfAvailable(trigger: Bool) -> some View {
+        if #available(iOS 17.0, *) {
+            sensoryFeedback(.selection, trigger: trigger)
+        } else {
+            self
+        }
+    }
+}

--- a/openHAB/UI/SwiftUI/Rows/ColorPickerRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ColorPickerRowView.swift
@@ -348,6 +348,7 @@ private struct ColorPickerRowContent: View {
     @State private var isEditingColor = false
     @State private var isPresentingColorWheel = false
     @State private var suppressNextColorSync = false
+    @State private var triggerFeedback = false
 
     private let logger = Logger(subsystem: "org.openhab", category: "WidgetColorPickerView")
 
@@ -379,6 +380,7 @@ private struct ColorPickerRowContent: View {
                 )
 
                 Button {
+                    triggerFeedback.toggle()
                     isPresentingColorWheel = true
                 } label: {
                     Circle()
@@ -391,6 +393,7 @@ private struct ColorPickerRowContent: View {
                         .shadow(color: .black.opacity(0.15), radius: 2, y: 1)
                 }
                 .buttonStyle(.plain)
+                .sensoryHeavyFeedbackIfAvailable(trigger: triggerFeedback)
                 .accessibilityLabel("Choose color")
                 .accessibilityValue(colorAccessibilityValue)
 

--- a/openHAB/UI/SwiftUI/Rows/RollershutterRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/RollershutterRowView.swift
@@ -136,26 +136,6 @@ struct RollershutterRowView: View {
     }
 }
 
-extension View {
-    @ViewBuilder
-    func sensoryHeavyFeedbackIfAvailable(trigger: Bool) -> some View {
-        if #available(iOS 17.0, *) {
-            sensoryFeedback(.impact(weight: .heavy, intensity: 0.9), trigger: trigger)
-        } else {
-            self
-        }
-    }
-
-    @ViewBuilder
-    func sensoryStopFeedbackIfAvailable(trigger: Bool) -> some View {
-        if #available(iOS 17.0, *) {
-            sensoryFeedback(.impact(flexibility: .rigid), trigger: trigger)
-        } else {
-            self
-        }
-    }
-}
-
 #if DEBUG
 #Preview {
     let widget = PreviewConstants.openHABSitemapPage!.widgets[5]

--- a/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
@@ -31,6 +31,8 @@ private struct SegmentedRowContent: View {
     @State private var optimisticStartVersion: Int?
     @State private var pressedIndex: Int?
     @State private var singlePressed = false
+    @State private var triggerSelectionFeedback = false
+    @State private var triggerPressFeedback = false
 
     var body: some View {
         let selectedIndex = effectiveSelectedIndex(displayState: input.displayState, mappings: input.mappings)
@@ -104,6 +106,8 @@ private struct SegmentedRowContent: View {
                 self.optimisticStartVersion = widgetVersion
             }
         }
+        .sensorySelectionFeedbackIfAvailable(trigger: triggerSelectionFeedback)
+        .sensoryHeavyFeedbackIfAvailable(trigger: triggerPressFeedback)
     }
 
     /// Button-based segmented control with animated selection indicator
@@ -194,6 +198,7 @@ private struct SegmentedRowContent: View {
                     .onChanged { _ in
                         if singlePressed == false {
                             singlePressed = true
+                            triggerSelectionFeedback.toggle()
                             startOptimisticSelection(
                                 command: mapping.command,
                                 displayState: displayState,
@@ -251,6 +256,7 @@ private struct SegmentedRowContent: View {
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                 optimisticSelectedIndex = index
             }
+            triggerSelectionFeedback.toggle()
             sendCommand(mapping.command, .immediate, .change)
         } label: {
             Text(mapping.label)
@@ -292,6 +298,7 @@ private struct SegmentedRowContent: View {
                     .onChanged { _ in
                         if pressedIndex != index {
                             pressedIndex = index
+                            triggerPressFeedback.toggle()
                             // Send command on press
                             logger.info("Sending press command: \(mapping.command)")
                             sendCommand(

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -37,7 +37,7 @@ struct SegmentRow: View {
                 multiSegmentContent
             }
         }
-        .sensoryFeedback(.click, trigger: triggerPressFeedback)
+        .sensoryFeedback(.impact(weight: .medium), trigger: triggerPressFeedback)
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
         }

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -37,10 +37,10 @@ struct SegmentRow: View {
                 multiSegmentContent
             }
         }
+        .sensoryFeedback(.click, trigger: triggerPressFeedback)
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
         }
-        .sensoryFeedback(.click, trigger: triggerPressFeedback)
     }
 
     // MARK: - Press-Release

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -19,6 +19,7 @@ struct SegmentRow: View {
     @EnvironmentObject var settings: AppSettings
     @State private var pressedIndex: Int?
     @State private var singlePressed = false
+    @State private var triggerPressFeedback = false
     @State private var viewModel: WidgetRowViewModel
     @State private var commandSender = WidgetCommandDispatcher()
 
@@ -39,6 +40,7 @@ struct SegmentRow: View {
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
         }
+        .sensoryFeedback(.click, trigger: triggerPressFeedback)
     }
 
     // MARK: - Press-Release
@@ -81,6 +83,7 @@ struct SegmentRow: View {
                                             guard bounds.contains(value.startLocation) else { return }
                                             if pressedIndex != index {
                                                 pressedIndex = index
+                                                triggerPressFeedback.toggle()
                                                 commandSender.sendPress(mapping.command, for: widget)
                                             }
                                         }
@@ -190,6 +193,7 @@ struct SegmentRow: View {
                                 }
                                 .onEnded { value in
                                     if singlePressed, bounds.contains(value.location) {
+                                        triggerPressFeedback.toggle()
                                         commandSender.send(mapping.command, for: widget, policy: .immediate)
                                     }
                                     singlePressed = false


### PR DESCRIPTION
## Summary

- Extracts shared `sensoryFeedback` `View` helpers into a new `HapticFeedback.swift` (removes duplication from `RollershutterRowView`), adding a `sensorySelectionFeedbackIfAvailable` variant alongside the existing heavy/stop helpers
- **SegmentedRowView** (iOS): `.selection` feedback on segment taps and single-mapping presses; heavy impact on press-release press events
- **SegmentRow** (watchOS): `.click` feedback on press-release and single-mapping commits; multi-segment `NavigationLink` left untouched as watchOS provides navigation haptics automatically
- **ColorPickerRowView** (iOS): heavy impact on color circle button tap; `BrightnessButton` already handled its own feedback internally

## Test plan

- [ ] Tap each segment in a multi-segment widget — feel selection feedback
- [ ] Tap a single-mapping button — feel selection feedback
- [ ] Press and hold a press-release button — feel heavy impact on press
- [ ] Tap the color circle to open the color wheel — feel heavy impact
- [ ] Verify `BrightnessButton` tap/long-press feedback unchanged
- [ ] On watchOS: press a press-release segment button — feel click
- [ ] On watchOS: tap a single-mapping button and confirm — feel click
- [ ] On watchOS: open multi-segment picker via NavigationLink — no double haptic