### PR TITLE
Fix sitemap picker showing empty when connected via cloud

### DIFF
--- a/openHAB/UI/SettingsView/SettingsView.swift
+++ b/openHAB/UI/SettingsView/SettingsView.swift
@@ -90,12 +90,13 @@ struct SettingsView: View {
             }
         }
         .task {
-            if !viewAppearedOnce {
-                viewAppearedOnce = true
-                loadSettings()
-                let activeConfiguration = networkTracker.activeConnection?.configuration ?? settingsLocalConnectionConfiguration
-                await updateSitemaps(activeConfiguration: activeConfiguration)
-            }
+            guard !viewAppearedOnce else { return }
+            viewAppearedOnce = true
+            loadSettings()
+        }
+        .task(id: networkTracker.activeConnection) {
+            guard let activeConnection = networkTracker.activeConnection else { return }
+            await updateSitemaps(activeConfiguration: activeConnection.configuration)
         }
     }
 

--- a/openHAB/UI/SettingsView/SettingsView.swift
+++ b/openHAB/UI/SettingsView/SettingsView.swift
@@ -15,6 +15,8 @@ import os
 import SwiftUI
 
 struct SettingsView: View {
+    @StateObject private var networkTracker = MainActorNetworkTracker.shared
+
     @State private var settingsDemomode = false
     @State private var settingsIdleOff = true
     @State private var settingsRealTimeSliders = true
@@ -91,7 +93,7 @@ struct SettingsView: View {
             if !viewAppearedOnce {
                 viewAppearedOnce = true
                 loadSettings()
-                let activeConfiguration = settingsLocalConnectionConfiguration
+                let activeConfiguration = networkTracker.activeConnection?.configuration ?? settingsLocalConnectionConfiguration
                 await updateSitemaps(activeConfiguration: activeConfiguration)
             }
         }


### PR DESCRIPTION
## Summary

- `SettingsView` was always using the local connection config to fetch sitemaps, regardless of which connection is actually active
- When connected via openHAB Cloud Connector (no reachable local URL), the fetch fails silently and the sitemap picker shows "No sitemaps available"
- Fix mirrors the approach already used in `DrawerView`: use `MainActorNetworkTracker`'s active connection, falling back to the local config if no active connection exists yet

Fixes #1189