### PR TITLE
Reload icons after extended background

### DIFF
--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -27,25 +27,35 @@ import SwiftUI
 @MainActor
 final class IconReloadCoordinator: ObservableObject {
     static let shared = IconReloadCoordinator()
+    static let reloadThreshold: TimeInterval = 60
 
     @Published private(set) var reloadEpoch: Int = 0
 
     private var backgroundedAt: Date?
-    private let reloadThreshold: TimeInterval = 60
 
-    private init() {
+    init(observeNotifications: Bool = true) {
+        guard observeNotifications else { return }
         Task { [weak self] in
             for await _ in NotificationCenter.default.notifications(named: UIApplication.didEnterBackgroundNotification) {
-                self?.backgroundedAt = Date()
+                self?.didEnterBackground()
             }
         }
         Task { [weak self] in
             for await _ in NotificationCenter.default.notifications(named: UIApplication.didBecomeActiveNotification) {
-                guard let self else { return }
-                guard let backgroundedAt, Date().timeIntervalSince(backgroundedAt) > reloadThreshold else { return }
-                self.backgroundedAt = nil
-                reloadEpoch += 1
+                self?.didBecomeActive()
             }
+        }
+    }
+
+    func didEnterBackground(now: Date = Date()) {
+        backgroundedAt = now
+    }
+
+    func didBecomeActive(now: Date = Date()) {
+        guard let backgroundedAt else { return }
+        self.backgroundedAt = nil
+        if now.timeIntervalSince(backgroundedAt) >= Self.reloadThreshold {
+            reloadEpoch += 1
         }
     }
 }

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -17,6 +17,39 @@ import os.log
 import SFSafeSymbols
 import SwiftUI
 
+/// Forces KFImage recreation after the app returns from an extended background period.
+///
+/// When iOS evicts Kingfisher's in-memory cache under memory pressure, KFImage instances
+/// whose `.id()` hasn't changed are never recreated and therefore never re-fetch their
+/// images. This coordinator increments `reloadEpoch` after the app has been in the
+/// background for longer than `reloadThreshold`, which is included in each KFImage's
+/// `.id()` so that a fresh load from the Kingfisher disk cache is triggered automatically.
+@MainActor
+final class IconReloadCoordinator: ObservableObject {
+    static let shared = IconReloadCoordinator()
+
+    @Published private(set) var reloadEpoch: Int = 0
+
+    private var backgroundedAt: Date?
+    private let reloadThreshold: TimeInterval = 60
+
+    private init() {
+        Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.didEnterBackgroundNotification) {
+                self?.backgroundedAt = Date()
+            }
+        }
+        Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.didBecomeActiveNotification) {
+                guard let self else { return }
+                guard let backgroundedAt, Date().timeIntervalSince(backgroundedAt) > reloadThreshold else { return }
+                self.backgroundedAt = nil
+                reloadEpoch += 1
+            }
+        }
+    }
+}
+
 /// Thread-safe actor for tracking cached icon keys
 actor IconCacheTracker {
     static let shared = IconCacheTracker()
@@ -46,6 +79,7 @@ struct IconInputView: View {
     let rowIdentity: String
     let fallbackSymbol: SFSymbol?
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    @ObservedObject private var iconReloader = IconReloadCoordinator.shared
     @Environment(\.colorScheme) private var colorScheme
 
     let size: CGSize
@@ -136,7 +170,7 @@ struct IconInputView: View {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(iconURL.absoluteString)-\(colorScheme)")
+                    .id("\(iconURL.absoluteString)-\(colorScheme)-\(iconReloader.reloadEpoch)")
                     .onAppear {
                         recordIconStart(url: iconURL)
                     }
@@ -233,6 +267,7 @@ struct IconInputView: View {
 struct IconView: View {
     @ObservedObject var widget: OpenHABWidget
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    @ObservedObject private var iconReloader = IconReloadCoordinator.shared
     @Environment(\.colorScheme) private var colorScheme
 
     let size: CGSize
@@ -328,7 +363,7 @@ struct IconView: View {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(width: size.width, height: size.height)
-                    .id("\(iconURL.absoluteString)-\(colorScheme)")
+                    .id("\(iconURL.absoluteString)-\(colorScheme)-\(iconReloader.reloadEpoch)")
                     .onAppear {
                         recordIconStart(url: iconURL)
                     }

--- a/openHABTestsSwift/IconReloadCoordinatorTests.swift
+++ b/openHABTestsSwift/IconReloadCoordinatorTests.swift
@@ -1,0 +1,92 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+@testable import openHAB
+import Testing
+
+@MainActor
+@Suite
+struct IconReloadCoordinatorTests {
+    // Each test creates an isolated coordinator instance rather than using the shared
+    // singleton, so tests do not interfere with each other.
+
+    @Test("Active with no prior background is a no-op")
+    func activeWithNoPriorBackground() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        coord.didBecomeActive(now: .now)
+        #expect(coord.reloadEpoch == 0)
+    }
+
+    @Test("Short background does not trigger reload")
+    func shortBackgroundNoReload() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold - 1))
+        #expect(coord.reloadEpoch == 0)
+    }
+
+    @Test("Background exactly at threshold triggers reload")
+    func backgroundAtThresholdTriggersReload() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold))
+        #expect(coord.reloadEpoch == 1)
+    }
+
+    @Test("Long background triggers reload")
+    func longBackgroundTriggersReload() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold + 1))
+        #expect(coord.reloadEpoch == 1)
+    }
+
+    @Test("Short background clears timestamp so a later inactive to active cannot use the stale value")
+    func shortBackgroundClearsTimestampPreventsStaleReload() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        // Returns active quickly — below threshold, must not reload, but must clear the timestamp.
+        coord.didBecomeActive(now: t1.addingTimeInterval(30))
+        #expect(coord.reloadEpoch == 0)
+        // Inactive→active without a new background event: stale timestamp must not trigger reload.
+        coord.didBecomeActive(now: t1.addingTimeInterval(90))
+        #expect(coord.reloadEpoch == 0)
+    }
+
+    @Test("After a reload, subsequent active without new background is a no-op")
+    func afterReloadNoSpuriousSecondReload() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold + 1))
+        #expect(coord.reloadEpoch == 1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold + 10))
+        #expect(coord.reloadEpoch == 1)
+    }
+
+    @Test("Each long background increments epoch independently")
+    func multipleLongBackgroundsEachIncrementEpoch() {
+        let coord = IconReloadCoordinator(observeNotifications: false)
+        let t1 = Date.now
+        coord.didEnterBackground(now: t1)
+        coord.didBecomeActive(now: t1.addingTimeInterval(IconReloadCoordinator.reloadThreshold + 1))
+        #expect(coord.reloadEpoch == 1)
+        let t2 = t1.addingTimeInterval(200)
+        coord.didEnterBackground(now: t2)
+        coord.didBecomeActive(now: t2.addingTimeInterval(IconReloadCoordinator.reloadThreshold + 1))
+        #expect(coord.reloadEpoch == 2)
+    }
+}


