### PR TITLE
Fix notification action category collisions

### DIFF
--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -49,13 +49,13 @@ actor NotificationServiceHandler {
     var cancellables = Set<AnyCancellable>()
     var networkTracker: NetworkTracker?
     var cloudUserId: String?
+    private var notificationCategoryRegistrationTask: Task<Void, Never>?
 
-    func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+    func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) async {
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
         guard let bestAttemptContent else { return }
 
-        var notificationActions: [UNNotificationAction] = []
         let userInfo = bestAttemptContent.userInfo
 
         Logger.notificationService.info("didReceive userInfo \(userInfo)")
@@ -71,37 +71,10 @@ actor NotificationServiceHandler {
 
         // Check if the user has defined custom actions in the payload
         if let actionsArray = parseActions(userInfo), let category = parseCategory(userInfo) {
-            for actionDict in actionsArray {
-                if let action = actionDict["action"],
-                   let title = actionDict["title"] {
-                    var options: UNNotificationActionOptions = []
-                    // navigate/browser options need to bring the app to the foreground
-                    if action.hasPrefix("ui") || action.hasPrefix("http") || action.hasPrefix("app") {
-                        options = [.foreground]
-                    }
-                    let notificationAction = UNNotificationAction(
-                        identifier: action,
-                        title: title,
-                        options: options
-                    )
-                    notificationActions.append(notificationAction)
-                }
-            }
-            if !notificationActions.isEmpty {
-                Logger.notificationService.info("didReceive registering \(notificationActions) for category \(category)")
-                let notificationCategory =
-                    UNNotificationCategory(
-                        identifier: category,
-                        actions: notificationActions,
-                        intentIdentifiers: [],
-                        options: .customDismissAction
-                    )
-                UNUserNotificationCenter.current().getNotificationCategories { existingCategories in
-                    var updatedCategories = Set(existingCategories.filter { $0.identifier != category })
-                    Logger.notificationService.info("handleNotification adding category \(category)")
-                    updatedCategories.insert(notificationCategory)
-                    UNUserNotificationCenter.current().setNotificationCategories(updatedCategories)
-                }
+            if let notificationCategory = makeNotificationCategory(baseCategory: category, actionsArray: actionsArray) {
+                Logger.notificationService.info("didReceive registering \(notificationCategory.actions) for category \(notificationCategory.identifier)")
+                await registerNotificationCategory(notificationCategory, baseCategory: category)
+                bestAttemptContent.categoryIdentifier = notificationCategory.identifier
             }
         }
 
@@ -253,6 +226,92 @@ actor NotificationServiceHandler {
             Logger.notificationService.error("Failed to create UNNotificationAttachment: \(error.localizedDescription)")
         }
         return nil
+    }
+
+    private func notificationActions(from actionsArray: [[String: String]]) -> [UNNotificationAction] {
+        actionsArray.compactMap { actionDict in
+            guard let action = actionDict["action"],
+                  let title = actionDict["title"] else {
+                return nil
+            }
+            var options: UNNotificationActionOptions = []
+            // navigate/browser options need to bring the app to the foreground
+            if action.hasPrefix("ui") || action.hasPrefix("http") || action.hasPrefix("app") {
+                options = [.foreground]
+            }
+            return UNNotificationAction(
+                identifier: action,
+                title: title,
+                options: options
+            )
+        }
+    }
+
+    private func makeNotificationCategory(baseCategory: String, actionsArray: [[String: String]]) -> UNNotificationCategory? {
+        let actions = notificationActions(from: actionsArray)
+        guard !actions.isEmpty else { return nil }
+
+        let categoryIdentifier = notificationCategoryIdentifier(baseCategory: baseCategory, actionsArray: actionsArray)
+        return UNNotificationCategory(
+            identifier: categoryIdentifier,
+            actions: actions,
+            intentIdentifiers: [],
+            options: .customDismissAction
+        )
+    }
+
+    private func notificationCategoryIdentifier(baseCategory: String, actionsArray: [[String: String]]) -> String {
+        "\(baseCategory).\(notificationActionsHash(actionsArray))"
+    }
+
+    private func notificationActionsHash(_ actionsArray: [[String: String]]) -> String {
+        // FNV-1a keeps category identifiers short; collisions are possible but negligible for local notification action sets.
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for actionDict in actionsArray {
+            combine(actionDict["action"].orEmpty, into: &hash)
+            combine(actionDict["title"].orEmpty, into: &hash)
+        }
+        return String(hash, radix: 16)
+    }
+
+    private func combine(_ value: String, into hash: inout UInt64) {
+        for byte in "\(value.utf8.count):\(value)|".utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+    }
+
+    private func registerNotificationCategory(_ notificationCategory: UNNotificationCategory, baseCategory: String) async {
+        let previousTask = notificationCategoryRegistrationTask
+        let registrationTask = Task {
+            await previousTask?.value
+            await setNotificationCategory(notificationCategory, baseCategory: baseCategory)
+        }
+        notificationCategoryRegistrationTask = registrationTask
+        await registrationTask.value
+    }
+
+    private func setNotificationCategory(_ notificationCategory: UNNotificationCategory, baseCategory: String) async {
+        await withCheckedContinuation { continuation in
+            let notificationCenter = UNUserNotificationCenter.current()
+            notificationCenter.getDeliveredNotifications { deliveredNotifications in
+                let categoryPrefix = "\(baseCategory)."
+                let deliveredCategoryIdentifiers = Set(deliveredNotifications.map(\.request.content.categoryIdentifier))
+                notificationCenter.getNotificationCategories { existingCategories in
+                    let updatedCategories = existingCategories.filter { category in
+                        guard category.identifier != notificationCategory.identifier else { return false }
+                        guard category.identifier != baseCategory else { return false }
+                        guard category.identifier.hasPrefix(categoryPrefix) else { return true }
+                        return deliveredCategoryIdentifiers.contains(category.identifier)
+                    }
+                    var categories = Set(updatedCategories)
+                    Logger.notificationService.info("handleNotification adding category \(notificationCategory.identifier)")
+                    categories.insert(notificationCategory)
+                    notificationCenter.setNotificationCategories(categories)
+                    continuation.resume()
+                }
+            }
+        }
     }
 
     func networkTracker() async -> NetworkTracker {

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -29,7 +29,7 @@ final class IconReloadCoordinator: ObservableObject {
     static let shared = IconReloadCoordinator()
     static let reloadThreshold: TimeInterval = 60
 
-    @Published private(set) var reloadEpoch: Int = 0
+    @Published private(set) var reloadEpoch = 0
 
     private var backgroundedAt: Date?
 

--- a/openHABTestsSwift/URLWebViewPathTests.swift
+++ b/openHABTestsSwift/URLWebViewPathTests.swift
@@ -13,6 +13,31 @@ import Foundation
 @testable import openHAB
 import Testing
 
+@Suite("relativeWebViewPath(proxyURL:rootURLString:)")
+struct RelativeWebViewPathFunctionTests {
+    @Test func prefersProxyURLWhenPresent() {
+        let proxy = URL(string: "https://host/proxy")!
+        let result = relativeWebViewPath("/proxy/ui", proxyURL: proxy, rootURLString: "https://host")
+        #expect(result == "/ui")
+    }
+
+    @Test func proxyDoesNotMatchSiblingPath() {
+        let proxy = URL(string: "https://host/proxy")!
+        let result = relativeWebViewPath("/proxy2/ui", proxyURL: proxy, rootURLString: "https://host")
+        #expect(result == "/proxy2/ui")
+    }
+
+    @Test func fallsBackToRootURLWhenNoProxy() {
+        let result = relativeWebViewPath("/openhab/ui", proxyURL: nil, rootURLString: "https://host/openhab")
+        #expect(result == "/ui")
+    }
+
+    @Test func rootURLDoesNotMatchSiblingPath() {
+        let result = relativeWebViewPath("/openhab2/ui", proxyURL: nil, rootURLString: "https://host/openhab")
+        #expect(result == "/openhab2/ui")
+    }
+}
+
 @Suite("URL.relativeWebViewPath")
 struct URLWebViewPathTests {
     // MARK: - Exact match
@@ -62,30 +87,5 @@ struct URLWebViewPathTests {
     @Test func unrelatedPath() {
         let url = URL(string: "https://host/openhab")!
         #expect(url.relativeWebViewPath(for: "/other/path") == "/other/path")
-    }
-}
-
-@Suite("relativeWebViewPath(proxyURL:rootURLString:)")
-struct RelativeWebViewPathFunctionTests {
-    @Test func prefersProxyURLWhenPresent() {
-        let proxy = URL(string: "https://host/proxy")!
-        let result = relativeWebViewPath("/proxy/ui", proxyURL: proxy, rootURLString: "https://host")
-        #expect(result == "/ui")
-    }
-
-    @Test func proxyDoesNotMatchSiblingPath() {
-        let proxy = URL(string: "https://host/proxy")!
-        let result = relativeWebViewPath("/proxy2/ui", proxyURL: proxy, rootURLString: "https://host")
-        #expect(result == "/proxy2/ui")
-    }
-
-    @Test func fallsBackToRootURLWhenNoProxy() {
-        let result = relativeWebViewPath("/openhab/ui", proxyURL: nil, rootURLString: "https://host/openhab")
-        #expect(result == "/ui")
-    }
-
-    @Test func rootURLDoesNotMatchSiblingPath() {
-        let result = relativeWebViewPath("/openhab2/ui", proxyURL: nil, rootURLString: "https://host/openhab")
-        #expect(result == "/openhab2/ui")
     }
 }


### PR DESCRIPTION
## Summary

- Long-pressing a notification showed wrong or missing action buttons when multiple notifications were delivered simultaneously
- Root cause: all notifications with the same base category shared one registered `UNNotificationCategory`, so the last to register would overwrite the others
- Fix: append a FNV-1a hash of the action set to the category identifier (e.g. `ring` → `ring.cbf29ce484222325`), giving each distinct action set its own stable identifier and updating `categoryIdentifier` on the notification content before delivery
- Stale hashed categories are garbage-collected on each registration by cross-referencing currently delivered notifications; bare base-category identifiers from before this fix are also cleaned up on first run

Reported on TestFlight 3.2.43 (251):
> I cleared all other pending notifications and kept just the night mode one and the long press gave the correct options. So maybe when there's multiple notifications the long press gets confused?

## Test plan

- [ ] Send two notifications with the same category but different action sets; verify both show their own correct actions on long-press
- [ ] Send a single notification with actions; verify long-press actions are correct
- [ ] Verify notifications without custom actions are unaffected
- [ ] Confirm stale categories are cleaned up after dismissing old notifications