### PR TITLE
Fix missing back button when navigating to sitemap sub-page from notification

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -35,6 +35,7 @@ class SitemapPageViewModel: ObservableObject {
     @Published private(set) var trackerStatus: NetworkStatus = .stopped
     @Published private(set) var widgetUpdateVersions: [String: Int] = [:]
     @Published private(set) var rowInputs: [SitemapRowInput] = []
+    @Published var navigationPath: [LinkedPageNavigation] = []
 
     let networkTracker = MainActorNetworkTracker.shared
     private var openAPIService: OpenAPIService?
@@ -796,7 +797,13 @@ extension SitemapPageViewModel {
         defaultSitemap = name
         defaultSitemapLabel = ""
         self.pageId = pageId ?? ""
+        navigationPath = []
         error = nil
+    }
+
+    @MainActor
+    func navigateToLinkedPage(_ nav: LinkedPageNavigation) {
+        navigationPath.append(nav)
     }
 
     @MainActor

--- a/openHAB/UI/HostingSitemapViewController.swift
+++ b/openHAB/UI/HostingSitemapViewController.swift
@@ -89,21 +89,10 @@ class HostingSitemapViewController: UIHostingController<SitemapNavigationView>, 
             .appending(path: name)
             .appending(path: path)
 
+        // Load the root sitemap so the back button returns to it, then navigate to the sub-page
+        // within the existing SwiftUI NavigationStack so SwiftUI manages back-navigation.
         await viewModel.pushSitemap(name: name, path: nil)
-
-        let pageViewModel = SitemapPageViewModel(
-            sitemapName: name,
-            pageUrl: pageURL.absoluteString,
-            title: name,
-            pageId: path
-        )
-        let pageViewController = HostingSitemapViewController(viewModel: pageViewModel)
-        if let rootViewController {
-            pageViewController.setRootViewController(rootViewController)
-        }
-
-        navigationController?.popToRootViewController(animated: false)
-        navigationController?.pushViewController(pageViewController, animated: true)
+        viewModel.navigateToLinkedPage(LinkedPageNavigation(pageLink: pageURL.absoluteString, pageTitle: name))
     }
 
     @MainActor

--- a/openHAB/UI/SwiftUI/SitemapNavigationView.swift
+++ b/openHAB/UI/SwiftUI/SitemapNavigationView.swift
@@ -23,7 +23,7 @@ struct SitemapNavigationView: View {
     let onShowSideMenu: () -> Void
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $viewModel.navigationPath) {
             sitemapContent
                 .navigationDestination(for: LinkedPageNavigation.self) { nav in
                     SitemapPageView(viewModel: SitemapPageViewModel(pageUrl: nav.pageLink, title: nav.pageTitle))

--- a/openHABUITests/apn-test.json
+++ b/openHABUITests/apn-test.json
@@ -1,0 +1,11 @@
+{
+     "Simulator Target Bundle": "org.openhab.app",
+     "aps": {
+         "alert": {
+             "title": "Test",
+             "body": "Navigate to sub-page"
+         }
+     },
+     "message": "Navigate to sub-page",
+     "on-click": "ui:/basicui/app?w=1304&sitemap=uicomponents_page_myHome"
+ }


### PR DESCRIPTION
## Summary

- PR #1204 fixed which sitemap page is loaded when tapping a notification action, but the back button (`< Home`) was missing because it pushed a brand-new `HostingSitemapViewController` with its own isolated `NavigationStack` — SwiftUI had no navigation history to show a back arrow from, and the only escape was force-quitting or reloading via the hamburger menu.
- Drive navigation programmatically through the **existing** `NavigationStack` instead: expose a `@Published navigationPath: [LinkedPageNavigation]` on `SitemapPageViewModel`, bind `NavigationStack(path:)` to it in `SitemapNavigationView`, and append a `LinkedPageNavigation` entry on notification tap rather than pushing a new `UIViewController`.
- `configureSitemap` clears the path when the sitemap changes so stale navigation state is never carried over.

## Test plan

- [ ] Send a simulated push to the simulator with `"on-click": "ui:/basicui/app?w=<pageId>&sitemap=<name>"` using `xcrun simctl push booted org.openhab.app <payload.apns>`
- [ ] Background the app, send the notification, tap the banner → sub-page loads with a back button pointing to the root sitemap
- [ ] Tap back → returns to the root sitemap page
- [ ] Foreground the app, send the notification, tap the SwiftMessages banner → same result
- [ ] Normal in-app sub-page navigation (tapping linked-page rows) still works and back button still appears

Fixes #842