### PR TITLE
Fix crash on first Preferences access in extension processes

### DIFF
--- a/AppIntents/Home.swift
+++ b/AppIntents/Home.swift
@@ -88,7 +88,9 @@ enum HomeResolver {
     static func resolveHomeId(selectedHome: Home?,
                               itemName: String,
                               allowedTypes: [OpenHABItem.ItemType]? = nil) async throws -> UUID {
-        try await resolveHomeId(
+        await Preferences.prepareForAppExtensionAccess()
+
+        return try await resolveHomeId(
             selectedHome: selectedHome,
             itemName: itemName,
             findHomeId: { identifier in

--- a/AppIntents/Intents/ContactStateIntent.swift
+++ b/AppIntents/Intents/ContactStateIntent.swift
@@ -54,6 +54,8 @@ struct ContactStateIntent: AppIntent {
     var state: ContactState
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/GetItemStateIntent.swift
+++ b/AppIntents/Intents/GetItemStateIntent.swift
@@ -46,6 +46,8 @@ struct GetItemStateIntent: AppIntent {
     var itemEntity: GenericItemEntity
 
     func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/SetColorValueIntent.swift
+++ b/AppIntents/Intents/SetColorValueIntent.swift
@@ -56,6 +56,8 @@ struct SetColorValueIntent: AppIntent {
     var value: String
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/SetDateTimeValueIntent.swift
+++ b/AppIntents/Intents/SetDateTimeValueIntent.swift
@@ -53,6 +53,8 @@ struct SetDateTimeValueIntent: AppIntent {
     var value: Date
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,
             itemHomeId: itemEntity.homeId,

--- a/AppIntents/Intents/SetDimmerRollerValueIntent.swift
+++ b/AppIntents/Intents/SetDimmerRollerValueIntent.swift
@@ -56,6 +56,8 @@ struct SetDimmerRollerValueIntent: AppIntent {
     var value: Int
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/SetLocationValueIntent.swift
+++ b/AppIntents/Intents/SetLocationValueIntent.swift
@@ -62,6 +62,8 @@ struct SetLocationValueIntent: AppIntent {
     var longitude: Double
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,
             itemHomeId: itemEntity.homeId,

--- a/AppIntents/Intents/SetNumberValueIntent.swift
+++ b/AppIntents/Intents/SetNumberValueIntent.swift
@@ -53,6 +53,8 @@ struct SetNumberValueIntent: AppIntent {
     var value: Double
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/SetPlayerValueIntent.swift
+++ b/AppIntents/Intents/SetPlayerValueIntent.swift
@@ -54,6 +54,8 @@ struct SetPlayerValueIntent: AppIntent {
     var action: PlayerAction
 
     func perform() async throws -> some IntentResult {
+        await Preferences.prepareForAppExtensionAccess()
+
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,
             itemHomeId: itemEntity.homeId,

--- a/AppIntents/Intents/SetStringValueIntent.swift
+++ b/AppIntents/Intents/SetStringValueIntent.swift
@@ -53,6 +53,8 @@ struct SetStringValueIntent: AppIntent {
     var value: String
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/Intents/SetSwitchItemIntent.swift
+++ b/AppIntents/Intents/SetSwitchItemIntent.swift
@@ -54,6 +54,8 @@ struct SetSwitchItemIntent: AppIntent {
     var action: SwitchAction
 
     func perform() async throws -> some IntentResult {
+        await Preferences.prepareForAppExtensionAccess()
+
         // Validate that the item belongs to the selected home
         let homeId = try await HomeResolver.resolvedHomeId(
             selectedHome: home,

--- a/AppIntents/ItemEntityQuery.swift
+++ b/AppIntents/ItemEntityQuery.swift
@@ -80,6 +80,8 @@ extension ItemEntityQuery {
     }
 
     func entities(for identifiers: [ItemIdentifier]) async throws -> [EntityType] {
+        await Preferences.prepareForAppExtensionAccess()
+
         var result: [EntityType] = []
 
         for identifier in identifiers {
@@ -96,6 +98,8 @@ extension ItemEntityQuery {
     }
 
     func suggestedEntities() async throws -> [EntityType] {
+        await Preferences.prepareForAppExtensionAccess()
+
         // If the user selected a Home in the intent UI, scope results to that home.
         if let selectedHomeId = await resolvedSelectedHomeId() {
             await OpenHABItemCache.instance.reloadCacheIfNeeded(homes: [selectedHomeId])
@@ -117,6 +121,8 @@ extension ItemEntityQuery {
     }
 
     func entities(matching string: String) async throws -> [EntityType] {
+        await Preferences.prepareForAppExtensionAccess()
+
         let selectedHomeId = await resolvedSelectedHomeId()
         let searchResults: [UUID: [OpenHABItem]]
         if let selectedHomeId {

--- a/AppIntents/iOS16/GetItemState.swift
+++ b/AppIntents/iOS16/GetItemState.swift
@@ -28,6 +28,7 @@ enum GetItemStateError: Error, CustomLocalizedStringResourceConvertible {
 struct GetItemState: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct StringOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             return allItems.flatMap { $0.value.map(\.name) }
         }

--- a/AppIntents/iOS16/SetColorValue.swift
+++ b/AppIntents/iOS16/SetColorValue.swift
@@ -34,6 +34,7 @@ enum SetColorValueError: Error, CustomLocalizedStringResourceConvertible {
 struct SetColorValue: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct StringOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .color }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetContactStateValue.swift
+++ b/AppIntents/iOS16/SetContactStateValue.swift
@@ -34,6 +34,7 @@ enum SetContactStateValueError: Error, CustomLocalizedStringResourceConvertible 
 struct SetContactStateValue: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct ItemOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .contact }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetDateTimeValue.swift
+++ b/AppIntents/iOS16/SetDateTimeValue.swift
@@ -31,6 +31,7 @@ enum SetDateTimeValueError: Error, CustomLocalizedStringResourceConvertible {
 struct SetDateTimeValue: AppIntent, PredictableIntent {
     struct DateTimeOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .dateTime }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetDimmerRollerValue.swift
+++ b/AppIntents/iOS16/SetDimmerRollerValue.swift
@@ -34,6 +34,7 @@ enum SetDimmerRollerValueError: Error, CustomLocalizedStringResourceConvertible 
 struct SetDimmerRollerValue: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct StringOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .dimmer || $0.type == .rollershutter }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetLocationValue.swift
+++ b/AppIntents/iOS16/SetLocationValue.swift
@@ -37,6 +37,7 @@ enum SetLocationValueError: Error, CustomLocalizedStringResourceConvertible {
 struct SetLocationValue: AppIntent, PredictableIntent {
     struct LocationOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .location }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetNumberValue.swift
+++ b/AppIntents/iOS16/SetNumberValue.swift
@@ -31,6 +31,7 @@ enum SetNumberValueError: Error, CustomLocalizedStringResourceConvertible {
 struct SetNumberValue: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct StringOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .number }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetPlayerValue.swift
+++ b/AppIntents/iOS16/SetPlayerValue.swift
@@ -43,6 +43,7 @@ struct SetPlayerValue: AppIntent, PredictableIntent {
 
     struct ItemOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .player }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetStringValue.swift
+++ b/AppIntents/iOS16/SetStringValue.swift
@@ -31,6 +31,7 @@ enum SetStringValueError: Error, CustomLocalizedStringResourceConvertible {
 struct SetStringValue: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     struct StringOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .stringItem }
             return items.map(\.name)

--- a/AppIntents/iOS16/SetSwitchState.swift
+++ b/AppIntents/iOS16/SetSwitchState.swift
@@ -47,6 +47,7 @@ struct SetSwitchState: AppIntent, CustomIntentMigratedAppIntent, PredictableInte
 
     struct ItemOptionsProvider: DynamicOptionsProvider {
         func results() async throws -> [String] {
+            await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
             let items = allItems.flatMap(\.value).filter { $0.type == .switchItem }
             return items.map(\.name)

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -318,8 +318,7 @@ actor NotificationServiceHandler {
         if let tracker = networkTracker {
             return tracker
         }
-        // Ensure Preferences initializes on the MainActor to avoid crashes
-        await MainActor.run { _ = Preferences.shared }
+        await Preferences.prepareForAppExtensionAccess()
 
         let tracker = NetworkTracker(timeout: NotificationServiceHandler.networkTimeout)
         let connections: [ConnectionConfiguration]
@@ -330,9 +329,10 @@ actor NotificationServiceHandler {
             connections = await [instance.localConnectionConfig, instance.remoteConnectionConfig]
         } else {
             Logger.notificationService.info("Using default connection configurations")
+            let currentHomePreferences = await Preferences.shared.currentHomePreferences
             connections = await [
-                Preferences.shared.currentHomePreferences.localConnectionConfig,
-                Preferences.shared.currentHomePreferences.remoteConnectionConfig
+                currentHomePreferences.localConnectionConfig,
+                currentHomePreferences.remoteConnectionConfig
             ]
         }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -160,6 +160,7 @@ public actor OpenHABItemCache {
     private init() {}
 
     public func getAllCachedItems() async -> [UUID: [OpenHABItem]] {
+        await Preferences.prepareForAppExtensionAccess()
         await reloadCacheIfNeeded(homes: Preferences.shared.listStoredHomes())
         return items
     }
@@ -272,6 +273,7 @@ public actor OpenHABItemCache {
 
     public func forceCacheReload() async {
         Logger.itemCache.info("forced cache reload for all homes")
+        await Preferences.prepareForAppExtensionAccess()
         let homes = await Preferences.shared.listStoredHomes()
         // some house keeping
         let networkTrackersToRemove = networkTrackers.filter { !homes.contains($0.key) }
@@ -334,6 +336,7 @@ public actor OpenHABItemCache {
     }
 
     private func assureNetworkTracker(homeId: UUID) async -> NetworkTracker? {
+        await Preferences.prepareForAppExtensionAccess()
         if networkTrackers[homeId] == nil, let homePreferences = await Preferences.shared.storedHomes[homeId] {
             let tracker = NetworkTracker(timeout: OpenHABItemCache.networkTimeout)
             networkTrackers[homeId] = tracker
@@ -373,6 +376,7 @@ public extension OpenHABItemCache {
     }
 
     func searchCachedOrPersistedItems(searchTerm: String, types: [OpenHABItem.ItemType]? = nil, homes: [UUID]? = nil) async -> [UUID: [OpenHABItem]] {
+        await Preferences.prepareForAppExtensionAccess()
         let targetHomes: [UUID] = if let homes {
             homes
         } else {

--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -276,6 +276,16 @@ public actor Preferences {
     }
 }
 
+// MARK: App extension access
+
+public extension Preferences {
+    static func prepareForAppExtensionAccess() async {
+        await MainActor.run {
+            _ = Preferences.shared
+        }
+    }
+}
+
 // MARK: Multiple homes
 
 @MainActor


### PR DESCRIPTION
## Summary

Fixes the crash reported in #975 where NotificationService and AppIntents extension processes crash on launch because `Preferences.shared` is first accessed from a non-MainActor cooperative thread.

**Root cause:** `Preferences.shared` is a lazily-initialised singleton whose init constructs a `@MainActor`-isolated `HomePreferences`. Accessing it for the first time from outside the main actor triggers `dispatch_assert_queue` in Swift's concurrency runtime.

**Fix:** Add `Preferences.prepareForAppExtensionAccess()` — a single static async method that forces the singleton to initialise on the MainActor before extension code touches it:

```swift
public static func prepareForAppExtensionAccess() async {
    await MainActor.run { _ = Preferences.shared }
}
```

This is called at every async entry point in extension processes:
- All iOS 16 intent `perform()` methods
- All iOS 17+ intent `perform()` methods
- All `ItemEntityQuery` protocol methods (`entities(for:)`, `suggestedEntities()`, `entities(matching:)`)
- `HomeResolver.resolveHomeId` (item-by-name overload)
- `NotificationServiceHandler.networkTracker()`
- Four `OpenHABItemCache` methods that access `Preferences.shared` directly (`getAllCachedItems`, `forceCacheReload`, `assureNetworkTracker`, `searchCachedOrPersistedItems`)

After the first call the singleton is already initialised, so subsequent calls are a fast `dispatch_once` check plus a main actor context switch.

## Test plan

- [ ] Trigger a notification with an item image attachment — verify no crash in NotificationService
- [ ] Run an AppIntent (e.g. Set Switch State) via Shortcuts or Siri — verify no crash
- [ ] Run an iOS 16 compat intent — verify no crash
- [ ] Confirm entity picker (`suggestedEntities`, `entities(matching:)`, `entities(for:)`) works correctly in the Shortcuts app