### PR TITLE
Fix image widget flickering during auto-refresh

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
@@ -31,6 +31,11 @@ private struct ImageRowContent: View {
         let url: URL?
     }
 
+    private struct RegularImageState {
+        let url: URL?
+        let image: KFCrossPlatformImage
+    }
+
     let input: MediaRowInput
     @ObservedObject var viewModel: SitemapPageViewModel
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
@@ -38,6 +43,7 @@ private struct ImageRowContent: View {
     @State private var refreshTimer: Timer?
     @State private var forceRefreshKey = UUID()
     @State private var lastChartImage: KFCrossPlatformImage?
+    @State private var lastRegularImageState: RegularImageState?
     @State private var chartDisplayState: ChartDisplayState?
 
     private let logger = Logger(subsystem: "org.openhab", category: "ImageRowView")
@@ -162,6 +168,25 @@ private struct ImageRowContent: View {
             KFImage(url)
                 .withOpenHABCredentials(for: networkTracker.activeConnection)
                 .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
+                .placeholder {
+                    if let state = lastRegularImageState, state.url == url {
+                        Image(uiImage: state.image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } else {
+                        Color.gray.opacity(0.1)
+                            .frame(height: 200)
+                            .clipShape(.rect(cornerRadius: 8))
+                    }
+                }
+                .onSuccess { result in
+                    lastRegularImageState = RegularImageState(url: url, image: result.image)
+                }
+                .onFailure { error in
+                    guard !error.isTaskCancelled else { return }
+                    logger.warning("Image fetch failed for \(url?.absoluteString ?? "nil", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+                .fade(duration: 0)
                 .resizable()
                 .cacheMemoryOnly(!shouldCache)
                 .forceRefresh(shouldCache ? false : true)


### PR DESCRIPTION
## Summary

- When auto-refresh was active, each timer tick changed the `.id()` on the `KFImage`, causing SwiftUI to destroy and recreate the view entirely — leaving a blank frame for the duration of the network round-trip
- Fix mirrors the existing chart image approach: a URL-scoped `RegularImageState` stores the last successfully loaded image and serves it as a placeholder while the next fetch is in flight
- Adds `.onFailure` logging to distinguish placeholder churn from genuine fetch/decode failures; expected task cancellations (caused by in-flight loads being superseded by the next refresh tick) are suppressed

## Test plan

- [ ] Configure a sitemap Image widget with a `refresh` interval pointing at a camera or periodically-updating image URL
- [ ] Verify the image updates without flickering or blanking between refreshes
- [ ] Verify the first load shows a gray placeholder (no prior image cached)
- [ ] Change the image URL in the sitemap and verify the old image is not shown as a placeholder for the new URL
- [ ] Trigger a network failure (e.g. disable WiFi briefly) and verify a warning appears in the log without flooding from cancellation noise