### PR TITLE
Fix image attachments not shown in foreground notifications

### DIFF
--- a/openHAB/NotificationCenterDelegateImpl.swift
+++ b/openHAB/NotificationCenterDelegateImpl.swift
@@ -60,12 +60,18 @@ final class NotificationCenterDelegateImpl: NSObject, UNUserNotificationCenterDe
             userInfo: userInfo
         )
 
+        // Use the system banner when there are media attachments so the image is visible.
+        // The didReceive handler will process any on-click action when the user taps.
+        if !notification.request.content.attachments.isEmpty {
+            return [.banner, .sound]
+        }
+
         let message = userInfo["message"] as? String ?? String(localized: "message_not_decoded", comment: "")
         let action = userInfo["actionIdentifier"] as? String ?? userInfo["on-click"] as? String
         let cloudUserId = userInfo["userId"] as? String
         await displayNotification(message: message, action: action, cloudUserId: cloudUserId)
 
-        return [] // Modify this if you want to show banners, alerts, etc.
+        return []
     }
 
     // this is called when clicking a notification while in the background


### PR DESCRIPTION
## Summary

- When a notification with a media attachment arrived while the app was open, the `willPresent` handler returned `[]` and showed a custom SwiftMessages banner — which only renders text, silently dropping the image
- The `NotificationService` extension had already downloaded and attached the image to the notification content before `willPresent` was called, but it was never surfaced
- Fix: return `[.banner, .sound]` when `notification.request.content.attachments` is non-empty, letting iOS display the native banner with the image; text-only notifications continue to use the existing SwiftMessages banner
- Tapping the system banner routes through `didReceive`, which already handles `on-click` actions correctly

Fixes #1191

## Test plan

- [ ] Send a notification with an image attachment (`item:` URL or direct URL) while the app is in the foreground — image should appear in the banner
- [ ] Send a text-only notification while the app is in the foreground — custom SwiftMessages banner still appears
- [ ] Tap the image notification banner — on-click action is handled correctly
- [ ] Send a notification with an image attachment while the app is in the background — image still appears (existing behaviour, unaffected)