### PR TITLE
Migrate remaining XCTest files to Swift Testing

### DIFF
--- a/OpenHABCore/Tests/OpenHABCoreTests/ClientCertificateManagerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ClientCertificateManagerTests.swift
@@ -10,9 +10,8 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Foundation
-
 @testable import OpenHABCore
-import XCTest
+import Testing
 
 final class MockClientCertDelegate: ClientCertificateManagerDelegate {
     var shouldImport = true
@@ -42,71 +41,46 @@ final class MockClientCertDelegate: ClientCertificateManagerDelegate {
 // openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=TestCert"
 // openssl pkcs12 -export -out test.p12 -inkey key.pem -in cert.pem -password pass:password
 
-final class ClientCertificateManagerTests: XCTestCase {
-    var manager: ClientCertificateManager!
-    var delegate: MockClientCertDelegate!
+struct ClientCertificateManagerTests {
+    let manager: ClientCertificateManager
+    let delegate: MockClientCertDelegate
 
-    override func setUp() {
-        super.setUp()
+    init() {
         manager = ClientCertificateManager()
         delegate = MockClientCertDelegate()
         manager.delegate = delegate
     }
 
-    override func tearDown() {
-        manager = nil
-        delegate = nil
-        super.tearDown()
-    }
-
-    func testStartImportCertificateReturnsFalseIfDataMissing() async {
+    @Test func startImportCertificateReturnsFalseIfDataMissing() async {
         let result = await manager.startImportClientCertificate(url: URL(fileURLWithPath: "/nonexistent.p12"))
-        XCTAssertFalse(result)
+        #expect(!result)
     }
 
-    func testStartImportCertificateReturnsTrueIfDelegateApproves() async throws {
-        // Use a real P12 file in your test bundle if needed
+    @Test func startImportCertificateReturnsTrueIfDelegateApproves() async throws {
         guard let url = Bundle.module.url(forResource: "test", withExtension: "p12") else {
-            return XCTFail("Test PKCS#12 file not found.")
+            Issue.record("Test PKCS#12 file not found.")
+            return
         }
 
         let result = await manager.startImportClientCertificate(url: url)
-        XCTAssertTrue(result)
+        #expect(result)
     }
 
-//    func testClientCertificateAcceptedSuccessPath() async {
-//        manager.importingRawCert = loadMockPKCS12Data()
-//        delegate.password = "password"
-//
-//        await manager.clientCertificateAccepted(password: "password")
-//        XCTAssertNil(delegate.receivedErrorMessage)
-//    }
-
-    func testPKCS12DecodeReturnsIdentity() {
+    @Test func pKCS12DecodeReturnsIdentity() {
         manager.importingRawCert = loadMockPKCS12Data()
         manager.importingPassword = "password"
 
         let status = manager.decodePKCS12()
-        XCTAssertEqual(status, errSecSuccess)
-        XCTAssertNotNil(manager.importingIdentity)
+        #expect(status == errSecSuccess)
+        #expect(manager.importingIdentity != nil)
     }
 
-//    func testClientCertificateAcceptedFailsAndAlerts() async {
-//        manager.importingRawCert = Data([0x00, 0x01, 0x02]) // invalid cert
-//        await manager.clientCertificateAccepted(password: "badpassword")
-//        XCTAssertNotNil(delegate.receivedErrorMessage)
-//    }
-
-    @MainActor
-    func testClientCertificateAcceptedFailsAndAlerts() async {
+    @Test @MainActor func clientCertificateAcceptedFailsAndAlerts() async {
         manager.importingRawCert = Data([0x00, 0x01, 0x02]) // invalid cert
         await manager.clientCertificateAccepted(password: "badpassword")
-
-        let errorMessage = await MainActor.run { delegate.receivedErrorMessage }
-        XCTAssertNotNil(errorMessage)
+        #expect(delegate.receivedErrorMessage != nil)
     }
 
-    // Helper to load valid PKCS#12 mock
     private func loadMockPKCS12Data() -> Data? {
         guard let url = Bundle.module.url(forResource: "test", withExtension: "p12") else { return nil }
         return try? Data(contentsOf: url)

--- a/OpenHABCore/Tests/OpenHABCoreTests/ConnectionFailureTrackerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ConnectionFailureTrackerTests.swift
@@ -10,32 +10,31 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Foundation
-
 @testable import OpenHABCore
-import XCTest
+import Testing
 
-final class ConnectionFailureTrackerTests: XCTestCase {
-    func testShouldAttemptLogic() async {
+struct ConnectionFailureTrackerTests {
+    @Test func shouldAttemptLogic() async {
         let tracker = ConnectionFailureTracker()
         await tracker.setEnabled(true)
         let config = ConnectionConfiguration(url: "http://test", username: "", password: "", priority: 1)
 
         var result = await tracker.shouldAttempt(config)
-        XCTAssertTrue(result)
+        #expect(result)
 
         await tracker.recordFailure(config)
         await tracker.recordFailure(config)
         await tracker.recordFailure(config)
 
         result = await tracker.shouldAttempt(config)
-        XCTAssertFalse(result)
+        #expect(!result)
 
         await tracker.reset(config)
         result = await tracker.shouldAttempt(config)
-        XCTAssertTrue(result)
+        #expect(result)
     }
 
-    func testMaxFailureCount() async {
+    @Test func maxFailureCount() async {
         let tracker = ConnectionFailureTracker()
         await tracker.setEnabled(true)
         let config1 = ConnectionConfiguration(url: "http://a", username: "", password: "", priority: 0)
@@ -46,6 +45,6 @@ final class ConnectionFailureTrackerTests: XCTestCase {
         await tracker.recordFailure(config2)
 
         let max = await tracker.maxFailureCount()
-        XCTAssertEqual(max, 2)
+        #expect(max == 2)
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/ConnectionPoolTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ConnectionPoolTests.swift
@@ -10,18 +10,17 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Foundation
-
 @testable import OpenHABCore
-import XCTest
+import Testing
 
-final class ConnectionPoolTests: XCTestCase {
-    func testGetOrCreateServiceReturnsSameInstance() async throws {
+struct ConnectionPoolTests {
+    @Test func getOrCreateServiceReturnsSameInstance() async throws {
         let pool = ConnectionPool()
         let config = ConnectionConfiguration(url: "http://test", username: "", password: "", priority: 1)
 
         let service1 = try await pool.getOrCreateService(for: config)
         let service2 = try await pool.getOrCreateService(for: config)
 
-        XCTAssertTrue(service1 === service2)
+        #expect(service1 === service2)
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/JSONParserTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/JSONParserTests.swift
@@ -12,61 +12,42 @@
 @testable import OpenHABCore
 
 import os.signpost
-import XCTest
+import Testing
 
-final class JSONParserTests: XCTestCase {
-    let decoder = JSONDecoder()
+struct JSONParserTests {
+    let decoder: JSONDecoder
 
-    override func setUp() {
-        super.setUp()
-        decoder.dateDecodingStrategy = JSONDecoder.makeISO8601TolerantDecoder().dateDecodingStrategy
-
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    init() {
+        decoder = JSONDecoder.makeISO8601TolerantDecoder()
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testJSONSitemapDecoder() {
+    @Test func jSONSitemapDecoder() throws {
         let data = Data(jsonSitemap3.utf8)
-        do {
-            let codingData = try decoder.decode([Components.Schemas.SitemapDTO].self, from: data)
-            XCTAssertEqual(codingData[0].homepage?.link, "https://192.168.2.63:8444/rest/sitemaps/myHome/myHome", "Sitemap properly parsed")
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        let codingData = try decoder.decode([Components.Schemas.SitemapDTO].self, from: data)
+        #expect(codingData[0].homepage?.link == "https://192.168.2.63:8444/rest/sitemaps/myHome/myHome")
     }
 
     // Version 2.1 is without timeout
     // Contributed by Tobi-1234 in #348
-    func testJSONShortSitemapDecoder() {
+    @Test func jSONShortSitemapDecoder() throws {
         let json = """
         [{"name":"Haus","label":"HauptmenÃ¼","link":"http://192.xxxx:8080/rest/sitemaps/Haus","homepage":{"link":"http://192.xxx:8080/rest/sitemaps/Haus/Haus","leaf":false,"widgets":[]}},{"name":"_default","label":"Home","link":"http://192.Xxx:8080/rest/sitemaps/_default","homepage":{"link":"http://192.Xxxx:8080/rest/sitemaps/_default/_default","leaf":false,"widgets":[]}}]
         """
         let data = Data(json.utf8)
-        do {
-            let codingData = try decoder.decode([Components.Schemas.SitemapDTO].self, from: data)
-            XCTAssertEqual(codingData[0].homepage?.link, "http://192.xxx:8080/rest/sitemaps/Haus/Haus", "Sitemap properly parsed")
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        let codingData = try decoder.decode([Components.Schemas.SitemapDTO].self, from: data)
+        #expect(codingData[0].homepage?.link == "http://192.xxx:8080/rest/sitemaps/Haus/Haus")
     }
 
-    func testWidgetMapping() {
+    @Test func widgetMapping() throws {
         let json = """
         [{"command": "0","label": "Overwrite"}, {"command": "1","label": "Calendar"}]
         """
         let data = Data(json.utf8)
-        do {
-            let decoded = try decoder.decode([OpenHABWidgetMapping].self, from: data)
-            XCTAssertEqual(decoded[0].label, "Overwrite", "WidgetMapping properly parsed")
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        let decoded = try decoder.decode([OpenHABWidgetMapping].self, from: data)
+        #expect(decoded[0].label == "Overwrite")
     }
 
-    func testJSONWidgetMapping() {
+    @Test func jSONWidgetMapping() throws {
         let json = Data("""
         [
             {
@@ -83,32 +64,22 @@ final class JSONParserTests: XCTestCase {
             }
         ]
         """.utf8)
-        do {
-            let codingData = try decoder.decode([OpenHABWidgetMapping].self, from: json)
-            XCTAssertEqual(codingData[0].label, "Overwrite", "WidgetMapping properly parsed")
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        let codingData = try decoder.decode([OpenHABWidgetMapping].self, from: json)
+        #expect(codingData[0].label == "Overwrite")
     }
 
-    func testWatchSitemap() {
+    @Test func watchSitemap() throws {
         let json = Data("""
         {"name":"watch","label":"watch","link":"https://192.168.2.15:8444/rest/sitemaps/watch","homepage":{"id":"watch","title":"watch","link":"https://192.168.2.15:8444/rest/sitemaps/watch/watch","leaf":false,"timeout":false,"widgets":[{"widgetId":"00","type":"Frame","label":"Ground floor","icon":"frame","mappings":[],"widgets":[{"widgetId":"0000","type":"Switch","label":"Licht Oberlicht","icon":"switch","mappings":[],"item":{"link":"https://192.168.2.15:8444/rest/items/lcnLightSwitch14_1","state":"OFF","editable":false,"type":"Switch","name":"lcnLightSwitch14_1","label":"Licht Oberlicht","tags":["Lighting"],"groupNames":["G_PresenceSimulation","gLcn"]},"widgets":[]},{"widgetId":"0001","type":"Switch","label":"Licht Keller WC Decke","icon":"colorpicker","mappings":[],"item":{"link":"https://192.168.2.15:8444/rest/items/lcnLightSwitch6_1","state":"OFF","editable":false,"type":"Switch","name":"lcnLightSwitch6_1","label":"Licht Keller WC Decke","category":"colorpicker","tags":["Lighting"],"groupNames":["gKellerLicht","gLcn"]},"widgets":[]}]}]}}
         """.utf8)
-        do {
-            let codingData = try decoder.decode(Components.Schemas.SitemapDTO.self, from: json)
-            XCTAssertEqual(codingData.homepage?.link, "https://192.168.2.15:8444/rest/sitemaps/watch/watch", "OpenHABSitemapPage properly parsed")
-            //        XCTAssert(codingData.openHABSitemapPage. widgets[0].type == "Frame", "")
-            //        XCTAssert(.widgets[0].linkedPage?.pageId == "0000", "widget properly parsed")
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        let codingData = try decoder.decode(Components.Schemas.SitemapDTO.self, from: json)
+        #expect(codingData.homepage?.link == "https://192.168.2.15:8444/rest/sitemaps/watch/watch")
     }
 
-    func testJSONLargeSitemapParseSwift() throws {
+    @Test func jSONLargeSitemapParseSwift() throws {
         let jsonFile = "LargeSitemap"
         let testBundle = Bundle.module
-        let url = try XCTUnwrap(testBundle.url(forResource: jsonFile, withExtension: "json"))
+        let url = try #require(testBundle.url(forResource: jsonFile, withExtension: "json"))
 
         let signposter = OSSignposter(subsystem: "org.openhab.app", category: "RecordDecoding")
 
@@ -120,16 +91,16 @@ final class JSONParserTests: XCTestCase {
         let codingData = try decoder.decode(Components.Schemas.SitemapDTO.self, from: contents)
         signposter.endInterval("Decode JSON", state2)
 
-        let widgets = try XCTUnwrap(codingData.homepage?.widgets)
+        let widgets = try #require(codingData.homepage?.widgets)
         let widget = widgets[0]
-        XCTAssertEqual(widget.label, "Flat Scenes")
-        XCTAssertEqual(widget.widgets?[0].label, "Scenes")
-        XCTAssertEqual(codingData.homepage?.link, "https://192.168.0.9:8443/rest/sitemaps/default/default")
+        #expect(widget.label == "Flat Scenes")
+        #expect(widget.widgets?[0].label == "Scenes")
+        #expect(codingData.homepage?.link == "https://192.168.0.9:8443/rest/sitemaps/default/default")
         let widget2 = widgets[10]
-        XCTAssertEqual(widget2.widgets?[0].label, "Admin Items")
+        #expect(widget2.widgets?[0].label == "Admin Items")
     }
 
-    func testServerVersion() {
+    @Test func serverVersion() throws {
         let json = """
         {"version":"3", "links":[{"type":"uuid","url":"http://192.168.2.15:8081/rest/uuid"},
         {"type":"audio","url":"http://192.168.2.15:8081/rest/audio"},{"type":"bindings","url":"http://192.168.2.15:8081/rest/bindings"},{"type":"channel-types","url":"http://192.168.2.15:8081/rest/channel-types"},{"type":"config-descriptions","url":"http://192.168.2.15:8081/rest/config-descriptions"},{"type":"discovery","url":"http://192.168.2.15:8081/rest/discovery"},
@@ -137,15 +108,10 @@ final class JSONParserTests: XCTestCase {
         {"type":"things","url":"http://192.168.2.15:8081/rest/things"},{"type":"thing-types","url":"http://192.168.2.15:8081/rest/thing-types"},{"type":"sitemaps","url":"http://192.168.2.15:8081/rest/sitemaps"},{"type":"voice","url":"http://192.168.2.15:8081/rest/voice"},{"type":"iconsets","url":"http://192.168.2.15:8081/rest/iconsets"},{"type":"habpanel","url":"http://192.168.2.15:8081/rest/habpanel"}]}
         """
         let data = Data(json.utf8)
-        do {
-            let properties = try decoder.decode(OpenHABServerProperties.self, from: data)
+        let properties = try decoder.decode(OpenHABServerProperties.self, from: data)
 
-            XCTAssertEqual(properties.version, "3", "Checking version")
-            XCTAssertEqual(properties.links[0].type, "uuid", "Checking finding links")
-            XCTAssertEqual(properties.linkUrl(byType: "uuid"), "http://192.168.2.15:8081/rest/uuid", "Checking finding link by type")
-
-        } catch {
-            XCTFail("Whoops, an error occured: \(error)")
-        }
+        #expect(properties.version == "3")
+        #expect(properties.links[0].type == "uuid")
+        #expect(properties.linkUrl(byType: "uuid") == "http://192.168.2.15:8081/rest/uuid")
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABJSONParserTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABJSONParserTests.swift
@@ -10,36 +10,21 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import OpenHABCore
-import XCTest
+import Testing
 
-class OpenHABJSONParserTests: XCTestCase {
-    let decoder = JSONDecoder()
+struct OpenHABJSONParserTests {
+    let decoder: JSONDecoder
 
-    override func setUp() {
-        super.setUp()
-        decoder.dateDecodingStrategy = JSONDecoder.makeISO8601TolerantDecoder().dateDecodingStrategy
-
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    init() {
+        decoder = JSONDecoder.makeISO8601TolerantDecoder()
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testJSONNotificationDecoder() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-
-        // [{"_id":"5c4229b41cd87d98382869da","message":"Light Küche was changed","__v":0,"created":"2019-01-18T19:32:04.648Z"},
+    @Test func jSONNotificationDecoder() throws {
         let json = Data("""
                 [{"_id":"5c82e14d2b48ecbf7a7223e0","message":"Light Küche was changed","__v":0,"created":"2019-03-08T21:40:29.412Z"},{"_id":"5c82c9c22b48ecbf7a70f44e","message":"Light Küche was changed","__v":0,"created":"2019-03-08T20:00:02.368Z"},{"_id":"5c82c9c02b48ecbf7a70f42c","message":"Light Küche was changed","__v":0,"created":"2019-03-08T20:00:00.982Z"},{"_id":"5c7fff782b48ecbf7a4dd8e4","message":"Light Küche was changed","__v":0,"created":"2019-03-06T17:12:24.093Z"},{"_id":"5c7ff5c12b48ecbf7a4d56fb","message":"Light Küche was changed","__v":0,"created":"2019-03-06T16:30:57.101Z"},{"_id":"5c7ed0852b48ecbf7a3d2151","message":"Light Küche was changed","__v":0,"created":"2019-03-05T19:39:49.373Z"},{"_id":"5c7d50ba2b48ecbf7a26948f","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:18.473Z"},{"_id":"5c7d50b62b48ecbf7a269455","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:14.321Z"},{"_id":"5c7d50b42b48ecbf7a269442","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:12.468Z"},{"_id":"5c7d507d2b48ecbf7a26916c","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:21:17.006Z"}]
         """.utf8)
 
-        do {
-            let codingData = try decoder.decode([OpenHABNotification.CodingData].self, from: json)
-            XCTAssertEqual(codingData[0].message, "Light Küche was changed", "Message properly parsed")
-        } catch {
-            XCTFail("should not throw \(error)")
-        }
+        let codingData = try decoder.decode([OpenHABNotification.CodingData].self, from: json)
+        #expect(codingData[0].message == "Light Küche was changed")
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/ParseAsTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ParseAsTests.swift
@@ -10,33 +10,21 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import OpenHABCore
+import Testing
 
-import XCTest
-
-final class ParseAsTests: XCTestCase {
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+struct ParseAsTests {
+    @Test func parseAsBool() {
+        #expect("10,10,0".parseAsBool() == false)
+        #expect("10,10,50".parseAsBool() == true)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-
-        XCTAssertFalse("10,10,0".parseAsBool())
-        XCTAssertTrue("10,10,50".parseAsBool())
-    }
-
-    func testValidOpenHABURL() throws {
+    @Test func validOpenHABURL() throws {
         try "http://localhost:8080".testAsValidOpenHABURL()
         try "https://localhost:8080".testAsValidOpenHABURL()
         try "192.168.2.10".testAsValidOpenHABURL()
     }
 
-    func testInvalidOpenHABURL() {
+    @Test func invalidOpenHABURL() {
         let invalidURLs = [
             "ftp://localhost", // Unsupported scheme
             "http:/localhost", // Malformed
@@ -47,12 +35,11 @@ final class ParseAsTests: XCTestCase {
         ]
 
         for url in invalidURLs {
-            XCTAssertThrowsError(try url.testAsValidOpenHABURL(), "Expected to throw for URL: \(url)") { error in
-                if let urlError = error as? URLError {
-                    XCTAssertEqual(urlError.code, .badURL, "Expected .badURL, got \(urlError.code)")
-                } else {
-                    XCTFail("Unexpected error type: \(error)")
-                }
+            #expect {
+                try url.testAsValidOpenHABURL()
+            } throws: { error in
+                guard let urlError = error as? URLError else { return false }
+                return urlError.code == .badURL
             }
         }
     }

--- a/OpenHABCore/Tests/OpenHABCoreTests/UserDefaultsTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/UserDefaultsTests.swift
@@ -10,22 +10,13 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import OpenHABCore
-
-import XCTest
+import Testing
 
 @MainActor
-final class UserDefaultsTests: XCTestCase {
-    // Testing the consistency between Preferences and UserDefaults
-    func testConsistency() {
-        // Set Preferences from MainActor
-        let defaultsName: String
-        // Reset UserDefaults
+struct UserDefaultsTests {
+    @Test func consistency() throws {
         let data = UserDefaults(suiteName: "group.org.openhab.app")!
-        do {
-            defaultsName = try XCTUnwrap(Bundle.main.bundleIdentifier)
-        } catch {
-            fatalError()
-        }
+        let defaultsName = try #require(Bundle.main.bundleIdentifier)
         data.removePersistentDomain(forName: defaultsName)
 
         let random: String = UUID().uuidString
@@ -55,16 +46,16 @@ final class UserDefaultsTests: XCTestCase {
 
         Preferences.shared.idleOff = false
 
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.remoteConnectionConfig.username, home.remoteConnectionConfig.username)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.localConnectionConfig.url, home.localConnectionConfig.url)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.remoteConnectionConfig.url, home.remoteConnectionConfig.url)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.remoteConnectionConfig.password, home.remoteConnectionConfig.password)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.remoteConnectionConfig.ignoreSSL, home.remoteConnectionConfig.ignoreSSL)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.demomode, home.demomode)
-        XCTAssertEqual(Preferences.shared.idleOff, data.bool(forKey: "idleOff"))
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.iconType, home.iconType)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.defaultSitemap, home.defaultSitemap)
-        XCTAssertEqual(Preferences.shared.currentHomePreferences.sitemapForWatch, home.sitemapForWatch)
-        XCTAssertEqual(home, try? JSONDecoder().decode(HomePreferences.self, from: data.data(forKey: "currentHomePreferences")!))
+        #expect(Preferences.shared.currentHomePreferences.remoteConnectionConfig.username == home.remoteConnectionConfig.username)
+        #expect(Preferences.shared.currentHomePreferences.localConnectionConfig.url == home.localConnectionConfig.url)
+        #expect(Preferences.shared.currentHomePreferences.remoteConnectionConfig.url == home.remoteConnectionConfig.url)
+        #expect(Preferences.shared.currentHomePreferences.remoteConnectionConfig.password == home.remoteConnectionConfig.password)
+        #expect(Preferences.shared.currentHomePreferences.remoteConnectionConfig.ignoreSSL == home.remoteConnectionConfig.ignoreSSL)
+        #expect(Preferences.shared.currentHomePreferences.demomode == home.demomode)
+        #expect(Preferences.shared.idleOff == data.bool(forKey: "idleOff"))
+        #expect(Preferences.shared.currentHomePreferences.iconType == home.iconType)
+        #expect(Preferences.shared.currentHomePreferences.defaultSitemap == home.defaultSitemap)
+        #expect(Preferences.shared.currentHomePreferences.sitemapForWatch == home.sitemapForWatch)
+        #expect(home == (try? JSONDecoder().decode(HomePreferences.self, from: data.data(forKey: "currentHomePreferences")!)))
     }
 }

--- a/openHABTestsSwift/OpenHABGeneralTests.swift
+++ b/openHABTestsSwift/OpenHABGeneralTests.swift
@@ -11,53 +11,49 @@
 
 @testable import openHAB
 import OpenHABCore
-import XCTest
+import Testing
 
-class OpenHABGeneralTests: XCTestCase {
-    func testNamedColors() {
-        XCTAssertEqual(UIColor.red, UIColor(fromString: "red"))
-        XCTAssertEqual(UIColor.gray, UIColor(fromString: "abc"))
+struct OpenHABGeneralTests {
+    @Test func namedColors() {
+        #expect(UIColor.red == UIColor(fromString: "red"))
+        #expect(UIColor.gray == UIColor(fromString: "abc"))
     }
 
-    func testValueToText() {
+    @Test func valueToText() {
         func valueTextWithoutFormatter(_ widgetValue: Double, step: Double) -> String {
             let digits = max(-Decimal(step).exponent, 0)
             return String(format: "%.\(digits)f", widgetValue)
         }
 
         let value = 1000.0
-        XCTAssertEqual(value.valueText(step: 0.01), "1000.00")
-        XCTAssertEqual(value.valueText(step: 1), "1000")
-        XCTAssertEqual(valueTextWithoutFormatter(1000.0, step: 5.23), "1000.00")
+        #expect(value.valueText(step: 0.01) == "1000.00")
+        #expect(value.valueText(step: 1) == "1000")
+        #expect(valueTextWithoutFormatter(1000.0, step: 5.23) == "1000.00")
     }
 
-    func testHexString() {
+    @Test func hexString() {
         let iPhoneData = Data("Tim iPhone".utf8)
         let hexWithReduce = iPhoneData.reduce("") { $0 + String(format: "%02X", $1) }
-        XCTAssertEqual(hexWithReduce, "54696D206950686F6E65", "hex properly calculated with reduce")
+        #expect(hexWithReduce == "54696D206950686F6E65")
     }
 
-    func testWebViewURLParsing() {
+    @Test func webViewURLParsing() {
         let localURL = "http://openhab.local:8080"
 
-        // Test external HTTP URL
         let httpURL = "http://camera.example.com/stream"
         let httpResult = httpURL.lowercased().hasPrefix("http://") || httpURL.lowercased().hasPrefix("https://") ? httpURL : localURL + httpURL
-        XCTAssertEqual(httpResult, httpURL, "External HTTP URL should not be modified")
+        #expect(httpResult == httpURL)
 
-        // Test external HTTPS URL
         let httpsURL = "https://camera.example.com/stream"
         let httpsResult = httpsURL.lowercased().hasPrefix("http://") || httpsURL.lowercased().hasPrefix("https://") ? httpsURL : localURL + httpsURL
-        XCTAssertEqual(httpsResult, httpsURL, "External HTTPS URL should not be modified")
+        #expect(httpsResult == httpsURL)
 
-        // Test relative URL
         let relativeURL = "/proxy/camera"
         let relativeResult = relativeURL.lowercased().hasPrefix("http://") || relativeURL.lowercased().hasPrefix("https://") ? relativeURL : localURL + relativeURL
-        XCTAssertEqual(relativeResult, localURL + relativeURL, "Relative URL should be combined with local URL")
+        #expect(relativeResult == localURL + relativeURL)
 
-        // Test case-insensitive HTTPS
         let uppercaseHttpsURL = "HTTPS://example.com/image.jpg"
         let uppercaseResult = uppercaseHttpsURL.lowercased().hasPrefix("http://") || uppercaseHttpsURL.lowercased().hasPrefix("https://") ? uppercaseHttpsURL : localURL + uppercaseHttpsURL
-        XCTAssertEqual(uppercaseResult, uppercaseHttpsURL, "Uppercase HTTPS URL should not be modified")
+        #expect(uppercaseResult == uppercaseHttpsURL)
     }
 }


### PR DESCRIPTION
## Summary

- Converts the last 8 test files still on XCTest to the Swift Testing framework, completing the migration that was already partially done across the codebase
- `XCTestCase` subclasses → plain structs; `setUp`/`tearDown` → `init`; `XCTAssert*` → `#expect`/`#require`; `XCTFail` → `Issue.record`; `XCTAssertThrowsError` → `#expect { } throws: { }` closure form
- `do/catch/XCTFail` patterns in parser tests replaced with throwing `@Test` functions, removing ~100 lines of boilerplate

Files changed: `OpenHABGeneralTests`, `ConnectionPoolTests`, `ClientCertificateManagerTests`, `JSONParserTests`, `ConnectionFailureTrackerTests`, `OpenHABJSONParserTests`, `ParseAsTests`, `UserDefaultsTests`

## Test plan

- [x] `openHABTestsSwift` scheme builds for testing (`TEST BUILD SUCCEEDED`)
- [x] `OpenHABCore` scheme builds for testing (`TEST BUILD SUCCEEDED`)