### PR TITLE
Fix white flash on MainUI in dark mode

### DIFF
--- a/openHAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "510fece68ecb3b20f88be6a202204737d9bb1b0c487b784869bdd79b26798df4",
+  "originHash" : "5d09299cca05d481ff6456cdbd90914f268a8a34e524c80fef53066ee94ce606",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "2053b120767c42a70bcba21095f34e4cfb54a75d",
-        "version" : "5.21.3"
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
       }
     },
     {
@@ -182,6 +182,42 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "f039fa6d6338aab5164f3d1be16281524c9a8f89",
+        "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession",
+      "state" : {
+        "revision" : "576a65b4ffb8c12ddad4950dc21eea2ef071bec2",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
@@ -197,6 +233,15 @@
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
+      }
+    },
+    {
+      "identity" : "swift-timeout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/swift-timeout.git",
+      "state" : {
+        "revision" : "4efb73b593d5553b90766d531db701ecf2306237",
+        "version" : "0.4.1"
       }
     },
     {
@@ -224,6 +269,15 @@
       "state" : {
         "revision" : "c0ff6c65bfc00e6a707957cb7069988c5cde2a30",
         "version" : "10.0.2"
+      }
+    },
+    {
+      "identity" : "swiftui-flow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tevelee/SwiftUI-Flow.git",
+      "state" : {
+        "revision" : "d227f999b2894ab737ef5786d9b14d02d3e5362e",
+        "version" : "3.1.1"
       }
     }
   ],

