### PR TITLE
Fix Input widget sending wrong value when state description changes unit

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/TextInputRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/TextInputRowView.swift
@@ -282,7 +282,11 @@ private struct TextInputRowContent: View {
                 : inputCommandFormatter.numericDraftFromState(inputText)
             draftInputText = numericDraft
             lastValidDraft = numericDraft
-            draftUnitSuffix = ""
+            if numberState.value.isFinite, let unit = numberState.unit, !unit.isEmpty {
+                draftUnitSuffix = " \(unit)"
+            } else {
+                draftUnitSuffix = ""
+            }
         } else {
             draftInputText = inputText
             lastValidDraft = inputText


### PR DESCRIPTION
Fixes the issue raised in #1198 (review by @mherwege).

## Problem

When a `Number:Dimension` item has a state description that converts the item unit (e.g. `W → kW`), the server sends the effective state in the display unit — e.g. `"1.5 kW"`. The previous code always sent a bare number command (`"1.5"`), causing the server to apply the item's base unit and write `1.5 W` instead of `1.5 kW`.

## Fix

In `TextInputRowView.prepareEditDraft()`, extract the unit from the parsed effective state (`numberState.unit`) and store it in `draftUnitSuffix`. The command is then sent with the unit suffix (e.g. `"1.5 kW"`), matching the behaviour of `SetpointRowView` which already uses `NumberState.commandString` (includes unit).

Plain `Number` items and states without a unit are unaffected (`draftUnitSuffix` remains `""`).

## Test plan

- [ ] `Number:Power` item with item unit `W` and state description `%.1f kW`, current state `1500 W`: edit dialog shows `1.5`, submitting sends `1.5 kW` → server writes 1500 W ✓
- [ ] `Number:Temperature` item, state `25.5 °C`: edit dialog shows `25.5`, submitting sends `25.5 °C` ✓
- [ ] Plain `Number` item, state `220.5`: edit dialog shows `220.5`, submitting sends `220.5` (no unit) ✓
- [ ] All `InputCommandFormatterTests` pass ✓