### PR TITLE
Fix watch hang caused by App Intents spawning extra NetworkTrackers

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -343,6 +343,13 @@ public actor OpenHABItemCache {
     }
 
     private func assureNetworkTracker(homeId: UUID) async -> NetworkTracker? {
+        #if os(watchOS)
+        // On watchOS, App Intents run in the watch app process (no extension process exists).
+        // Creating private NetworkTracker instances here would spawn additional NWPathMonitors
+        // and URLSession connections alongside the app's existing NetworkTracker.shared, which
+        // exhausts watchOS's constrained network resources and causes hangs.
+        return NetworkTracker.shared
+        #else
         await Preferences.prepareForAppExtensionAccess()
         if networkTrackers[homeId] == nil, let homePreferences = await Preferences.shared.storedHomes[homeId] {
             let tracker = NetworkTracker(timeout: OpenHABItemCache.networkTimeout)
@@ -351,6 +358,7 @@ public actor OpenHABItemCache {
         }
         // TODO: do we need to make sure / wait that the connection is live?
         return networkTrackers[homeId]
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary

- On watchOS, App Intents have no separate extension process — `perform()` and entity queries execute inside the watch app process itself
- `OpenHABItemCache.assureNetworkTracker` was creating a private `NetworkTracker` per home (with its own `NWPathMonitor` and URLSession pool), adding network activity on top of the app's already-running `NetworkTracker.shared`
- On watchOS's constrained resources this caused the app to hang, and after force-quitting the app could not be reopened until the stale Shortcuts request timed out
- On watchOS, `assureNetworkTracker` now returns `NetworkTracker.shared` — the watch always operates against a single active connection, so the per-home tracker dictionary provides no benefit there
- iOS/macOS behaviour is unchanged

## Test plan

- [ ] Run an openHAB Shortcut from Apple Watch while the watch app is open and long-polling — verify no hang
- [ ] Verify Shortcut entity resolution (picker) works on watchOS
- [ ] Verify `perform()` sends the command successfully on watchOS
- [ ] Verify iOS App Intents behaviour is unchanged (entity queries, perform, multi-home)