### PR TITLE
Sync Watch preferences immediately when WCSession activates

### DIFF
--- a/openHAB/UI/Watch/WatchMessageService.swift
+++ b/openHAB/UI/Watch/WatchMessageService.swift
@@ -41,6 +41,10 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {
         Logger.preferences.info("WCSession activation completed. State: \(String(describing: activationState)), Error: \(String(describing: error))")
+        guard activationState == .activated else { return }
+        Task { @MainActor in
+            await WatchMessageService.singleton.syncPreferencesToWatch()
+        }
     }
 
     func sessionDidBecomeInactive(_ session: WCSession) {


### PR DESCRIPTION
## Summary

- `WatchMessageService.activationDidCompleteWith`: trigger `syncPreferencesToWatch()` as soon as the session reaches `.activated`
- Eliminates the race where the Combine debounce fires before WCSession is ready, silently skipping the initial push and leaving the Watch without configuration until the user manually changes a preference
- The existing cache equality check makes the call a no-op when the debounce already synced the same preferences, so there is no redundant WCSession write

## Test plan

- [ ] Cold-start iPhone app with Watch off; turn Watch on — Watch should pick up configuration without requiring a preference change
- [ ] Restart iPhone app normally — Watch preferences still sync within a second of app launch
- [ ] Change a preference on iPhone — Watch still receives the update via the Combine debounce path