### PR TITLE
Align button areas to consistent width across SegmentedRowView rows

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
@@ -16,6 +16,42 @@ import os.log
 import SFSafeSymbols
 import SwiftUI
 
+// MARK: - Button-area width alignment
+
+private struct SegmentedButtonAreaWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private struct AlignSegmentedButtonAreasModifier: ViewModifier {
+    @State private var maxWidth: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .onPreferenceChange(SegmentedButtonAreaWidthKey.self) { maxWidth = $0 }
+            .environment(\.segmentedButtonAreaMaxWidth, maxWidth)
+    }
+}
+
+private struct ButtonAreaWidthModifier: ViewModifier {
+    @Environment(\.segmentedButtonAreaMaxWidth) private var maxWidth
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: SegmentedButtonAreaWidthKey.self, value: geo.size.width)
+                }
+            )
+            .frame(width: maxWidth > 0 ? maxWidth : nil, alignment: .trailing)
+    }
+}
+
+// MARK: -
+
 private struct SegmentedRowContent: View {
     let input: SegmentedRowInput
     let widgetVersion: Int
@@ -63,7 +99,7 @@ private struct SegmentedRowContent: View {
                         Spacer(minLength: 8)
                     }
                     pressReleaseButtons(mappings: input.mappings)
-                        .fixedSize(horizontal: true, vertical: false)
+                        .buttonAreaWidth()
                         .padding(.leading, 8)
 
                 } else if input.mappings.count == 1 {
@@ -71,7 +107,7 @@ private struct SegmentedRowContent: View {
                         Spacer(minLength: 8)
                     }
                     singleMappingButton(displayState: input.displayState, mappings: input.mappings, widgetVersion: widgetVersion)
-                        .fixedSize(horizontal: true, vertical: false)
+                        .buttonAreaWidth()
                         .padding(.leading, 8)
                 } else {
                     if noInputLabelValue {
@@ -81,6 +117,7 @@ private struct SegmentedRowContent: View {
                     // Button-based segmented control with animated selection indicator
                     segmentedButtons(mappings: input.mappings, selectedIndex: selectedIndex, displayState: input.displayState, widgetVersion: widgetVersion)
                         .frame(minWidth: 75)
+                        .buttonAreaWidth()
                         .padding(.leading, leadingPadding)
                         .layoutPriority(1)
                 }
@@ -371,6 +408,7 @@ struct PreviewList<Content: View>: View {
             content()
                 .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
         }
+        .alignSegmentedButtonAreas()
         .listStyle(.plain)
         .listRowSpacing(0)
         .environment(\.defaultMinListRowHeight, 32)
@@ -391,6 +429,22 @@ private extension SegmentedRowView {
             icon: icon,
             valueText: detailLabel
         ))
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var segmentedButtonAreaMaxWidth: CGFloat = 0
+}
+
+extension View {
+    func alignSegmentedButtonAreas() -> some View {
+        modifier(AlignSegmentedButtonAreasModifier())
+    }
+}
+
+private extension View {
+    func buttonAreaWidth() -> some View {
+        modifier(ButtonAreaWidthModifier())
     }
 }
 

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -47,6 +47,7 @@ struct SitemapPageView: View {
                         .listRowInsets(RowLayoutPolicy.rowInsets(for: rowInput))
                         .listRowBackground(RowLayoutPolicy.rowBackground(for: rowInput))
                 }
+                .alignSegmentedButtonAreas()
             }
         }
         .environmentObject(viewModel)


### PR DESCRIPTION
## Summary

- Segmented, press-release and single-mapping button areas on the same page previously had different widths, making the list look ragged
- Introduces `SegmentedButtonAreaWidthKey` (PreferenceKey, max-reduce) and `segmentedButtonAreaMaxWidth` (`@Entry` environment value) to propagate the page-wide maximum button-area width
- `alignSegmentedButtonAreas()` on the `List` in `SitemapPageView` (and `PreviewList`) wires `onPreferenceChange` → `environment`
- `buttonAreaWidth()` on each button-area type measures natural width via a `GeometryReader` background and applies an exact `frame(width: maxWidth, alignment: .trailing)` once the page-wide max is known — all three button types (segmented, press-release, single-mapping) share the same frame width and stay trailing-aligned within it

## Test plan

- [ ] Open a sitemap page with a mix of segmented, press-release and single-mapping rows — verify all button areas are the same width and flush with the trailing edge
- [ ] Verify the selection indicator animation and optimistic selection still work correctly on segmented rows
- [ ] Verify press-and-hold behaviour on press-release buttons is unaffected
- [ ] Verify single-mapping button tap behaviour is unaffected
- [ ] Check layout on pages that contain only one segmented row (no alignment effect expected)
- [ ] Check layout with very long labels to confirm the button area does not overflow its row insets