### PR TITLE
ConnectionView: refresh home name on appear to fix stale display after home switch

### DIFF
--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -111,6 +111,9 @@ struct ConnectionView: View {
         .onReceive(Preferences.shared.currentHomePreferencesPublisher) { prefs in
             homeName = prefs.homeName
         }
+        .onAppear {
+            homeName = Preferences.shared.currentHomePreferences.homeName
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The drawer's `ConnectionView` shows the active home name via `@State private var homeName`.
The state is kept in sync with `onReceive(currentHomePreferencesPublisher)`, but `onReceive`
only fires while the view is live in the SwiftUI hierarchy — i.e. while the drawer is open.

When the home is switched while the drawer is closed (e.g. via a Shortcuts automation), the
`publisher` event is missed, so the drawer still shows the old home name when next opened.

## Fix

Add `.onAppear` to synchronously re-read `Preferences.shared.currentHomePreferences.homeName`
every time the drawer slides in, so the displayed name is always current regardless of when the
home switch happened.

```swift
.onAppear {
    homeName = Preferences.shared.currentHomePreferences.homeName
}
```

The existing `onReceive` subscriber is kept so live updates (home switch while drawer is open)
still propagate without needing to close and reopen the drawer.