### PR TITLE
Fix home switch via Shortcuts not loading new home's sitemap

### DIFF
--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -106,6 +106,9 @@ class OpenHABRootViewController: UIViewController {
 
     private var activeConnection: ConnectionInfo?
     private var lastTrackerStartupSettings: TrackerStartupSettings?
+    /// Tracks the last active home's `HomePreferences.id` to detect home switches
+    /// and navigate to the new home's default sitemap.
+    private var lastActiveHomeId: UUID?
     private let synthesizer = AVSpeechSynthesizer()
 
     override func viewDidLoad() {
@@ -149,6 +152,8 @@ class OpenHABRootViewController: UIViewController {
         #endif
         // save this so we know if its changed later
         isDemoMode = Preferences.shared.currentHomePreferences.demomode
+        // seed initial value so the first publisher fire doesn't treat it as a home switch
+        lastActiveHomeId = Preferences.shared.currentHomePreferences.id
 
         view.addSubview(transitionCoverView)
         NSLayoutConstraint.activate([
@@ -353,6 +358,27 @@ class OpenHABRootViewController: UIViewController {
         serverInfo.debounce(for: .milliseconds(500), scheduler: RunLoop.main) // ensures if multiple values are saved, we get called once
             .sink { [weak self] homeSettings in
                 guard let self else { return }
+
+                // When the active home changes, navigate to its default sitemap.
+                // This covers Shortcuts automations and any other background home switch.
+                let currentHomeId = homeSettings.id
+                if lastActiveHomeId != currentHomeId {
+                    lastActiveHomeId = currentHomeId
+                    let defaultSitemap = homeSettings.defaultSitemap
+                    let defaultView = homeSettings.defaultView
+                    if defaultView == "sitemap" {
+                        if currentView !== sitemapViewController {
+                            // Ensure the sitemap view is visible (e.g. user was on webview)
+                            switchView(target: .sitemap(defaultSitemap))
+                        }
+                        Task { @MainActor [weak self] in
+                            await (self?.sitemapViewController as? HostingSitemapViewController)?
+                                .pushSitemap(name: defaultSitemap, path: nil)
+                        }
+                    } else {
+                        switchView(target: .webview)
+                    }
+                }
 
                 let settings = TrackerStartupSettings(homeSettings: homeSettings)
                 guard lastTrackerStartupSettings != settings else {


### PR DESCRIPTION
## Problem

When `SetActiveHomeIntent` (or any background home switch) fires, `Preferences.switchActiveHome()` correctly updates `currentHomePreferences` and the debounced sink in `setupTracker()` restarts `NetworkTracker` with the new home's connections. However, `SitemapPageViewModel.defaultSitemap` was never updated.

When the tracker connected to the new home and fired `connection-changed`, the view model reloaded the **old** sitemap name against the **new** home's server → 404 on every home switch.

The transition that appeared to work (e.g. back to Geirer) only worked by accident because the previously-loaded sitemap name happened to exist on that server.

## Fix

In `OpenHABRootViewController.setupTracker()`, track the last active home's `HomePreferences.id` alongside `lastTrackerStartupSettings`. When the id changes:

1. Call `pushSitemap(name: defaultSitemap)` on `HostingSitemapViewController` — this resets `SitemapPageViewModel.defaultSitemap` synchronously and starts loading the correct sitemap.
2. If the current view is not the sitemap view (user was on webview), call `switchView` first to make it visible.

`lastActiveHomeId` is seeded in `viewDidLoad` so the very first page load (handled by `switchToSavedView()`) is not duplicated.