### PR TITLE
Fix MainUI default path storing proxy-prefixed URL when using cloud connection

### DIFF
--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -482,8 +482,10 @@ extension OpenHABWebViewController: WKScriptMessageHandler {
         Logger.viewController.info("WKScriptMessage \(message.name)")
         if message.name == "pathChanged", let newPath = message.body as? String {
             Logger.viewController.debug("Path changed to: \(newPath)")
+            let proxyURL = activeConnectionInfo?.proxyURL
+            let rootURLString = openHABTrackedRootUrl
             Task { @MainActor in
-                Preferences.shared.currentWebViewPath = newPath
+                Preferences.shared.currentWebViewPath = relativeWebViewPath(newPath, proxyURL: proxyURL, rootURLString: rootURLString)
             }
         }
         if message.name == "mainUi", let callbackName = message.body as? String {
@@ -660,13 +662,11 @@ extension OpenHABWebViewController: WKNavigationDelegate {
         acceptsCommands = true
         // watch for URL changes so we can store the last visited path
         if let webviewURL = webView.url {
-            let url = URL(string: webviewURL.path, relativeTo: URL(string: openHABTrackedRootUrl))
-            if let path = url?.path {
-                let string = openHABTrackedRootUrl
-                Logger.viewController.info("navigation change base: \(string) path: \(path)")
-                Task { @MainActor in
-                    Preferences.shared.currentWebViewPath = path.hasSuffix("/") ? path : path + "/"
-                }
+            let relative = relativeWebViewPath(webviewURL.path, proxyURL: activeConnectionInfo?.proxyURL, rootURLString: openHABTrackedRootUrl)
+            let trackedRootUrl = openHABTrackedRootUrl
+            Logger.viewController.info("navigation change base: \(trackedRootUrl, privacy: .public) path: \(relative, privacy: .public)")
+            Task { @MainActor in
+                Preferences.shared.currentWebViewPath = relative.hasSuffix("/") ? relative : relative + "/"
             }
         }
     }

--- a/openHAB/UI/Util/URL+WebViewPath.swift
+++ b/openHAB/UI/Util/URL+WebViewPath.swift
@@ -17,7 +17,8 @@ extension URL {
     /// always relative to the MainUI root rather than carrying a proxy-specific prefix.
     func relativeWebViewPath(for absolutePath: String) -> String {
         let basePath = path
-        guard !basePath.isEmpty, basePath != "/", absolutePath.hasPrefix(basePath) else {
+        guard !basePath.isEmpty, basePath != "/",
+              absolutePath == basePath || absolutePath.hasPrefix(basePath + "/") else {
             return absolutePath
         }
         let relative = String(absolutePath.dropFirst(basePath.count))

--- a/openHAB/UI/Util/URL+WebViewPath.swift
+++ b/openHAB/UI/Util/URL+WebViewPath.swift
@@ -1,0 +1,35 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+
+extension URL {
+    /// Returns `absolutePath` with this URL's path prefix stripped.
+    /// Use when `self` is a proxy or root URL so that stored paths are
+    /// always relative to the MainUI root rather than carrying a proxy-specific prefix.
+    func relativeWebViewPath(for absolutePath: String) -> String {
+        let basePath = path
+        guard !basePath.isEmpty, basePath != "/", absolutePath.hasPrefix(basePath) else {
+            return absolutePath
+        }
+        let relative = String(absolutePath.dropFirst(basePath.count))
+        return relative.isEmpty ? "/" : (relative.hasPrefix("/") ? relative : "/" + relative)
+    }
+}
+
+/// Returns `absolutePath` relative to the active base URL.
+/// Prefers the proxy URL path when present; falls back to `rootURLString`.
+func relativeWebViewPath(_ absolutePath: String, proxyURL: URL?, rootURLString: String) -> String {
+    if let proxyURL, !proxyURL.path.isEmpty, proxyURL.path != "/" {
+        return proxyURL.relativeWebViewPath(for: absolutePath)
+    }
+    return URL(string: rootURLString)?.relativeWebViewPath(for: absolutePath) ?? absolutePath
+}

--- a/openHABTestsSwift/URLWebViewPathTests.swift
+++ b/openHABTestsSwift/URLWebViewPathTests.swift
@@ -1,0 +1,91 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import Foundation
+@testable import openHAB
+import Testing
+
+@Suite("URL.relativeWebViewPath")
+struct URLWebViewPathTests {
+    // MARK: - Exact match
+
+    @Test func exactBasePath() {
+        let url = URL(string: "https://host/openhab")!
+        #expect(url.relativeWebViewPath(for: "/openhab") == "/")
+    }
+
+    // MARK: - Normal sub-path stripping
+
+    @Test func stripsBasePath() {
+        let url = URL(string: "https://host/openhab")!
+        #expect(url.relativeWebViewPath(for: "/openhab/ui") == "/ui")
+    }
+
+    @Test func stripsBasePathWithTrailingSlash() {
+        let url = URL(string: "https://host/openhab")!
+        #expect(url.relativeWebViewPath(for: "/openhab/ui/") == "/ui/")
+    }
+
+    // MARK: - Sibling-path false-match guard (the bug this fixes)
+
+    @Test func doesNotMatchSiblingWithSamePrefix() {
+        let url = URL(string: "https://host/openhab")!
+        // /openhab2/ui must NOT be treated as a sub-path of /openhab
+        #expect(url.relativeWebViewPath(for: "/openhab2/ui") == "/openhab2/ui")
+    }
+
+    @Test func doesNotMatchSiblingExactPrefix() {
+        let url = URL(string: "https://host/openhab")!
+        #expect(url.relativeWebViewPath(for: "/openhab2") == "/openhab2")
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyBasePath() {
+        let url = URL(string: "https://host")!
+        #expect(url.relativeWebViewPath(for: "/ui") == "/ui")
+    }
+
+    @Test func rootBasePath() {
+        let url = URL(string: "https://host/")!
+        #expect(url.relativeWebViewPath(for: "/ui") == "/ui")
+    }
+
+    @Test func unrelatedPath() {
+        let url = URL(string: "https://host/openhab")!
+        #expect(url.relativeWebViewPath(for: "/other/path") == "/other/path")
+    }
+}
+
+@Suite("relativeWebViewPath(proxyURL:rootURLString:)")
+struct RelativeWebViewPathFunctionTests {
+    @Test func prefersProxyURLWhenPresent() {
+        let proxy = URL(string: "https://host/proxy")!
+        let result = relativeWebViewPath("/proxy/ui", proxyURL: proxy, rootURLString: "https://host")
+        #expect(result == "/ui")
+    }
+
+    @Test func proxyDoesNotMatchSiblingPath() {
+        let proxy = URL(string: "https://host/proxy")!
+        let result = relativeWebViewPath("/proxy2/ui", proxyURL: proxy, rootURLString: "https://host")
+        #expect(result == "/proxy2/ui")
+    }
+
+    @Test func fallsBackToRootURLWhenNoProxy() {
+        let result = relativeWebViewPath("/openhab/ui", proxyURL: nil, rootURLString: "https://host/openhab")
+        #expect(result == "/ui")
+    }
+
+    @Test func rootURLDoesNotMatchSiblingPath() {
+        let result = relativeWebViewPath("/openhab2/ui", proxyURL: nil, rootURLString: "https://host/openhab")
+        #expect(result == "/openhab2/ui")
+    }
+}


### PR DESCRIPTION
## Summary

- When connected via a cloud proxy URL with a sub-path (e.g. myopenhab.org), `window.location.pathname` includes the proxy prefix
- Storing this directly as `defaultMainUIPath` caused a doubled path on next load, producing a wrong URL for MainUI
- Strip the proxy (or root) URL path prefix before storing `currentWebViewPath` so the saved path is always relative to the MainUI root
- Extracted the stripping logic into `URL+WebViewPath.swift` as a reusable URL extension and free function

## Test plan

- [ ] Connect via cloud (myopenhab.org) and navigate to a non-root MainUI page
- [ ] Background and relaunch the app — MainUI should open at the correct page, not a doubled path
- [ ] Connect via local URL and verify MainUI navigation is unaffected