--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -200,7 +200,6 @@ struct DrawerView: View {
 
     private func menuEntry(image: Image, text: Text, goTo target: TargetController) -> some View {
         Button {
-            dismiss()
             onDismiss(target)
         } label: {
             HStack {
@@ -218,7 +217,6 @@ struct DrawerView: View {
                            goTo target: TargetController,
                            @ViewBuilder label: () -> some View) -> some View {
         Button {
-            dismiss()
             onDismiss(target)
         } label: {
             HStack {

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -156,6 +156,14 @@ class OpenHABRootViewController: UIViewController {
 
     private var networkStatusButton: UIButton = .init(type: .custom)
 
+    private let transitionCoverView: UIView = {
+        let v = UIView()
+        v.backgroundColor = .systemBackground
+        v.isHidden = true
+        v.translatesAutoresizingMaskIntoConstraints = false
+        return v
+    }()
+
     private lazy var webViewController: OpenHABWebViewController = {
         let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
         var viewController = storyboard.instantiateViewController(withIdentifier: "OpenHABWebViewController") as! OpenHABWebViewController
@@ -213,7 +221,20 @@ class OpenHABRootViewController: UIViewController {
         #endif
         // save this so we know if its changed later
         isDemoMode = Preferences.shared.currentHomePreferences.demomode
+
+        view.addSubview(transitionCoverView)
+        NSLayoutConstraint.activate([
+            transitionCoverView.topAnchor.constraint(equalTo: view.topAnchor),
+            transitionCoverView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            transitionCoverView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            transitionCoverView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
         switchToSavedView()
+        if currentView === webViewController {
+            webViewController.prepareForDisplayTransition()
+        }
+
         setupTracker()
         startSSEListening()
         observeAppForegroundForSideMenu()
@@ -519,17 +540,24 @@ class OpenHABRootViewController: UIViewController {
     private func handleDismiss(mode: TargetController) {
         switch mode {
         case .webview:
-            Logger.viewController.debug("Dismissed to WebView")
-            if currentView !== webViewController {
-                // Coming from another view: put webVC in place before the animation
-                // and reload so the loading overlay covers its blank state
+            let needsSwitch = currentView !== webViewController
+            if needsSwitch {
+                // Cover the root view so the dismiss animation doesn't expose the
+                // old child view (e.g. SitemapView) while the menu slides away.
+                // addView inserts at index 0, so transitionCoverView stays on top.
+                webViewController.prepareForDisplayTransition()
+                view.bringSubviewToFront(transitionCoverView)
+                transitionCoverView.isHidden = false
                 switchView(target: .webview)
-                webViewController.reloadView()
             }
-            // Already on webVC: show existing content during animation — no reload
-            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
+            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+                if needsSwitch, !webViewController.hasLoadedPage {
+                    webViewController.reloadView()
+                }
+                transitionCoverView.isHidden = true
+            }
         case .settings:
-            Logger.viewController.debug("Dismissed to Settings")
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {
                 self.modalDismissed(to: .settings)
             }
@@ -925,7 +953,7 @@ class OpenHABRootViewController: UIViewController {
 
     private func addView(viewController: UIViewController) {
         addChild(viewController)
-        view.insertSubview(viewController.view, belowSubview: networkStatusButton)
+        view.insertSubview(viewController.view, at: 0)
         viewController.view.frame = view.bounds
         viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         viewController.didMove(toParent: self)

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -520,11 +520,13 @@ class OpenHABRootViewController: UIViewController {
         switch mode {
         case .webview:
             Logger.viewController.debug("Dismissed to WebView")
-            let switchingFromOtherView = currentView !== webViewController
-            switchView(target: .webview)
-            if switchingFromOtherView {
+            if currentView !== webViewController {
+                // Coming from another view: put webVC in place before the animation
+                // and reload so the loading overlay covers its blank state
+                switchView(target: .webview)
                 webViewController.reloadView()
             }
+            // Already on webVC: show existing content during animation — no reload
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -520,18 +520,8 @@ class OpenHABRootViewController: UIViewController {
         switch mode {
         case .webview:
             Logger.viewController.debug("Dismissed to WebView")
-            if currentView === webViewController {
-                // Already on MainUI: let the animation play with existing content visible,
-                // then reload after — avoids blanking the view mid-animation.
-                SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {
-                    self.webViewController.reloadView()
-                }
-            } else {
-                // Coming from another view: put the webview in place before the animation
-                // so the correct content slides in.
-                switchView(target: .webview)
-                SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
-            }
+            switchView(target: .webview)
+            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -519,10 +519,10 @@ class OpenHABRootViewController: UIViewController {
     private func handleDismiss(mode: TargetController) {
         switch mode {
         case .webview:
-            // Handle webview navigation or state update
             Logger.viewController.debug("Dismissed to WebView")
-            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
-            switchView(target: .webview)
+            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {
+                self.modalDismissed(to: .webview)
+            }
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -520,7 +520,11 @@ class OpenHABRootViewController: UIViewController {
         switch mode {
         case .webview:
             Logger.viewController.debug("Dismissed to WebView")
+            let switchingFromOtherView = currentView !== webViewController
             switchView(target: .webview)
+            if switchingFromOtherView {
+                webViewController.reloadView()
+            }
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -520,8 +520,18 @@ class OpenHABRootViewController: UIViewController {
         switch mode {
         case .webview:
             Logger.viewController.debug("Dismissed to WebView")
-            switchView(target: .webview)
-            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
+            if currentView === webViewController {
+                // Already on MainUI: let the animation play with existing content visible,
+                // then reload after — avoids blanking the view mid-animation.
+                SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {
+                    self.webViewController.reloadView()
+                }
+            } else {
+                // Coming from another view: put the webview in place before the animation
+                // so the correct content slides in.
+                switchView(target: .webview)
+                SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
+            }
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -520,9 +520,8 @@ class OpenHABRootViewController: UIViewController {
         switch mode {
         case .webview:
             Logger.viewController.debug("Dismissed to WebView")
-            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {
-                self.modalDismissed(to: .webview)
-            }
+            switchView(target: .webview)
+            SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true)
         case .settings:
             Logger.viewController.debug("Dismissed to Settings")
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) {

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -35,6 +35,10 @@ class OpenHABWebViewController: OpenHABViewController {
     private var etagCheckerConfigURL: String? // Track which config the checker was created for
     private var lastLoadedURL: String? // Track the last successfully loaded URL from didFinish
 
+    var hasLoadedPage: Bool {
+        !currentTarget.isEmpty
+    }
+
     private var js = """
     (function() {
         // Main UI Callbacks
@@ -113,8 +117,18 @@ class OpenHABWebViewController: OpenHABViewController {
         setHideNavigationBar(shouldHide: hideNavigationBar, animated: animated)
         navigationController?.navigationBar.prefersLargeTitles = false
         parent?.navigationItem.title = "Main View"
+
+        // On first appearance (no page loaded yet) keep the overlay visible so the blank
+        // WKWebView is never exposed to the user before the page starts loading.
+        if currentTarget.isEmpty {
+            loadingOverlay.layer.removeAllAnimations()
+            loadingOverlay.alpha = 1
+            loadingOverlay.isHidden = false
+        }
+
         MainActorNetworkTracker.shared.$activeConnection
             .receive(on: DispatchQueue.main)
+            .removeDuplicates()
             .sink { activeConnection in
                 if let activeConnection {
                     let activeConfiguration = activeConnection.configuration
@@ -146,6 +160,14 @@ class OpenHABWebViewController: OpenHABViewController {
         trackerCancellables.removeAll()
 
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    func prepareForDisplayTransition() {
+        guard isViewLoaded, !hasLoadedPage else { return }
+        loadingOverlay.layer.removeAllAnimations()
+        loadingOverlay.alpha = 1
+        loadingOverlay.isHidden = false
+        showActivityIndicator(show: true)
     }
 
     func startTracker() {
@@ -719,6 +741,11 @@ extension OpenHABWebViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            Logger.viewController.debug("didFailProvisionalNavigation cancelled - webView.url: \(String(describing: webView.url?.description))")
+            return
+        }
         setHideNavigationBar(shouldHide: false)
         reloadView()
     }

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -365,6 +365,8 @@ class OpenHABWebViewController: OpenHABViewController {
     func clearExistingPage() {
         Logger.viewController.info("clearExistingPage")
         setHideNavigationBar(shouldHide: false)
+        loadingOverlay.layer.removeAllAnimations()
+        loadingOverlay.alpha = 1
         loadingOverlay.isHidden = false
         webView.stopLoading()
         webView.evaluateJavaScript("document.body.remove()")

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -82,11 +82,24 @@ class OpenHABWebViewController: OpenHABViewController {
     }
 
     private var webView: WKWebView = .init(frame: .zero)
+    private let loadingOverlay = UIView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         attachWebViewToLayout(webView)
+
+        loadingOverlay.backgroundColor = .systemBackground
+        loadingOverlay.isHidden = true
+        loadingOverlay.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(loadingOverlay)
+        NSLayoutConstraint.activate([
+            loadingOverlay.topAnchor.constraint(equalTo: view.topAnchor),
+            loadingOverlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            loadingOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            loadingOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
         activityIndicator = UIActivityIndicatorView()
         activityIndicator.center = view.center
         activityIndicator.hidesWhenStopped = true
@@ -352,12 +365,13 @@ class OpenHABWebViewController: OpenHABViewController {
     func clearExistingPage() {
         Logger.viewController.info("clearExistingPage")
         setHideNavigationBar(shouldHide: false)
-        // clear out existing page while we load.
+        loadingOverlay.isHidden = false
         webView.stopLoading()
         webView.evaluateJavaScript("document.body.remove()")
     }
 
     func pageLoadError(message: String) {
+        loadingOverlay.isHidden = true
         showActivityIndicator(show: true)
         showPopupMessage(seconds: 60, title: String(localized: "Error", comment: ""), message: message, theme: .error)
     }
@@ -437,6 +451,7 @@ class OpenHABWebViewController: OpenHABViewController {
         // support dark mode and avoid white flashing when loading
         webview.isOpaque = false
         webview.backgroundColor = UIColor.clear
+        webview.underPageBackgroundColor = .systemBackground
         if UIDevice.current.userInterfaceIdiom == .pad {
             // since ios 13 Safari sets the user agent to desktop mode on iPads so the view renders correctly with larger screens
             webview.customUserAgent = "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
@@ -462,7 +477,7 @@ class OpenHABWebViewController: OpenHABViewController {
 
     func attachWebViewToLayout(_ webView: WKWebView) {
         if webView.superview !== view {
-            view.addSubview(webView)
+            view.insertSubview(webView, at: 0)
         }
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -658,6 +673,12 @@ extension OpenHABWebViewController: WKNavigationDelegate {
 
         setHideNavigationBar(shouldHide: true)
         showActivityIndicator(show: false)
+        UIView.animate(withDuration: 0.2) {
+            self.loadingOverlay.alpha = 0
+        } completion: { _ in
+            self.loadingOverlay.isHidden = true
+            self.loadingOverlay.alpha = 1
+        }
         hidePopupMessages()
         acceptsCommands = true
         // watch for URL changes so we can store the last visited path

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -743,7 +743,6 @@ extension OpenHABWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
-            Logger.viewController.debug("didFailProvisionalNavigation cancelled - webView.url: \(String(describing: webView.url?.description))")
             return
         }
         setHideNavigationBar(shouldHide: false)


### PR DESCRIPTION
## Summary

Fixes #1153 and a series of related visual glitches when navigating between MainUI and sitemaps via the drawer.

### Root causes addressed

**Dark mode white flash (MainUI reconnect / forced reload)**
- `underPageBackgroundColor` defaults to white in WebKit's rendering subprocess, independent of UIKit's `backgroundColor`/`isOpaque`. Set to `.systemBackground` so the overscroll canvas adapts to dark mode.
- `clearExistingPage()` calls `document.body.remove()`, leaving the `<html>` element with its default white CSS background. Added a `systemBackground`-coloured `loadingOverlay` pinned above the webview that is shown in `clearExistingPage()` / `viewWillAppear` (when no page has loaded yet) and faded out in `didFinish`. Webviews are inserted at z-index 0 via `insertSubview(at:0)` so new instances never land above the overlay.

**Blank/white SitemapView flash when returning to MainUI via drawer**
- Added a `transitionCoverView` (`systemBackground`-coloured, full-bounds) on `rootVC.view` above all child views. When `handleDismiss(.webview)` determines a view switch is needed, it brings the cover to front, switches to the webview, then calls `dismiss(animated:)`. The cover hides whatever was below (e.g. SitemapView) during the SideMenu slide-away animation and is hidden in the dismiss completion block.

**Unnecessary page reload when MainUI already has content**
- `hasLoadedPage` (true when `currentTarget` is non-empty) gates `prepareForDisplayTransition()` and the `reloadView()` call in the dismiss completion block, so returning to an already-loaded MainUI never triggers a redundant network fetch or overlay flash.

**Double page load from Combine subscription**
- `MainActorNetworkTracker.shared.$activeConnection` could re-emit the same `ConnectionInfo` value, triggering multiple `loadWebView(force:false)` calls. Added `.removeDuplicates()` to the pipeline (`ConnectionInfo` is `Equatable`).

**Spurious full reload on cancelled navigation**
- When a new WKWebView navigation starts, the previous one fires `didFailProvisionalNavigation` with `NSURLErrorCancelled`. This was triggering a full `reloadView()`. Added an early return for this case.

## Test plan

- [ ] Enable dark mode
- [ ] Open MainUI and let it connect — no white flash
- [ ] Toggle airplane mode off/on — no white flash on reconnection
- [ ] Open drawer, tap MainUI — no white or blank flash
- [ ] Open drawer, tap a sitemap, open drawer again, tap MainUI — no white or blank flash; page not reloaded if already loaded
- [ ] Cold-start with MainUI as the saved default — loading overlay shown until page is ready, no blank state
- [ ] Repeat all steps in light mode — appearance unchanged