### PR DESCRIPTION
## Summary

After a long background period, iOS evicts Kingfisher's in-memory image cache under memory pressure. Because icon identity is URL-based (`.id("\(iconURL)-\(colorScheme)")`), SwiftUI keeps the same `KFImage` instance alive — which internally holds a `@StateObject ImageBinder` that is now in "done" state but may be backed by a purgeable `CGImage` that iOS has zeroed out. `KFImage` never detects this and never re-fetches, so icons remain blank until a server state update happens to produce a new URL.

Adds `IconReloadCoordinator`, a `@MainActor` singleton that:
- Records the timestamp when the app enters the background
- On `didBecomeActiveNotification`, if ≥ 60 s have elapsed, increments `reloadEpoch`

Both `IconInputView` and `IconView` observe it and include `reloadEpoch` in the `KFImage` `.id()`. When the epoch changes, SwiftUI recreates those views and Kingfisher serves the icons from disk cache (~50 ms) — no network round-trip needed.

Closes #1184

## Test plan

- [ ] Wake app after 60+ seconds in background — verify icons load without blanks
- [ ] Wake app after < 60 seconds in background — verify no unnecessary icon reload
- [ ] Toggle dark/light mode — verify icons reload with correct colours (existing behaviour)
- [ ] Navigate into a subpage and back — verify icons remain stable