### PR TITLE
Fix code review issues in AppIntents migration

### DIFF
--- a/AppIntents/Home.swift
+++ b/AppIntents/Home.swift
@@ -161,13 +161,27 @@ struct Home: AppEntity {
         func entities(for identifiers: [Home.ID]) throws -> [Home] {
             let storedHomes = Preferences.shared.storedHomes
             return identifiers.compactMap { identifier in
-                let stableId = Home.stableIdentifierComponent(of: identifier)
-                // Current format: match by stable cross-device identifier
-                if let match = storedHomes.values.first(where: { $0.stableIdentifier == stableId }) {
-                    return Home(homePrefs: match)
+                // Current format: "##" is present — prefer exact match (same device, disambiguates
+                // homes that share a stableIdentifier), then fall back to stableIdentifier-only
+                // match so shortcuts synced from another device still resolve.
+                if identifier.contains("##") {
+                    let stableId = Home.stableIdentifierComponent(of: identifier)
+                    if let match = storedHomes.values.first(where: {
+                        "\($0.stableIdentifier)##\($0.id.uuidString)" == identifier
+                    }) {
+                        return Home(homePrefs: match)
+                    }
+                    if let match = storedHomes.values.first(where: { $0.stableIdentifier == stableId }) {
+                        return Home(homePrefs: match)
+                    }
+                    return nil
                 }
                 // Legacy format: identifier is a device-local UUID string (shortcuts before this fix)
-                if let uuid = UUID(uuidString: stableId), let match = storedHomes[uuid] {
+                if let uuid = UUID(uuidString: identifier), let match = storedHomes[uuid] {
+                    return Home(homePrefs: match)
+                }
+                // Legacy format: bare stableIdentifier (no "##" separator)
+                if let match = storedHomes.values.first(where: { $0.stableIdentifier == identifier }) {
                     return Home(homePrefs: match)
                 }
                 return nil
@@ -205,9 +219,10 @@ struct Home: AppEntity {
 
     @MainActor
     init(homePrefs: HomePreferences) {
-        // Append the local UUID after "##" to guarantee uniqueness when two homes share the same
-        // stableIdentifier (e.g. same local URL on two different networks). Resolution code strips
-        // the suffix before matching so cross-device Shortcuts syncing still works.
+        // Append the local UUID after "##" to disambiguate homes that share the same
+        // stableIdentifier (e.g. same local URL on two different networks). Resolution
+        // tries an exact match first, then falls back to stableIdentifier-only so
+        // shortcuts synced from another device still resolve.
         self.init(id: "\(homePrefs.stableIdentifier)##\(homePrefs.id.uuidString)", displayString: homePrefs.homeName)
     }
 

--- a/AppIntents/Intents/SetNumberValueIntent.swift
+++ b/AppIntents/Intents/SetNumberValueIntent.swift
@@ -65,7 +65,7 @@ struct SetNumberValueIntent: AppIntent {
             try await OpenHABItemCache.instance.sendCommand(
                 to: itemEntity.item,
                 home: homeId,
-                command: String(value)
+                command: NumberState(value: value).commandString
             )
         } catch {
             throw NumberValueError.commandFailed(error.localizedDescription)

--- a/AppIntents/iOS16/SetNumberValue.swift
+++ b/AppIntents/iOS16/SetNumberValue.swift
@@ -84,7 +84,7 @@ struct SetNumberValue: AppIntent, CustomIntentMigratedAppIntent, PredictableInte
         let openHABItem = items[0]
 
         do {
-            try await OpenHABItemCache.instance.sendCommand(to: openHABItem, home: homeId, command: String(value))
+            try await OpenHABItemCache.instance.sendCommand(to: openHABItem, home: homeId, command: NumberState(value: value).commandString)
         } catch {
             throw SetNumberValueError.commandFailed(error.localizedDescription)
         }

--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -580,47 +580,45 @@ public extension NetworkTracker {
         return service
     }
 
+    // Retries once on ClientError after revalidating the connection.
+    // ClientError indicates a transport failure — the request never reached the server —
+    // which can happen when the active connection is stale after a network switch or
+    // process suspension.
+    private func withClientErrorRetry<T>(_ operation: () async throws -> T) async throws -> T {
+        do {
+            return try await operation()
+        } catch is OpenAPIRuntime.ClientError {
+            await revalidateConnection()
+            return try await operation()
+        }
+    }
+
     func send(to item: OpenHABItem, command: String, sourcePrefix: String? = nil, deviceId: String? = nil) async throws {
         try await send(to: item.name, command: command, sourcePrefix: sourcePrefix, deviceId: deviceId)
     }
 
     func send(to item: String, command: String, sourcePrefix: String? = nil, deviceId: String? = nil) async throws {
-        do {
-            try await service().sendItemCommand(itemname: item, command: command, sourcePrefix: sourcePrefix, deviceId: deviceId)
-        } catch is OpenAPIRuntime.ClientError {
-            // Transport error: the command never reached the server (safe to retry).
-            // The active connection may be stale if the process was suspended during a network switch.
-            await revalidateConnection()
+        try await withClientErrorRetry {
             try await service().sendItemCommand(itemname: item, command: command, sourcePrefix: sourcePrefix, deviceId: deviceId)
         }
     }
 
     func updateState(item: OpenHABItem, state: String, sourcePrefix: String? = nil, deviceId: String? = nil) async throws {
-        do {
-            try await service().updateItemState(itemname: item.name, with: state, sourcePrefix: sourcePrefix, deviceId: deviceId)
-        } catch is OpenAPIRuntime.ClientError {
-            await revalidateConnection()
+        try await withClientErrorRetry {
             try await service().updateItemState(itemname: item.name, with: state, sourcePrefix: sourcePrefix, deviceId: deviceId)
         }
     }
 
     func getStaticItems() async throws -> [OpenHABItem] {
-        do {
-            let items = try await service().getItems(query: Operations.getItems.Input.Query(staticDataOnly: true))
-            return items.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-        } catch is OpenAPIRuntime.ClientError {
-            await revalidateConnection()
+        try await withClientErrorRetry {
             let items = try await service().getItems(query: Operations.getItems.Input.Query(staticDataOnly: true))
             return items.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         }
     }
 
     func getItemByName(id: String) async throws -> OpenHABItem? {
-        do {
-            return try await service().getItemByName(id: id)
-        } catch is OpenAPIRuntime.ClientError {
-            await revalidateConnection()
-            return try await service().getItemByName(id: id)
+        try await withClientErrorRetry {
+            try await service().getItemByName(id: id)
         }
     }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -142,7 +142,7 @@ public actor OpenHABItemCache {
     private struct ItemStub: Codable {
         let name: String
         let label: String
-        let type: String
+        let type: String?
     }
 
     public static let instance = OpenHABItemCache()
@@ -156,8 +156,19 @@ public actor OpenHABItemCache {
     public var items: [UUID: [OpenHABItem]] = [:]
     private let ttl: TimeInterval = 20
     var lastLoad: [UUID: Date] = [:]
+    private var cachedStubs: [String: [ItemStub]]?
 
     private init() {}
+
+    private func loadedStubs() -> [String: [ItemStub]] {
+        if let cached = cachedStubs { return cached }
+        guard let data = UserDefaults(suiteName: Self.sharedDefaultsSuiteName)?.data(forKey: Self.stubsDefaultsKey),
+              let decoded = try? JSONDecoder().decode([String: [ItemStub]].self, from: data) else {
+            return [:]
+        }
+        cachedStubs = decoded
+        return decoded
+    }
 
     public func getAllCachedItems() async -> [UUID: [OpenHABItem]] {
         await reloadCacheIfNeeded(homes: Preferences.shared.listStoredHomes())
@@ -215,26 +226,23 @@ public actor OpenHABItemCache {
     private func persistStubs() {
         var allStubs: [String: [ItemStub]] = [:]
         for (homeId, homeItems) in items {
-            allStubs[homeId.uuidString] = homeItems.map { ItemStub(name: $0.name, label: $0.label, type: $0.type?.rawValue ?? "") }
+            allStubs[homeId.uuidString] = homeItems.map { ItemStub(name: $0.name, label: $0.label, type: $0.type?.rawValue) }
         }
         guard let data = try? JSONEncoder().encode(allStubs) else { return }
+        cachedStubs = allStubs
         UserDefaults(suiteName: Self.sharedDefaultsSuiteName)?.set(data, forKey: Self.stubsDefaultsKey)
     }
 
     private func persistedItem(name: String, home: UUID) -> OpenHABItem? {
-        guard let data = UserDefaults(suiteName: Self.sharedDefaultsSuiteName)?.data(forKey: Self.stubsDefaultsKey),
-              let allStubs = try? JSONDecoder().decode([String: [ItemStub]].self, from: data),
-              let stub = allStubs[home.uuidString]?.first(where: { $0.name == name }) else { return nil }
-        return OpenHABItem(name: stub.name, type: stub.type, state: nil, link: "", label: stub.label, groupType: nil, stateDescription: nil, commandDescription: nil, members: [], category: nil, options: nil)
+        guard let stub = loadedStubs()[home.uuidString]?.first(where: { $0.name == name }) else { return nil }
+        return OpenHABItem(name: stub.name, type: stub.type ?? "", state: nil, link: "", label: stub.label, groupType: nil, stateDescription: nil, commandDescription: nil, members: [], category: nil, options: nil)
     }
 
     private func persistedItems(home: UUID) -> [OpenHABItem] {
-        guard let data = UserDefaults(suiteName: Self.sharedDefaultsSuiteName)?.data(forKey: Self.stubsDefaultsKey),
-              let allStubs = try? JSONDecoder().decode([String: [ItemStub]].self, from: data) else { return [] }
-        return (allStubs[home.uuidString] ?? []).map {
+        (loadedStubs()[home.uuidString] ?? []).map {
             OpenHABItem(
                 name: $0.name,
-                type: $0.type,
+                type: $0.type ?? "",
                 state: nil,
                 link: "",
                 label: $0.label,
@@ -289,7 +297,6 @@ public actor OpenHABItemCache {
         itemsList
             .filtered(by: searchTerm, for: types)
             .map(\.name)
-            .sorted()
     }
 
     private func loadNonGroupItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
@@ -395,7 +402,6 @@ public extension OpenHABItemCache {
         await reloadCacheIfNeeded(homes: [home])
         return items[home]?
             .filtered(by: searchTerm, for: types)
-            .sorted(by: \.name)
             .map(\.name) ?? []
     }
 

--- a/openHABWatch/External/AppMessageService.swift
+++ b/openHABWatch/External/AppMessageService.swift
@@ -50,13 +50,15 @@ class AppMessageService: NSObject, WCSessionDelegate {
 
     private func isExpectedApplicationContextRequestFailure(_ error: any Error) -> Bool {
         let nsError = error as NSError
-        guard nsError.domain == WCErrorDomain else { return false }
+        guard nsError.domain == WCErrorDomain,
+              let code = WCError.Code(rawValue: nsError.code) else { return false }
 
-        let normalizedDescription = nsError.localizedDescription.lowercased()
-        return normalizedDescription.contains("counterpart app not installed")
-            || normalizedDescription.contains("companion app not installed")
-            || normalizedDescription.contains("watch app not installed")
-            || normalizedDescription.contains("not paired")
+        switch code {
+        case .deviceNotPaired, .companionAppNotInstalled, .notReachable:
+            return true
+        default:
+            return false
+        }
     }
 
     func requestApplicationContext() {


### PR DESCRIPTION
## Summary

- **AppMessageService**: replace locale-dependent `localizedDescription` string matching with `WCError.Code` enum values (`.deviceNotPaired`, `.companionAppNotInstalled`, `.notReachable`) so non-English iOS users no longer see spurious error logs
- **OpenHABItemCache**: make `ItemStub.type` optional so `nil` persists as JSON `null` rather than `""`; add `cachedStubs` in-memory cache to avoid repeated UserDefaults reads and JSON decodes on every cache miss; remove redundant name re-sort from `getItemNames`/`matchingItemNames` that was discarding ranked search order
- **NetworkTracker**: extract `withClientErrorRetry` helper to deduplicate the retry-on-`ClientError`/`revalidateConnection` pattern across `send`, `updateState`, `getStaticItems`, and `getItemByName`
- **Home.entities(for:)**: try exact `stableIdentifier##UUID` match before falling back to `stableIdentifier`-only, so two homes sharing a `stableIdentifier` are correctly disambiguated on the same device while cross-device Shortcuts sync still works
- **SetNumberValueIntent / SetNumberValue**: use `NumberState(value:).commandString` instead of `String(Double)` to avoid scientific notation (`1e+06`) and ensure a consistently parseable, locale-independent number is sent to the server

## Test plan

- [ ] Verify Shortcuts targeting a home with a non-unique stableIdentifier resolve to the correct home
- [ ] Verify Watch app does not log errors when iPhone companion app is not installed or device is not paired
- [ ] Send a large number (e.g. 1000000) and a fractional number (e.g. 30.3) via a Number intent and confirm the server receives `"1000000"` and `"30.3"` respectively
- [ ] Confirm item stub round-trip for items with nil type does not crash on restore