### PR TITLE
Upgrade SwiftFormatPlugin 0.58.7→0.61.1, SwiftLintPlugin 0.62.2→0.63.3

### DIFF
--- a/AppIntents/Intents/ContactStateIntent.swift
+++ b/AppIntents/Intents/ContactStateIntent.swift
@@ -28,9 +28,13 @@ enum ContactStateError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct ContactStateIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.contact] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.contact]
+    }
 
     static var parameterSummary: some ParameterSummary {
         Summary("Set the state of \(\.$itemEntity) to \(\.$state)") {

--- a/AppIntents/Intents/GetItemStateIntent.swift
+++ b/AppIntents/Intents/GetItemStateIntent.swift
@@ -25,7 +25,9 @@ enum ItemStateError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct GetItemStateIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
     static var parameterSummary: some ParameterSummary {
         Summary("Get \(\.$itemEntity) State") {

--- a/AppIntents/Intents/SetActiveHomeIntent.swift
+++ b/AppIntents/Intents/SetActiveHomeIntent.swift
@@ -14,7 +14,9 @@ import OpenHABCore
 
 @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
 struct SetActiveHomeIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
     static let title: LocalizedStringResource = "Set Active Home"
     static let description = IntentDescription("Switch the active home in the openHAB app")

--- a/AppIntents/Intents/SetColorValueIntent.swift
+++ b/AppIntents/Intents/SetColorValueIntent.swift
@@ -31,9 +31,14 @@ enum ColorValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetColorValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.color] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.color]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$value) (HSB)") {
             \.$home

--- a/AppIntents/Intents/SetDateTimeValueIntent.swift
+++ b/AppIntents/Intents/SetDateTimeValueIntent.swift
@@ -28,9 +28,14 @@ enum DateTimeValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetDateTimeValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.dateTime] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.dateTime]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$value)") {
             \.$home

--- a/AppIntents/Intents/SetDimmerRollerValueIntent.swift
+++ b/AppIntents/Intents/SetDimmerRollerValueIntent.swift
@@ -31,9 +31,14 @@ enum DimmerRollerValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetDimmerRollerValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.dimmer, .rollershutter] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.dimmer, .rollershutter]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$value)") {
             \.$home

--- a/AppIntents/Intents/SetLocationValueIntent.swift
+++ b/AppIntents/Intents/SetLocationValueIntent.swift
@@ -34,9 +34,14 @@ enum LocationValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetLocationValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.location] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.location]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$latitude), \(\.$longitude)") {
             \.$home

--- a/AppIntents/Intents/SetNumberValueIntent.swift
+++ b/AppIntents/Intents/SetNumberValueIntent.swift
@@ -28,9 +28,14 @@ enum NumberValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetNumberValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.number, .numberWithDimension] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.number, .numberWithDimension]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$value)") {
             \.$home

--- a/AppIntents/Intents/SetPlayerValueIntent.swift
+++ b/AppIntents/Intents/SetPlayerValueIntent.swift
@@ -28,9 +28,13 @@ enum PlayerValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetPlayerValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.player] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.player]
+    }
 
     static var parameterSummary: some ParameterSummary {
         Summary("Send \(\.$action) to \(\.$itemEntity)") {

--- a/AppIntents/Intents/SetStringValueIntent.swift
+++ b/AppIntents/Intents/SetStringValueIntent.swift
@@ -28,9 +28,14 @@ enum StringValueError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetStringValueIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.stringItem] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.stringItem]
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Set \(\.$itemEntity) to \(\.$value)") {
             \.$home

--- a/AppIntents/Intents/SetSwitchItemIntent.swift
+++ b/AppIntents/Intents/SetSwitchItemIntent.swift
@@ -28,9 +28,13 @@ enum ControlItemError: Error, CustomLocalizedStringResourceConvertible {
 
 @available(iOS 17.0, macOS 14.0, *)
 struct SetSwitchItemIntent: AppIntent {
-    static var openAppWhenRun: Bool { false }
+    static var openAppWhenRun: Bool {
+        false
+    }
 
-    static var allowedItemTypes: [OpenHABItem.ItemType] { [.switchItem] }
+    static var allowedItemTypes: [OpenHABItem.ItemType] {
+        [.switchItem]
+    }
 
     static var parameterSummary: some ParameterSummary {
         Summary("Send \(\.$action) to \(\.$itemEntity)") {

--- a/AppIntents/ItemEntity.swift
+++ b/AppIntents/ItemEntity.swift
@@ -26,15 +26,34 @@ protocol ItemEntity: AppEntity where ID == ItemIdentifier {
 
 @available(iOS 17.0, macOS 14.0, *)
 extension ItemEntity {
-    var homeId: UUID? { id.homeId }
-    var itemName: String { id.itemName }
+    var homeId: UUID? {
+        id.homeId
+    }
 
-    // Convenient access to common item properties
-    var label: String { item.label }
-    var category: String { item.category }
-    var type: OpenHABItem.ItemType? { item.type }
-    var state: String? { item.state }
-    var link: String { item.link }
+    var itemName: String {
+        id.itemName
+    }
+
+    /// Convenient access to common item properties
+    var label: String {
+        item.label
+    }
+
+    var category: String {
+        item.category
+    }
+
+    var type: OpenHABItem.ItemType? {
+        item.type
+    }
+
+    var state: String? {
+        item.state
+    }
+
+    var link: String {
+        item.link
+    }
 
     var displayRepresentation: DisplayRepresentation {
         if let homeName {

--- a/AppIntents/ItemIdentifier.swift
+++ b/AppIntents/ItemIdentifier.swift
@@ -33,11 +33,11 @@ struct ItemIdentifier: Codable {
     }
 }
 
-// homeId is a device-local UUID used only for cache lookups and network-tracker resolution.
-// For v2 identifiers (homeIdentifier != nil), entity identity is homeIdentifier + itemName so the
-// App Intents framework can match shortcuts across devices even when the embedded UUID differs.
-// For legacy identifiers (homeIdentifier == nil), homeId is the only home discriminator available,
-// so it is included in equality — without it, same-named items from different homes would collide.
+/// homeId is a device-local UUID used only for cache lookups and network-tracker resolution.
+/// For v2 identifiers (homeIdentifier != nil), entity identity is homeIdentifier + itemName so the
+/// App Intents framework can match shortcuts across devices even when the embedded UUID differs.
+/// For legacy identifiers (homeIdentifier == nil), homeId is the only home discriminator available,
+/// so it is included in equality — without it, same-named items from different homes would collide.
 extension ItemIdentifier: Equatable {
     static func == (lhs: ItemIdentifier, rhs: ItemIdentifier) -> Bool {
         guard lhs.homeIdentifier == nil, rhs.homeIdentifier == nil else {

--- a/AppIntents/iOS16/SetSwitchState.swift
+++ b/AppIntents/iOS16/SetSwitchState.swift
@@ -34,11 +34,11 @@ enum SetSwitchStateError: Error, CustomLocalizedStringResourceConvertible {
     }
 }
 
-// The @available(obsoleted: 17.0) annotation is intentionally absent: CustomIntentMigratedAppIntent
-// requires this struct to be available on iOS 17+ so that stored shortcuts using the legacy
-// SiriKit intent class (intentClassName) are migrated to this App Intent at runtime. Restricting
-// availability to iOS 16 would break that migration path for iOS 17+ users. The duplicate entry
-// in the Shortcuts picker is an accepted trade-off until migration is confirmed complete.
+/// The @available(obsoleted: 17.0) annotation is intentionally absent: CustomIntentMigratedAppIntent
+/// requires this struct to be available on iOS 17+ so that stored shortcuts using the legacy
+/// SiriKit intent class (intentClassName) are migrated to this App Intent at runtime. Restricting
+/// availability to iOS 16 would break that migration path for iOS 17+ users. The duplicate entry
+/// in the Shortcuts picker is an accepted trade-off until migration is confirmed complete.
 struct SetSwitchState: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
     // swiftlint:disable type_contents_order
 

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "981c20eb876b3478e70e69ad39fa28a4a7b3c0300977d08d767317cc43c4c93a",
+  "originHash" : "2195e162e93a04d869e4fd38210b4e523359da94e9b77c369bfa9c1dfa3e06b4",
   "pins" : [
     {
       "identity" : "swiftformatplugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftFormatPlugin",
       "state" : {
-        "revision" : "c41997c642ffc937c6e83b23dadbd7e626485cfa",
-        "version" : "0.58.7"
+        "revision" : "c7c81920d715e051306d2172083c14aaec2c1b9d",
+        "version" : "0.61.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftLintPlugin.git",
       "state" : {
-        "revision" : "47d1da3a8e30e0ada5543899e8c47f54664073ac",
-        "version" : "0.62.2"
+        "revision" : "3741567a0252090897336f1f39b8490107b49ead",
+        "version" : "0.63.3"
       }
     }
   ],

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -5,8 +5,8 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_13)],
     dependencies: [
-        .package(url: "https://github.com/weakfl/SwiftFormatPlugin", exact: "0.58.7"),
-        .package(url: "https://github.com/weakfl/SwiftLintPlugin.git", exact: "0.62.2")
+        .package(url: "https://github.com/weakfl/SwiftFormatPlugin", exact: "0.61.1"),
+        .package(url: "https://github.com/weakfl/SwiftLintPlugin.git", exact: "0.63.3")
     ],
     targets: [
         .target(

--- a/CommonUI/Sources/CommonUI/ColorExtension.swift
+++ b/CommonUI/Sources/CommonUI/ColorExtension.swift
@@ -36,8 +36,7 @@ public extension Color {
         let g: CGFloat = components?[1] ?? 0.0
         let b: CGFloat = components?[2] ?? 0.0
 
-        let hexString = String(format: "#%02lX%02lX%02lX", lroundf(Float(r * 255)), lroundf(Float(g * 255)), lroundf(Float(b * 255)))
-        return hexString
+        return String(format: "#%02lX%02lX%02lX", lroundf(Float(r * 255)), lroundf(Float(g * 255)), lroundf(Float(b * 255)))
     }
 }
 

--- a/CommonUI/Sources/CommonUI/LogsViewer.swift
+++ b/CommonUI/Sources/CommonUI/LogsViewer.swift
@@ -17,8 +17,10 @@ import SwiftUI
 // Thanks to https://useyourloaf.com/blog/fetching-oslog-messages-in-swift/
 
 public struct LogsViewer: View {
-    private static let template = NSPredicate(format:
-        "(subsystem BEGINSWITH $PREFIX)")
+    private static let template = NSPredicate(
+        format:
+        "(subsystem BEGINSWITH $PREFIX)"
+    )
 
     @State private var text = String(localized: "Loading…")
     @State private var exportURL: URL?
@@ -88,7 +90,8 @@ public struct LogsViewer: View {
             let predicate = Self.template.withSubstitutionVariables(
                 [
                     "PREFIX": "org.openhab"
-                ])
+                ]
+            )
 
             let logs = try Logger.fetch(
                 since: dayAgo,

--- a/CommonUI/Sources/CommonUI/PreviewConstants.swift
+++ b/CommonUI/Sources/CommonUI/PreviewConstants.swift
@@ -24,8 +24,7 @@ public enum PreviewConstants {
         let data = sitemapJson
         do {
             let sitemapPage = try data.decoded(as: Components.Schemas.PageDTO.self)
-            let openHABSitemapPage = OpenHABPage(sitemapPage)
-            return openHABSitemapPage
+            return OpenHABPage(sitemapPage)
         } catch {
             logger.error("Should not throw \(error.localizedDescription)")
             return nil

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -155,7 +155,7 @@ actor NotificationServiceHandler {
         return (localURL, urlResponse.mimeType)
     }
 
-    // Helper function to determine full URL
+    /// Helper function to determine full URL
     private func resolveFullURL(from url: String, baseURL: String) -> URL? {
         if let parsedURL = URL(string: url), parsedURL.scheme != nil {
             return parsedURL

--- a/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/NumberState.swift
@@ -62,7 +62,7 @@ public struct NumberState: CustomStringConvertible, Equatable {
         return stringValue
     }
 
-    // Access to default memberwise initializer not permitted outside of package
+    /// Access to default memberwise initializer not permitted outside of package
     public init(value: Double, unit: String? = "", format: String? = "") {
         self.value = value
         self.unit = unit

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABEvent.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABEvent.swift
@@ -18,7 +18,7 @@ public struct OpenHABEvent: Decodable, Hashable, Sendable {
         case itemStateChangedEvent = "ItemStateChangedEvent"
     }
 
-    struct Payload: Decodable, Equatable, Hashable, Sendable {
+    struct Payload: Decodable, Equatable, Hashable {
         private enum CodingKeys: String, CodingKey {
             case type, value, oldType, oldValue, lastStateUpdate, lastStateChange
         }

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABLink.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABLink.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-struct OpenHABLink: Decodable, Sendable {
+struct OpenHABLink: Decodable {
     var type: String?
     var url: String?
 }

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABNotification.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABNotification.swift
@@ -27,9 +27,9 @@ public struct OpenHABNotification: Sendable {
     }
 }
 
-// Decode an instance of OpenHABNotification.CodingData rather than decoding a OpenHABNotificaiton value directly,
-// then convert that into a openHABNotification
-// Inspired by https://www.swiftbysundell.com/basics/codable?rq=codingdata
+/// Decode an instance of OpenHABNotification.CodingData rather than decoding a OpenHABNotificaiton value directly,
+/// then convert that into a openHABNotification
+/// Inspired by https://www.swiftbysundell.com/basics/codable?rq=codingdata
 public extension OpenHABNotification {
     struct CodingData: Decodable {
         private enum CodingKeys: String, CodingKey {
@@ -46,7 +46,7 @@ public extension OpenHABNotification {
     }
 }
 
-// Convenience method to convert a decoded value into a proper OpenHABNotification instance
+/// Convenience method to convert a decoded value into a proper OpenHABNotification instance
 extension OpenHABNotification.CodingData {
     var openHABNotification: OpenHABNotification {
         OpenHABNotification(message: message, created: created, id: id)

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABPage.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABPage.swift
@@ -53,7 +53,7 @@ public class OpenHABPage: NSObject, @unchecked Sendable {
 
 public extension OpenHABPage {
     func filter(_ isIncluded: (OpenHABWidget) throws -> Bool) rethrows -> OpenHABPage {
-        let filteredOpenHABSitemapPage = try OpenHABPage(
+        try OpenHABPage(
             pageId: pageId,
             title: title,
             link: link,
@@ -61,7 +61,6 @@ public extension OpenHABPage {
             widgets: widgets.filter(isIncluded),
             icon: icon
         )
-        return filteredOpenHABSitemapPage
     }
 }
 

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABServerProperties.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABServerProperties.swift
@@ -19,11 +19,6 @@ public struct OpenHABServerProperties: Decodable, Sendable {
         linkUrl(byType: "habpanel")
     }
 
-    init(version: String?, links: [OpenHABLink]) {
-        self.version = version
-        self.links = links
-    }
-
     public func linkUrl(byType type: String?) -> String? {
         if let index = links.firstIndex(where: { $0.type == type }) {
             links[index].url

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemap.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemap.swift
@@ -11,8 +11,8 @@
 
 import Foundation
 
-// The OpenHAB REST API returns either a value (eg. String, Int, Double...) or false (not null).
-// Inspired by https://stackoverflow.com/questions/52836448/decodable-value-string-or-bool
+/// The OpenHAB REST API returns either a value (eg. String, Int, Double...) or false (not null).
+/// Inspired by https://stackoverflow.com/questions/52836448/decodable-value-string-or-bool
 public struct ValueOrFalse<T: Decodable>: Decodable {
     let value: T?
 

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemapWidgetEvent.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemapWidgetEvent.swift
@@ -46,6 +46,7 @@ public class OpenHABSitemapWidgetEvent {
 
     convenience init?(_ event: Components.Schemas.SitemapWidgetEvent?) {
         guard let event else { return nil }
+        // swiftlint:disable:next line_length
         self.init(sitemapName: event.sitemapName, pageId: event.pageId, widgetId: event.widgetId, label: event.label, labelSource: event.labelSource, icon: event.icon, reloadIcon: event.reloadIcon, labelcolor: event.labelcolor, valuecolor: event.valuecolor, iconcolor: event.iconcolor, visibility: event.visibility, state: event.state, enrichedItem: OpenHABItem(event.item), descriptionChanged: event.descriptionChanged)
     }
 }

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
@@ -109,8 +109,13 @@ public class OpenHABWidget: NSObject, MKAnnotation, Identifiable, ObservableObje
     public var stateless: Bool?
     public var yAxisDecimalPattern: String?
 
-    public var widgetType: WidgetType { type }
-    public var hasLinkedPage: Bool { linkedPage != nil }
+    public var widgetType: WidgetType {
+        type
+    }
+
+    public var hasLinkedPage: Bool {
+        linkedPage != nil
+    }
 
     public var coordinate: CLLocationCoordinate2D {
         item?.stateAsLocation()?.coordinate ?? kCLLocationCoordinate2DInvalid
@@ -118,7 +123,7 @@ public class OpenHABWidget: NSObject, MKAnnotation, Identifiable, ObservableObje
 }
 
 public extension OpenHABWidget {
-    // This is an ugly initializer
+    /// This is an ugly initializer
     convenience init(widgetId: String,
                      label: String,
                      icon: String,
@@ -219,11 +224,12 @@ public extension OpenHABWidget {
     }
 
     convenience init(icon: String, iconColor: String? = nil) {
+        // swiftlint:disable:next line_length
         self.init(widgetId: "\(UUID())", label: "", icon: icon, type: .unknown, url: nil, period: nil, minValue: nil, maxValue: nil, step: nil, refresh: nil, height: nil, isLeaf: nil, iconColor: iconColor, labelColor: nil, valueColor: nil, service: nil, state: nil, text: nil, legend: nil, inputHint: nil, encoding: nil, item: nil, linkedPage: nil, mappings: [], widgets: [], visibility: nil, switchSupport: nil, forceAsItem: nil, labelSource: .unknown, releaseOnly: nil)
     }
 }
 
-//  Recursive parsing of nested widget structure
+///  Recursive parsing of nested widget structure
 public extension [OpenHABWidget] {
     mutating func flatten(_ widgets: [Element]) {
         for widget in widgets {

--- a/OpenHABCore/Sources/OpenHABCore/Model/SetpointDisplayFormatter.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/SetpointDisplayFormatter.swift
@@ -12,8 +12,8 @@
 import Foundation
 
 public enum SetpointDisplayFormatter {
-    // Use a stable dot-decimal locale for platforms that intentionally avoid
-    // locale-aware formatting until all number controls are migrated together.
+    /// Use a stable dot-decimal locale for platforms that intentionally avoid
+    /// locale-aware formatting until all number controls are migrated together.
     public static let dotDecimalLocale = Locale(identifier: "en_US_POSIX")
 
     // swiftlint:disable:next function_parameter_count

--- a/OpenHABCore/Sources/OpenHABCore/Util/BonjourService.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/BonjourService.swift
@@ -31,7 +31,9 @@ public struct DiscoveredServer: Hashable, Sendable {
     public let address: String
     public let port: Int
 
-    public var url: String { "\(scheme)://\(address):\(port)" }
+    public var url: String {
+        "\(scheme)://\(address):\(port)"
+    }
 
     public init(scheme: String, address: String, port: Int) {
         self.scheme = scheme
@@ -42,7 +44,7 @@ public struct DiscoveredServer: Hashable, Sendable {
 
 // MARK: - Address Utilities
 
-enum BonjourAddressUtils: Sendable {
+enum BonjourAddressUtils {
     /// Determines if an address should be filtered out (link-local, loopback, unique local)
     static func shouldFilterAddress(_ address: String) -> Bool {
         address.hasPrefix("fe80:") ||
@@ -101,12 +103,12 @@ public protocol BonjourServiceProtocol: AnyObject, Sendable {
 public final class BonjourService: NSObject, BonjourServiceProtocol, NetServiceBrowserDelegate, NetServiceDelegate, Sendable {
     // MARK: - Types
 
-    private struct SchemePort: Hashable, Sendable {
+    private struct SchemePort: Hashable {
         let scheme: String
         let port: Int
     }
 
-    private struct ServiceAddressKey: Hashable, Sendable {
+    private struct ServiceAddressKey: Hashable {
         let name: String
         let type: String
     }

--- a/OpenHABCore/Sources/OpenHABCore/Util/ClientCertificateManager.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ClientCertificateManager.swift
@@ -15,11 +15,11 @@ import Security
 
 @MainActor
 public protocol ClientCertificateManagerDelegate: AnyObject {
-    // delegate should ask user for a decision on whether to import the client certificate into the keychain
+    /// delegate should ask user for a decision on whether to import the client certificate into the keychain
     func askForClientCertificateImport(_ clientCertificateManager: ClientCertificateManager?) async -> Bool
-    // delegate should ask user for a decision on whether to import the client certificate into the keychain
+    /// delegate should ask user for a decision on whether to import the client certificate into the keychain
     func askForCertificatePassword(_ clientCertificateManager: ClientCertificateManager?) async -> String?
-    // delegate should alert the user that an error occured importing the certificate
+    /// delegate should alert the user that an error occured importing the certificate
     func alertClientCertificateError(_ clientCertificateManager: ClientCertificateManager?, errMsg: String) async
 }
 
@@ -157,8 +157,7 @@ public class ClientCertificateManager {
 
             guard let delegate else { return false }
 
-            let shouldImport = await delegate.askForClientCertificateImport(self)
-            return shouldImport
+            return await delegate.askForClientCertificateImport(self)
         } catch {
             Logger.clientCert.error("Failed to read certificate from URL: \(error.localizedDescription)")
             return false

--- a/OpenHABCore/Sources/OpenHABCore/Util/Collection+SafeAccess.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Collection+SafeAccess.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 public extension Collection {
-    // Returns the element at the specified index if it is within bounds, otherwise nil.
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
     subscript(safe index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
     }

--- a/OpenHABCore/Sources/OpenHABCore/Util/Comparable.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Comparable.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-// Idea taken from https://twitter.com/alexiscreuzot/status/1635489793294454784?s=61&t=8ECwUy6QFS5UxjAFZzZ-hw
+/// Idea taken from https://twitter.com/alexiscreuzot/status/1635489793294454784?s=61&t=8ECwUy6QFS5UxjAFZzZ-hw
 public extension Comparable {
     func clamped(to limits: ClosedRange<Self>) -> Self {
         min(max(self, limits.lowerBound), limits.upperBound)

--- a/OpenHABCore/Sources/OpenHABCore/Util/ConnectionConfiguration.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ConnectionConfiguration.swift
@@ -19,7 +19,7 @@ public struct ConnectionPayload: Codable {
 public struct ConnectionConfiguration: Hashable, Sendable, Codable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case url, alwaysSendBasicAuth, ignoreSSL, supportsNotifications, priority, cloudUserId
-        // Legacy keys — decoded for migration from old JSON, never written
+        /// Legacy keys — decoded for migration from old JSON, never written
         case username, password
     }
 
@@ -42,8 +42,8 @@ public struct ConnectionConfiguration: Hashable, Sendable, Codable, Equatable {
         self.supportsNotifications = supportsNotifications
     }
 
-    // decodeIfPresent is used for every field that has a default so that stored data from older
-    // versions (missing those fields) decodes without throwing.
+    /// decodeIfPresent is used for every field that has a default so that stored data from older
+    /// versions (missing those fields) decodes without throwing.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let rawURL = try container.decode(String.self, forKey: .url)
@@ -58,7 +58,7 @@ public struct ConnectionConfiguration: Hashable, Sendable, Codable, Equatable {
         cloudUserId = try container.decodeIfPresent(String.self, forKey: .cloudUserId)
     }
 
-    // 🔹 Normalize a URL (removes trailing slashes, trims spaces, redirects openHAB cloud)
+    /// 🔹 Normalize a URL (removes trailing slashes, trims spaces, redirects openHAB cloud)
     private static func normalizeURL(_ url: String) -> String {
         var cleanedURL = url.trimmingCharacters(in: .whitespacesAndNewlines) // Trim whitespace
         cleanedURL = uriWithoutTrailingSlashes(cleanedURL) // Remove trailing slashes
@@ -115,7 +115,9 @@ extension ConnectionConfiguration {
 
 public extension ConnectionConfiguration {
     /// The host component of the connection URL, if parseable.
-    var host: String? { URL(string: url)?.host }
+    var host: String? {
+        URL(string: url)?.host
+    }
 
     /// URL suitable for diagnostics; credentials embedded in the URL are stripped.
     var publicLogURL: String {
@@ -134,7 +136,9 @@ public extension ConnectionConfiguration {
 
     /// Whether this connection is to an openHAB Cloud instance.
     /// Currently determined by the "openHAB Cloud Service" user preference (`supportsNotifications`).
-    var isCloudConnection: Bool { supportsNotifications }
+    var isCloudConnection: Bool {
+        supportsNotifications
+    }
 }
 
 extension ConnectionConfiguration: CustomStringConvertible {

--- a/OpenHABCore/Sources/OpenHABCore/Util/DateFormatterExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/DateFormatterExtension.swift
@@ -11,8 +11,8 @@
 
 import Foundation
 
-// Custom DateFormatter to handle fractional seconds
-// Inspired by https://useyourloaf.com/blog/swift-codable-with-custom-dates/
+/// Custom DateFormatter to handle fractional seconds
+/// Inspired by https://useyourloaf.com/blog/swift-codable-with-custom-dates/
 public extension DateFormatter {
     static let iso8601Full: DateFormatter = {
         let formatter = DateFormatter()

--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
@@ -29,7 +29,7 @@ public actor ETagChecker {
         cache = ETagCache.shared
     }
 
-    // Internal initializer for testing - allows cache injection
+    /// Internal initializer for testing - allows cache injection
     init(httpClient: HTTPClient, cache: ETagCache) {
         self.httpClient = httpClient
         self.cache = cache

--- a/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
@@ -22,7 +22,9 @@ public enum IconType: Int, CaseIterable, Identifiable, CustomStringConvertible, 
     case png
     case svg
 
-    public var id: Self { self }
+    public var id: Self {
+        self
+    }
 
     public var description: String {
         switch self {
@@ -59,9 +61,8 @@ public extension Endpoint {
         var components = URLComponents(string: baseURL)
         components?.path = path
         components?.queryItems = queryItems
-        let url = components?.url
+        return components?.url
 //        Logger.endpoint.debug("URL: \(url?.absoluteString ?? "", privacy: .private)")
-        return url
     }
 
     static func appleRegistration(prefsURL: String,

--- a/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/HTTPClient.swift
@@ -248,7 +248,7 @@ public final class HTTPClient: NSObject, Sendable {
         case mjpegStream
     }
 
-    // this can be changed if we detect another server
+    /// this can be changed if we detect another server
     public let baseURL: URL?
 
     private let connectionConfiguration: ConnectionConfiguration
@@ -336,7 +336,7 @@ public final class HTTPClient: NSObject, Sendable {
         return codingDatas.map(\.openHABNotification)
     }
 
-    /**
+    /* 
       Initiates a download request to a specified base URL for a specified path and returns the file URL via a completion handler.
 
       - Parameters:

--- a/OpenHABCore/Sources/OpenHABCore/Util/HTTPClientDelegate.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/HTTPClientDelegate.swift
@@ -54,14 +54,11 @@ public final class HTTPClientDelegate: NSObject, URLSessionDelegate, URLSessionT
         }
         switch authenticationMethod {
         case NSURLAuthenticationMethodServerTrust:
-            let result = await handleServerTrust(challenge: challenge)
-            return result
+            return await handleServerTrust(challenge: challenge)
         case NSURLAuthenticationMethodDefault, NSURLAuthenticationMethodHTTPBasic:
-            let result = await handleBasicAuth(challenge: challenge)
-            return result
+            return await handleBasicAuth(challenge: challenge)
         case NSURLAuthenticationMethodClientCertificate:
-            let result = await handleClientCertificateAuth(challenge: challenge)
-            return result
+            return await handleClientCertificateAuth(challenge: challenge)
         default:
             return (.performDefaultHandling, nil)
         }

--- a/OpenHABCore/Sources/OpenHABCore/Util/ItemEventStream.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ItemEventStream.swift
@@ -15,7 +15,7 @@ import OpenAPIRuntime
 import OpenAPIURLSession
 import OSLog
 
-/**
+/* 
  Example usage:
 
  ```
@@ -47,14 +47,16 @@ public enum StateStreamMessage: Sendable, Equatable {
 }
 
 public actor EventStream<Event: Sendable> {
-    // Alive and Item State Chnage message structures
+    /// Alive and Item State Chnage message structures
     private struct Alive: Decodable { let type: String; let interval: Int }
-    // Multiple items can come in a single message which makes this a little more complicated
+    /// Multiple items can come in a single message which makes this a little more complicated
     private struct ItemStateChanges: Decodable {
         struct Value: Decodable { let state: String }
 
         let wrapped: [String: Value]
-        var first: (String, Value)? { wrapped.first }
+        var first: (String, Value)? {
+            wrapped.first
+        }
 
         init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
@@ -93,7 +95,7 @@ public actor EventStream<Event: Sendable> {
         continuations.removeValue(forKey: id)
     }
 
-    // NetworkManager callback
+    /// NetworkManager callback
     private func updateConnection(_ info: ConnectionInfo?) {
         let newConfig = info?.configuration
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
@@ -12,7 +12,6 @@
 // Inspired by https://www.avanderlee.com/debugging/oslog-unified-logging/
 
 import Foundation
-
 import os.log
 
 public extension Logger {

--- a/OpenHABCore/Sources/OpenHABCore/Util/NWPathMonitoring.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NWPathMonitoring.swift
@@ -13,7 +13,7 @@ import Foundation
 import Network
 import os.log
 
-// Wrap real NWPathMonitor
+/// Wrap real NWPathMonitor
 final class RealPathMonitor: NWPathMonitoring, Sendable {
     private let monitor: NWPathMonitor
 
@@ -50,8 +50,8 @@ public protocol NWPathMonitoring: AnyObject, Sendable {
 
 // MARK: Extension for version iOS <17
 
-// this line breaks availability checking, since watchos 10 is minimum for the app
-// @available(watchOS, obsoleted: 10.0)
+/// this line breaks availability checking, since watchos 10 is minimum for the app
+/// @available(watchOS, obsoleted: 10.0)
 @available(iOS, obsoleted: 17.0)
 extension NWPathMonitor {
     func paths() -> AsyncStream<NWPath> {

--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -29,7 +29,7 @@ public struct ConnectionInfo: Equatable, Sendable {
     public let version: Int
     public let proxyURL: URL?
 
-    // Explicit public memberwise initializer
+    /// Explicit public memberwise initializer
     public init(configuration: ConnectionConfiguration, version: Int, proxyURL: URL? = nil) {
         self.configuration = configuration
         self.version = version
@@ -51,14 +51,14 @@ public enum NetworkTrackerError: Error, CustomDebugStringConvertible, Sendable {
     }
 }
 
-// Prevent race conditions.
-// Ensure thread-safe dictionary access.
-// Avoid memory corruption errors like unrecognized selector.
+/// Prevent race conditions.
+/// Ensure thread-safe dictionary access.
+/// Avoid memory corruption errors like unrecognized selector.
 public actor ConnectionPool {
     private var services: [ConnectionConfiguration: any OpenAPIServiceProtocol] = [:]
     private let serviceFactory: @Sendable (ConnectionConfiguration) throws -> any OpenAPIServiceProtocol
 
-    // Initializer allowing the injection of mocked OpenAPIServiceProtocol
+    /// Initializer allowing the injection of mocked OpenAPIServiceProtocol
     init(serviceFactory: @escaping @Sendable (ConnectionConfiguration) throws -> any OpenAPIServiceProtocol = {
         try OpenAPIService(connectionConfiguration: $0, serviceConfiguration: .shortTerm)
     }) {
@@ -77,7 +77,7 @@ public actor ConnectionPool {
     }
 }
 
-// Ensures a thread safe access to failureCounts dictionary
+/// Ensures a thread safe access to failureCounts dictionary
 public actor ConnectionFailureTracker {
     private var enabled = false
     private var failureCounts: [ConnectionConfiguration: Int] = [:]
@@ -270,7 +270,7 @@ public actor NetworkTracker {
         }
     }
 
-    // like startTracking but with the already configured connections and a fresh approach
+    /// like startTracking but with the already configured connections and a fresh approach
     public func restartTracking() async {
         Logger.networkTracker.debug("Networktracker: restartTracking")
         await failureTracker.resetAll() // just to make sure a few more connection attempts happen if necessary
@@ -280,7 +280,7 @@ public actor NetworkTracker {
         await startTracking(connectionConfigurations: connectionConfigurations)
     }
 
-    // This gets called periodically when we have an active connection to make sure it's still the best choice
+    /// This gets called periodically when we have an active connection to make sure it's still the best choice
     private func checkActiveConnection() async {
         guard status != .stopped else {
             return
@@ -603,10 +603,10 @@ public extension NetworkTracker {
         return service
     }
 
-    // Retries once after revalidating the connection on two transient failure kinds:
-    //  • ClientError  — transport failure against a stale connection (network switch, suspension)
-    //  • noActiveConnection — all connection tests timed out during a network handoff; the
-    //    tracker recovers shortly after, so one revalidation + retry is enough.
+    /// Retries once after revalidating the connection on two transient failure kinds:
+    ///  • ClientError  — transport failure against a stale connection (network switch, suspension)
+    ///  • noActiveConnection — all connection tests timed out during a network handoff; the
+    ///    tracker recovers shortly after, so one revalidation + retry is enough.
     private func withClientErrorRetry<T>(_ operation: () async throws -> T) async throws -> T {
         do {
             return try await operation()

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
@@ -35,25 +35,23 @@ protocol OpenAPIServiceProtocol: AnyObject, Sendable {
     func sendItemCommand(itemname: String, command: String, sourcePrefix: String?, deviceId: String?) async throws
     func updateItemState(itemname: String, with: String, sourcePrefix: String?, deviceId: String?) async throws
     func getItems() async throws -> [OpenHABItem]
-    func getItems(
-        query: Operations.getItems.Input.Query
-    ) async throws -> [OpenHABItem]
+    func getItems(query: Operations.getItems.Input.Query) async throws -> [OpenHABItem]
     func getItemByName(id: String) async throws -> OpenHABItem?
     func pollDataForPage(sitemapname: String, pageId: String, longPolling: Bool) async throws -> OpenHABPage?
     func runNow(ruleUID: String, payload: [String: any Sendable]) async throws
 }
 
-// The generated OpenAPI client is wrapped by this curated API.
-// The library leaks the fact that it uses Swift OpenAPI Generator under the hood in 'openHABSitemapWidgetEvents'.
-// It will require the migration to Swift 6.1 before this can be changed.
+/// The generated OpenAPI client is wrapped by this curated API.
+/// The library leaks the fact that it uses Swift OpenAPI Generator under the hood in 'openHABSitemapWidgetEvents'.
+/// It will require the migration to Swift 6.1 before this can be changed.
 public actor OpenAPIService {
     private var client: any APIProtocol
     private var url: URL?
     private var longPolling = false
     private var connectionConfiguration: ConnectionConfiguration
-    // Retained for lifecycle control only — URLSessionTransport does not call invalidateAndCancel()
-    // when it deallocates, so without this reference the session's threads and sockets would leak.
-    // Do not remove: deinit relies on this property to tear down the session.
+    /// Retained for lifecycle control only — URLSessionTransport does not call invalidateAndCancel()
+    /// when it deallocates, so without this reference the session's threads and sockets would leak.
+    /// Do not remove: deinit relies on this property to tear down the session.
     private var urlSession: URLSession?
 
     /// Creates a new client for OpenAPIService.
@@ -110,10 +108,9 @@ public actor OpenAPIService {
     }
 
     private func prepareURLSessionConfiguration(longPolling: Bool) -> URLSessionConfiguration {
-        let config = URLSessionConfiguration.default
+        URLSessionConfiguration.default
 //        config.timeoutIntervalForRequest = if longPolling { 35.0 } else { 20.0 }
 //        config.timeoutIntervalForResource = config.timeoutIntervalForRequest + 25
-        return config
     }
 
     private func sourceComponent(deviceId: String?) -> String? {
@@ -206,7 +203,8 @@ public extension OpenAPIService {
     func runNow(ruleUID: String, payload: [String: any Sendable]) async throws {
         let path = Operations.runRuleNow_1.Input.Path(ruleUID: ruleUID)
         let jsonPayload = try Operations.runRuleNow_1.Input.Body.jsonPayload(
-            additionalProperties: OpenAPIObjectContainer(unvalidatedValue: payload))
+            additionalProperties: OpenAPIObjectContainer(unvalidatedValue: payload)
+        )
         _ = try await client.runRuleNow_1(
             path: path,
             body: .json(jsonPayload)
@@ -234,7 +232,9 @@ public extension OpenAPIService {
                 _next = { try await it.next() }
             }
 
-            public mutating func next() async throws -> Element? { try await _next() }
+            public mutating func next() async throws -> Element? {
+                try await _next()
+            }
         }
 
         public let _make: () -> Iterator
@@ -243,10 +243,12 @@ public extension OpenAPIService {
             _make = { Iterator(base) }
         }
 
-        public func makeAsyncIterator() -> Iterator { _make() }
+        public func makeAsyncIterator() -> Iterator {
+            _make()
+        }
     }
 
-    // Returns subscription id or nil
+    /// Returns subscription id or nil
     func openHABcreateSubscription() async throws -> String? {
         Logger.openAPIService.info("Creating subscription")
         let result = try await client.createSitemapEventSubscription()
@@ -282,7 +284,7 @@ public extension OpenAPIService {
 }
 
 public extension OpenAPIService {
-    // Internal function for pollPage
+    /// Internal function for pollPage
     internal func pollDataForPage(path: Operations.pollDataForPage.Input.Path,
                                   query: Operations.pollDataForPage.Input.Query = .init(),
                                   headers: Operations.pollDataForPage.Input.Headers) async throws -> OpenHABPage? {
@@ -320,7 +322,7 @@ public extension OpenAPIService {
         return try await pollDataForPage(path: path, headers: headers)
     }
 
-    // Internal function for pollSitemap
+    /// Internal function for pollSitemap
     internal func pollDataForSitemap(path: Operations.pollDataForSitemap.Input.Path,
                                      query: Operations.pollDataForSitemap.Input.Query = .init(),
                                      headers: Operations.pollDataForSitemap.Input.Headers) async throws -> OpenHABSitemap? {
@@ -330,11 +332,9 @@ public extension OpenAPIService {
     }
 }
 
-// Array of items
+/// Array of items
 public extension OpenAPIService {
-    func getItems(
-        query: Operations.getItems.Input.Query
-    ) async throws -> [OpenHABItem] {
+    func getItems(query: Operations.getItems.Input.Query) async throws -> [OpenHABItem] {
         try await client.getItems(query: query)
             .ok.body.json
             .compactMap(OpenHABItem.init)

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABImageProcessor.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABImageProcessor.swift
@@ -231,7 +231,7 @@ public struct OpenHABImageProcessor: ImageProcessor {
         process(item: .data(data), options: KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions))
     }
 
-    // Convert input data/image to target image and return it.
+    /// Convert input data/image to target image and return it.
     public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         switch item {
         case let .image(image):

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -147,9 +147,9 @@ public actor OpenHABItemCache {
 
     public static let instance = OpenHABItemCache()
 
-    // Per-home trackers are created fresh each session (cold-start cost on first use).
-    // 10 s matches NetworkTracker.shared and is enough to survive a typical cellular
-    // handoff (~7 s in practice) without failing with noActiveConnection.
+    /// Per-home trackers are created fresh each session (cold-start cost on first use).
+    /// 10 s matches NetworkTracker.shared and is enough to survive a typical cellular
+    /// handoff (~7 s in practice) without failing with noActiveConnection.
     private static let networkTimeout: TimeInterval = 10
 
     private static let stubsDefaultsKey = "openHABItemStubs"

--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -108,11 +108,11 @@ public struct HomePreferences: Codable, Equatable {
         self.id = id
     }
 
-    // Custom decoder so that stored data from older app versions that are missing
-    // fields added later (e.g. alwaysAllowWebRTC, defaultMainUIPath, siteMapForWatchLabel)
-    // still decodes successfully. Without this, synthesized Codable requires every field
-    // to be present and silently falls back to the struct default via `try?` in
-    // UserDefaultObject — resetting homeName to "Home#1" for those users.
+    /// Custom decoder so that stored data from older app versions that are missing
+    /// fields added later (e.g. alwaysAllowWebRTC, defaultMainUIPath, siteMapForWatchLabel)
+    /// still decodes successfully. Without this, synthesized Codable requires every field
+    /// to be present and silently falls back to the struct default via `try?` in
+    /// UserDefaultObject — resetting homeName to "Home#1" for those users.
     public nonisolated init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
@@ -355,12 +355,11 @@ public extension Preferences {
 @MainActor
 public extension Preferences {
     func listStoredHomes() -> [UUID] {
-        let preferenceIds = storedHomes
+        storedHomes
             .sorted { e1, e2 in
                 e1.value.homeName <= e2.value.homeName
             }
             .map(\.key)
-        return preferenceIds
     }
 
     func createAndLoadNewStoredSettings(homeName: String) {
@@ -611,7 +610,7 @@ public extension Preferences {
         getNotificationConnection(of: [homeConfig.remoteConnectionConfig])
     }
 
-    // this will support mutliple connection configs, right now we just pass in the remote config
+    /// this will support mutliple connection configs, right now we just pass in the remote config
     func getNotificationConnection(of connections: [ConnectionConfiguration?]) -> ConnectionConfiguration? {
         connections
             .compactMap(\.self)

--- a/OpenHABCore/Sources/OpenHABCore/Util/ServerCertificateManager.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ServerCertificateManager.swift
@@ -14,11 +14,11 @@ import os.log
 
 @MainActor
 public protocol ServerCertificateManagerDelegate: AnyObject, Sendable {
-    // delegate should ask user for a decision on what to do with invalid certificate
+    /// delegate should ask user for a decision on what to do with invalid certificate
     func evaluateServerTrust(summary certificateSummary: String?, forDomain domain: String?) async -> ServerCertificateManager.EvaluateResult
-    // certificate received from openHAB doesn't match our record, ask user for a decision
+    /// certificate received from openHAB doesn't match our record, ask user for a decision
     func evaluateCertificateMismatch(summary certificateSummary: String?, forDomain domain: String?) async -> ServerCertificateManager.EvaluateResult
-    // notify delegate that the certificagtes that a user is willing to trust has changed
+    /// notify delegate that the certificagtes that a user is willing to trust has changed
     func acceptedServerCertificatesChanged() async
 }
 
@@ -28,7 +28,7 @@ enum ServerCertificateManagerError: Error {
 
 @MainActor
 public final class ServerCertificateManager {
-    // Handle the different responses of the user
+    /// Handle the different responses of the user
     public enum EvaluateResult: Sendable {
         case undecided
         case deny
@@ -37,10 +37,10 @@ public final class ServerCertificateManager {
     }
 
     public weak var delegate: (any ServerCertificateManagerDelegate)?
-    // ignoreSSL is a synonym for allowInvalidCertificates, ignoreCertificates
+    /// ignoreSSL is a synonym for allowInvalidCertificates, ignoreCertificates
     public var ignoreSSL = false
 
-    // Init a ServerCertificateManager and set ignore certificates setting
+    /// Init a ServerCertificateManager and set ignore certificates setting
     public init(ignoreSSL: Bool = false) {
         self.ignoreSSL = ignoreSSL
         Logger.serverCert.info("Initializing cert manager, delegating to CertificateStore")
@@ -78,8 +78,8 @@ public final class ServerCertificateManager {
         return result
     }
 
-    // Evaluates trust received during SSL negotiation and checks it against known ones,
-    // against policy setting to ignore certificate errors and so on.
+    /// Evaluates trust received during SSL negotiation and checks it against known ones,
+    /// against policy setting to ignore certificate errors and so on.
     public func evaluate(_ serverTrust: SecTrust, forHost domain: String) async throws {
         let evaluateResult = wrapperSecTrustEvaluate(serverTrust: serverTrust)
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/StringExtension.swift
@@ -57,8 +57,8 @@ public extension String {
         URL(string: self) == URL(string: self)?.absoluteURL
     }
 
-    // Sub-view gape title optionally concatenated with one space and value if present - to be inline with Nsic UI
-    // e.g. "Living Room [21°C]" → "Living Room 21°C"
+    /// Sub-view gape title optionally concatenated with one space and value if present - to be inline with Nsic UI
+    /// e.g. "Living Room [21°C]" → "Living Room 21°C"
     var labelValueTitle: String {
         // Base text before the first “[”
         let base = components(separatedBy: "[")[0]

--- a/OpenHABCore/Sources/OpenHABCore/Util/UIColorExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/UIColorExtension.swift
@@ -30,7 +30,7 @@ public enum OHInterfaceStyle: Int {
 }
 
 public extension UIColor {
-    // system colors
+    /// system colors
     class var ohLabel: UIColor {
         #if os(iOS)
         if #available(iOS 13.0, *) {
@@ -82,7 +82,7 @@ public extension UIColor {
         return .white
     }
 
-    // standard colors
+    /// standard colors
     class var ohMaroon: UIColor {
         OHInterfaceStyle.current == .light ? UIColor(hex: "#800000") : UIColor(hex: "#800000")
     }

--- a/OpenHABCore/Tests/OpenHABCoreTests/CertificateStoreTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/CertificateStoreTests.swift
@@ -22,7 +22,7 @@ enum CertificateStoreTestError: Error {
 
 @Suite("CertificateStore Tests", .serialized)
 struct CertificateStoreTests {
-    // Helper to load the bundled test certificate data
+    /// Helper to load the bundled test certificate data
     func loadTestCertificateData() throws -> Data {
         guard let certURL = Bundle.module.url(forResource: "test-cert", withExtension: "cer") else {
             throw CertificateStoreTestError.resourceNotFound("test-cert.cer")
@@ -30,12 +30,12 @@ struct CertificateStoreTests {
         return try Data(contentsOf: certURL)
     }
 
-    // Helper to create a fresh in-memory store for isolated testing
+    /// Helper to create a fresh in-memory store for isolated testing
     func makeInMemoryStore() -> CertificateStore {
         CertificateStore(persistencePath: nil)
     }
 
-    // Helper to create a unique temporary path for persistence tests
+    /// Helper to create a unique temporary path for persistence tests
     func makeTempPersistencePath() -> URL {
         let tempDir = FileManager.default.temporaryDirectory
         let uniqueID = UUID().uuidString
@@ -57,7 +57,7 @@ struct CertificateStoreTests {
         let info = await store.getCertificateInfo(forDomain: domain)
         #expect(info != nil)
         #expect(info?.data == data)
-        #expect(info!.dateAccepted.timeIntervalSinceNow > -5) // stored just now
+        #expect(try #require(info?.dateAccepted.timeIntervalSinceNow) > -5) // stored just now
     }
 
     @Test("Overwrite existing certificate updates data and date", .timeLimit(.minutes(1)))
@@ -69,7 +69,7 @@ struct CertificateStoreTests {
         await store.storeCertificateData(first, forDomain: domain)
         let firstInfo = await store.getCertificateInfo(forDomain: domain)
         #expect(firstInfo != nil)
-        let firstDate = firstInfo!.dateAccepted
+        let firstDate = try #require(firstInfo?.dateAccepted)
 
         // Overwrite with new data
         let second = Data([0x0A, 0x0B])
@@ -77,12 +77,12 @@ struct CertificateStoreTests {
 
         let info = await store.getCertificateInfo(forDomain: domain)
         #expect(info != nil)
-        #expect(info!.data == second)
-        #expect(info!.dateAccepted >= firstDate)
+        #expect(info?.data == second)
+        #expect(try #require(info?.dateAccepted) >= firstDate)
     }
 
     @Test("Remove certificate clears entry", .timeLimit(.minutes(1)))
-    func removeClears() async throws {
+    func removeClears() async {
         let domain = "remove-test.openhab.org"
         let store = makeInMemoryStore()
 
@@ -98,7 +98,7 @@ struct CertificateStoreTests {
     }
 
     @Test("Store nil removes certificate", .timeLimit(.minutes(1)))
-    func storeNilRemoves() async throws {
+    func storeNilRemoves() async {
         let domain = "nil-remove-test.openhab.org"
         let store = makeInMemoryStore()
 
@@ -111,7 +111,7 @@ struct CertificateStoreTests {
     }
 
     @Test("Get all certificates returns expected entries", .timeLimit(.minutes(1)))
-    func getAllCertificates() async throws {
+    func getAllCertificates() async {
         let domainA = "list-a-test.openhab.org"
         let domainB = "list-b-test.openhab.org"
         let store = makeInMemoryStore()
@@ -129,7 +129,7 @@ struct CertificateStoreTests {
     }
 
     @Test("Persistence across instances", .timeLimit(.minutes(1)))
-    func persistenceAcrossInstances() async throws {
+    func persistenceAcrossInstances() async {
         let domain = "persistence-test.openhab.org"
         let tempPath = makeTempPersistencePath()
 

--- a/OpenHABCore/Tests/OpenHABCoreTests/ClientCertificateManagerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ClientCertificateManagerTests.swift
@@ -56,7 +56,7 @@ struct ClientCertificateManagerTests {
         #expect(!result)
     }
 
-    @Test func startImportCertificateReturnsTrueIfDelegateApproves() async throws {
+    @Test func startImportCertificateReturnsTrueIfDelegateApproves() async {
         guard let url = Bundle.module.url(forResource: "test", withExtension: "p12") else {
             Issue.record("Test PKCS#12 file not found.")
             return

--- a/OpenHABCore/Tests/OpenHABCoreTests/CredentialsStoreTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/CredentialsStoreTests.swift
@@ -12,9 +12,9 @@
 @testable import OpenHABCore
 import Testing
 
-// These tests require the openHAB app as the test host so the xctest process inherits
-// the keychain-access-groups entitlement. Without it SecItemAdd returns errSecMissingEntitlement
-// and all store/retrieve tests fail. Configure the test scheme to use openHAB.app as the host.
+/// These tests require the openHAB app as the test host so the xctest process inherits
+/// the keychain-access-groups entitlement. Without it SecItemAdd returns errSecMissingEntitlement
+/// and all store/retrieve tests fail. Configure the test scheme to use openHAB.app as the host.
 @Suite("CredentialsStore Tests", .serialized, .disabled("Requires openHAB.app test host for Keychain entitlement"))
 struct CredentialsStoreTests {
     private let homeId = UUID()

--- a/OpenHABCore/Tests/OpenHABCoreTests/DateFormattingTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/DateFormattingTests.swift
@@ -20,7 +20,7 @@ private struct TimestampModel: Decodable {
 struct DateFormattingTests {
     // MARK: - ISO8601 Date Parsing Tests
 
-    @Test func iSO8601DateParsingWithFractionalSeconds() throws {
+    @Test func iSO8601DateParsingWithFractionalSeconds() {
         let dateString = "2025-12-21T10:30:45.123+00:00"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date != nil)
@@ -39,37 +39,37 @@ struct DateFormattingTests {
         #expect(model2.timestamp.timeIntervalSince1970 > 0)
     }
 
-    @Test func iSO8601DateParsingWithZuluTimeZone() throws {
+    @Test func iSO8601DateParsingWithZuluTimeZone() {
         let dateString = "2025-12-21T10:30:45.123Z"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date != nil)
     }
 
-    @Test func iSO8601DateParsingWithPositiveTimeZone() throws {
+    @Test func iSO8601DateParsingWithPositiveTimeZone() {
         let dateString = "2025-12-21T10:30:45.123+05:30"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date != nil)
     }
 
-    @Test func iSO8601DateParsingWithNegativeTimeZone() throws {
+    @Test func iSO8601DateParsingWithNegativeTimeZone() {
         let dateString = "2025-12-21T10:30:45.123-08:00"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date != nil)
     }
 
-    @Test func iSO8601DateParsingWithMilliseconds() throws {
+    @Test func iSO8601DateParsingWithMilliseconds() {
         let dateString = "2025-12-21T10:30:45.999+00:00"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date != nil)
     }
 
-    @Test func iSO8601DateParsingWithInvalidFormat() throws {
+    @Test func iSO8601DateParsingWithInvalidFormat() {
         let dateString = "not a date"
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date == nil)
     }
 
-    @Test func iSO8601DateParsingWithEmptyString() throws {
+    @Test func iSO8601DateParsingWithEmptyString() {
         let dateString = ""
         let date = try? Date(dateString, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
         #expect(date == nil)
@@ -77,7 +77,7 @@ struct DateFormattingTests {
 
     // MARK: - ISO8601 Date Formatting Tests
 
-    @Test func iSO8601DateFormattingWithFractionalSeconds() throws {
+    @Test func iSO8601DateFormattingWithFractionalSeconds() {
         // Create a date with a known value
         let calendar = Calendar(identifier: .gregorian)
         var components = DateComponents()
@@ -103,7 +103,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("10:30:45"))
     }
 
-    @Test func iSO8601DateRoundTrip() throws {
+    @Test func iSO8601DateRoundTrip() {
         // Test that formatting and parsing a date produces the same value (within millisecond precision)
         let calendar = Calendar(identifier: .gregorian)
         var components = DateComponents()
@@ -171,7 +171,7 @@ struct DateFormattingTests {
 
     @Test func dateTimeFormattingWithHourMinuteSecond() throws {
         var calendar = Calendar(identifier: .gregorian)
-        let tz = TimeZone(secondsFromGMT: 0)! // deterministic on CI
+        let tz = try #require(TimeZone(secondsFromGMT: 0)) // deterministic on CI
         calendar.timeZone = tz
 
         var components = DateComponents()
@@ -197,7 +197,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("T14:30:45"))
     }
 
-    @Test func dateFormattingAbbreviated() throws {
+    @Test func dateFormattingAbbreviated() {
         let calendar = Calendar(identifier: .gregorian)
         var components = DateComponents()
         components.year = 2025
@@ -216,7 +216,7 @@ struct DateFormattingTests {
         #expect(!formatted.isEmpty)
     }
 
-    @Test func dateFormattingTimeOmitted() throws {
+    @Test func dateFormattingTimeOmitted() {
         let calendar = Calendar(identifier: .gregorian)
         var components = DateComponents()
         components.year = 2025
@@ -238,7 +238,7 @@ struct DateFormattingTests {
 
     // MARK: - Log Date Format Tests (en_US_POSIX)
 
-    @Test func logDateFormattingWithPOSIXLocale() throws {
+    @Test func logDateFormattingWithPOSIXLocale() {
         // Test date formatting with en_US_POSIX locale for consistent log output
         let date = Date()
 
@@ -261,7 +261,7 @@ struct DateFormattingTests {
         #expect(formatted.count > 15)
     }
 
-    @Test func logDateFormattingWithSingleDigitsPOSIXLocale() throws {
+    @Test func logDateFormattingWithSingleDigitsPOSIXLocale() {
         // Test with single digit month/day to verify two-digit padding
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -294,7 +294,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("2025"))
     }
 
-    @Test func logDateFormattingConsistencyWithPOSIXLocale() throws {
+    @Test func logDateFormattingConsistencyWithPOSIXLocale() {
         // Verify that en_US_POSIX locale produces consistent, non-localized output
         let date1 = Date()
         let date2 = Date()
@@ -330,7 +330,7 @@ struct DateFormattingTests {
 
     // MARK: - Screen Saver Time Format Tests
 
-    @Test func screenSaverTime24HourFormatWithLeadingZeros() throws {
+    @Test func screenSaverTime24HourFormatWithLeadingZeros() {
         // Test 24-hour format with leading zeros for screen saver
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -356,7 +356,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("03"))
     }
 
-    @Test func screenSaverTime12HourFormatNaturalStyle() throws {
+    @Test func screenSaverTime12HourFormatNaturalStyle() {
         // Test 12-hour format with natural style (no leading zero for hours)
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -379,7 +379,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("05")) // Minutes should be padded
     }
 
-    @Test func screenSaverTimeMidnightFormat() throws {
+    @Test func screenSaverTimeMidnightFormat() {
         // Test midnight (00:00:00) with 24-hour format
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -403,7 +403,7 @@ struct DateFormattingTests {
         #expect(formatted.contains("00"))
     }
 
-    @Test func screenSaverTimeWithoutSeconds() throws {
+    @Test func screenSaverTimeWithoutSeconds() {
         // Test time format without seconds (HH:mm) - verify format structure
         let date = Date()
 
@@ -420,7 +420,7 @@ struct DateFormattingTests {
         #expect(formatted.count >= 5)
     }
 
-    @Test func screenSaverTime24HourVs12HourFormatting() throws {
+    @Test func screenSaverTime24HourVs12HourFormatting() {
         // Test the difference between 24-hour and 12-hour formatting
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -458,7 +458,7 @@ struct DateFormattingTests {
 
     // MARK: - Notification Timestamp Format Tests
 
-    @Test func notificationTimestampWithLongDateStandardTime() throws {
+    @Test func notificationTimestampWithLongDateStandardTime() {
         // Test notification format with long date and standard time (closest to original DateFormatter medium)
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -482,7 +482,7 @@ struct DateFormattingTests {
         // Exact format depends on locale, but should contain all components
     }
 
-    @Test func notificationTimestampIncludesSeconds() throws {
+    @Test func notificationTimestampIncludesSeconds() {
         // Verify that standard time format includes seconds (unlike shortened)
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()
@@ -503,7 +503,7 @@ struct DateFormattingTests {
         #expect(standardFormat.count >= shortenedFormat.count)
     }
 
-    @Test func notificationTimestampConsistentFormat() throws {
+    @Test func notificationTimestampConsistentFormat() {
         // Test that notification timestamps are formatted consistently
         let calendar = Calendar(identifier: .gregorian)
         var dateComponents = DateComponents()

--- a/OpenHABCore/Tests/OpenHABCoreTests/DoubleExtensionTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/DoubleExtensionTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 struct DoubleExtensionTests {
     @Test
-    func valueTextWithNoDecimalPlaces() throws {
+    func valueTextWithNoDecimalPlaces() {
         let value = 42.0
         let step = 1.0
         let result = value.valueText(step: step)
@@ -22,7 +22,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithOneDecimalPlace() throws {
+    func valueTextWithOneDecimalPlace() {
         let value = 42.5
         let step = 0.1
         let result = value.valueText(step: step)
@@ -30,7 +30,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithTwoDecimalPlaces() throws {
+    func valueTextWithTwoDecimalPlaces() {
         let value = 42.75
         let step = 0.01
         let result = value.valueText(step: step)
@@ -38,7 +38,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithThreeDecimalPlaces() throws {
+    func valueTextWithThreeDecimalPlaces() {
         let value = 3.142
         let step = 0.001
         let result = value.valueText(step: step)
@@ -46,7 +46,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextRoundsToStepPrecision() throws {
+    func valueTextRoundsToStepPrecision() {
         let value = 3.14159
         let step = 0.01
         let result = value.valueText(step: step)
@@ -54,7 +54,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithZeroValue() throws {
+    func valueTextWithZeroValue() {
         let value = 0.0
         let step = 0.1
         let result = value.valueText(step: step)
@@ -62,7 +62,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithNegativeValue() throws {
+    func valueTextWithNegativeValue() {
         let value = -42.5
         let step = 0.1
         let result = value.valueText(step: step)
@@ -70,7 +70,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithVerySmallStep() throws {
+    func valueTextWithVerySmallStep() {
         let value = 1.23456789
         let step = 0.00001
         let result = value.valueText(step: step)
@@ -78,7 +78,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextPadsTrailingZeros() throws {
+    func valueTextPadsTrailingZeros() {
         let value = 42.0
         let step = 0.01
         let result = value.valueText(step: step)
@@ -86,7 +86,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextWithLargeValue() throws {
+    func valueTextWithLargeValue() {
         let value = 12345.67
         let step = 0.1
         let result = value.valueText(step: step)
@@ -94,7 +94,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextUsesDecimalPoint() throws {
+    func valueTextUsesDecimalPoint() {
         let value = 1234.5
         let step = 0.1
         let result = value.valueText(step: step)
@@ -103,7 +103,7 @@ struct DoubleExtensionTests {
     }
 
     @Test
-    func valueTextNoThousandsSeparator() throws {
+    func valueTextNoThousandsSeparator() {
         let value = 1_000_000.0
         let step = 1.0
         let result = value.valueText(step: step)

--- a/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
@@ -83,7 +83,7 @@ struct ETagCheckerTests {
     func firstRunStoresETag() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/index.html")!
+        let testURL = try #require(URL(string: "https://example.com/index.html"))
         let etagValue = "\"abc123\""
 
         // Setup mock
@@ -111,7 +111,7 @@ struct ETagCheckerTests {
     func unchangedWhenETagMatches() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/data.json")!
+        let testURL = try #require(URL(string: "https://example.com/data.json"))
         let etagValue = "\"def456\""
 
         // Pre-populate cache
@@ -136,7 +136,7 @@ struct ETagCheckerTests {
     func changedWhenETagDiffers() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/api/v1/data")!
+        let testURL = try #require(URL(string: "https://example.com/api/v1/data"))
         let oldETag = "\"old123\""
         let newETag = "\"new456\""
 
@@ -166,7 +166,7 @@ struct ETagCheckerTests {
     func failedOnNetworkError() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/fail")!
+        let testURL = try #require(URL(string: "https://example.com/fail"))
 
         // Configure mock to fail
         MockURLProtocol.shouldFail = true
@@ -188,7 +188,7 @@ struct ETagCheckerTests {
     func changedWhenNoETagHeader() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/no-etag")!
+        let testURL = try #require(URL(string: "https://example.com/no-etag"))
 
         // Mock response without ETag header
         MockURLProtocol.mockResponses[testURL] = (200, [:])
@@ -209,7 +209,7 @@ struct ETagCheckerTests {
     func normalizesQuotedETags() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/normalize")!
+        let testURL = try #require(URL(string: "https://example.com/normalize"))
         let quotedETag = "\"abc123\""
         let unquotedETag = "abc123"
 
@@ -236,7 +236,7 @@ struct ETagCheckerTests {
     func caseInsensitiveETagHeader() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/case-test")!
+        let testURL = try #require(URL(string: "https://example.com/case-test"))
         let etagValue = "\"xyz789\""
 
         // Mock with lowercase "etag" (not "ETag")
@@ -262,7 +262,7 @@ struct ETagCheckerTests {
     func weakETagsSupported() async throws {
         MockURLProtocol.reset()
 
-        let testURL = URL(string: "https://example.com/weak-etag")!
+        let testURL = try #require(URL(string: "https://example.com/weak-etag"))
         let weakETag = "W/\"abc123\""
 
         // Store weak ETag

--- a/OpenHABCore/Tests/OpenHABCoreTests/EndpointTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/EndpointTests.swift
@@ -106,7 +106,7 @@ struct EndpointTests {
     }
 
     @Test
-    func emptyIconReturnsNilEndpoint() throws {
+    func emptyIconReturnsNilEndpoint() {
         let result = Endpoint.icon(
             rootUrl: "https://example.org",
             version: 3,
@@ -233,7 +233,7 @@ struct EndpointTests {
     }
 
     @Test
-    func classicNumberIconReturnsNil() throws {
+    func classicNumberIconReturnsNil() {
         let result = Endpoint.icon(
             rootUrl: "https://example.org",
             version: 4,
@@ -251,8 +251,8 @@ struct EndpointTests {
 //                "oh:classic:light" to "icon/light?format=PNG&anyFormat=true&iconset=classic",
 //                "oh:custom:light" to "icon/light?format=PNG&anyFormat=true&iconset=custom"
 
-    // Test no state is transmitted
-    // Test baseURL
+    /// Test no state is transmitted
+    /// Test baseURL
     @Test
     func materialIcon1() throws {
         let result = Endpoint.icon(

--- a/OpenHABCore/Tests/OpenHABCoreTests/HTTPResponseExtension.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/HTTPResponseExtension.swift
@@ -44,13 +44,19 @@ public enum TestError: Swift.Error, LocalizedError, CustomStringConvertible, Sen
     }
 
     /// A localized description of the error suitable for presenting to the user.
-    public var errorDescription: String? { description }
+    public var errorDescription: String? {
+        description
+    }
 }
 
 public extension Date {
-    static var test: Date { Date(timeIntervalSince1970: 1_674_036_251) }
+    static var test: Date {
+        Date(timeIntervalSince1970: 1_674_036_251)
+    }
 
-    static var testString: String { "2023-01-18T10:04:11Z" }
+    static var testString: String {
+        "2023-01-18T10:04:11Z"
+    }
 }
 
 public extension HTTPResponse {
@@ -61,19 +67,31 @@ public extension HTTPResponse {
         }
     }
 
-    func withEncodedBody(_ encodedBody: String) throws -> (HTTPResponse, HTTPBody) { (self, .init(encodedBody)) }
+    func withEncodedBody(_ encodedBody: String) throws -> (HTTPResponse, HTTPBody) {
+        (self, .init(encodedBody))
+    }
 }
 
 public extension Data {
-    static var abcdString: String { "abcd" }
+    static var abcdString: String {
+        "abcd"
+    }
 
-    static var abcd: Data { Data(abcdString.utf8) }
+    static var abcd: Data {
+        Data(abcdString.utf8)
+    }
 
-    static var efghString: String { "efgh" }
+    static var efghString: String {
+        "efgh"
+    }
 
-    static var quotedEfghString: String { #""efgh""# }
+    static var quotedEfghString: String {
+        #""efgh""#
+    }
 
-    static var efgh: Data { Data(efghString.utf8) }
+    static var efgh: Data {
+        Data(efghString.utf8)
+    }
 
     static let crlf: ArraySlice<UInt8> = [0xD, 0xA]
 
@@ -107,7 +125,9 @@ public extension Data {
         return bytes
     }
 
-    static var multipartBody: Data { Data(multipartBodyAsSlice) }
+    static var multipartBody: Data {
+        Data(multipartBodyAsSlice)
+    }
 
     static var multipartTypedBodyAsSlice: [UInt8] {
         var bytes: [UInt8] = []
@@ -180,5 +200,7 @@ public extension Data {
 }
 
 public extension HTTPRequest {
-    func withEncodedBody(_ encodedBody: String) -> (HTTPRequest, HTTPBody) { (self, .init(encodedBody)) }
+    func withEncodedBody(_ encodedBody: String) -> (HTTPRequest, HTTPBody) {
+        (self, .init(encodedBody))
+    }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/JSONParserTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/JSONParserTests.swift
@@ -10,7 +10,6 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import OpenHABCore
-
 import os.signpost
 import Testing
 
@@ -27,8 +26,8 @@ struct JSONParserTests {
         #expect(codingData[0].homepage?.link == "https://192.168.2.63:8444/rest/sitemaps/myHome/myHome")
     }
 
-    // Version 2.1 is without timeout
-    // Contributed by Tobi-1234 in #348
+    /// Version 2.1 is without timeout
+    /// Contributed by Tobi-1234 in #348
     @Test func jSONShortSitemapDecoder() throws {
         let json = """
         [{"name":"Haus","label":"HauptmenÃ¼","link":"http://192.xxxx:8080/rest/sitemaps/Haus","homepage":{"link":"http://192.xxx:8080/rest/sitemaps/Haus/Haus","leaf":false,"widgets":[]}},{"name":"_default","label":"Home","link":"http://192.Xxx:8080/rest/sitemaps/_default","homepage":{"link":"http://192.Xxxx:8080/rest/sitemaps/_default/_default","leaf":false,"widgets":[]}}]
@@ -69,9 +68,11 @@ struct JSONParserTests {
     }
 
     @Test func watchSitemap() throws {
+        // swiftlint:disable line_length
         let json = Data("""
         {"name":"watch","label":"watch","link":"https://192.168.2.15:8444/rest/sitemaps/watch","homepage":{"id":"watch","title":"watch","link":"https://192.168.2.15:8444/rest/sitemaps/watch/watch","leaf":false,"timeout":false,"widgets":[{"widgetId":"00","type":"Frame","label":"Ground floor","icon":"frame","mappings":[],"widgets":[{"widgetId":"0000","type":"Switch","label":"Licht Oberlicht","icon":"switch","mappings":[],"item":{"link":"https://192.168.2.15:8444/rest/items/lcnLightSwitch14_1","state":"OFF","editable":false,"type":"Switch","name":"lcnLightSwitch14_1","label":"Licht Oberlicht","tags":["Lighting"],"groupNames":["G_PresenceSimulation","gLcn"]},"widgets":[]},{"widgetId":"0001","type":"Switch","label":"Licht Keller WC Decke","icon":"colorpicker","mappings":[],"item":{"link":"https://192.168.2.15:8444/rest/items/lcnLightSwitch6_1","state":"OFF","editable":false,"type":"Switch","name":"lcnLightSwitch6_1","label":"Licht Keller WC Decke","category":"colorpicker","tags":["Lighting"],"groupNames":["gKellerLicht","gLcn"]},"widgets":[]}]}]}}
         """.utf8)
+        // swiftlint:enable line_length
         let codingData = try decoder.decode(Components.Schemas.SitemapDTO.self, from: json)
         #expect(codingData.homepage?.link == "https://192.168.2.15:8444/rest/sitemaps/watch/watch")
     }

--- a/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NetworkTrackerTests.swift
@@ -12,9 +12,8 @@
 import Combine
 import Foundation
 import Network
-import OSLog
-
 @testable import OpenHABCore
+import OSLog
 import Testing
 import XCTest
 

--- a/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/NumberStateTests.swift
@@ -10,7 +10,6 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import OpenHABCore
-
 import Testing
 import UIKit
 
@@ -179,7 +178,7 @@ struct NumberStateTests {
     }
 
     @Test("parseAs conversions")
-    func parseAs() {
+    func parseAs() throws {
         #expect("ON".parseAsBool() == true)
         #expect("4,3,1".parseAsBrightness() == 1)
         #expect("4,31".parseAsBrightness() == nil)
@@ -196,7 +195,7 @@ struct NumberStateTests {
         let col1 = "Uninitialized".parseAsUIColor()
         let col2 = UIColor(hue: 0, saturation: 0, brightness: 0, alpha: 1.0)
         #expect(col1 != nil)
-        #expect(col1!.equals(col2))
+        #expect(try #require(col1?.equals(col2)))
         #expect("360,100,100".parseAsUIColor() == UIColor(
             hue: CGFloat(state: "360", divisor: 360),
             saturation: CGFloat(state: "100", divisor: 100),

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceSendItemCommandTests.swift
@@ -15,7 +15,6 @@ import OpenAPIRuntime
 import OpenHABCore
 import Testing
 
-@Suite
 struct OpenAPIServiceSendItemCommandTests {
     @Test("sendItemCommand uses text/plain for non-empty commands")
     func sendItemCommandUsesPlainTextForNonEmptyCommand() async throws {

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABCoreGeneralTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABCoreGeneralTests.swift
@@ -10,9 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Foundation
-
 @testable import OpenHABCore
-
 import XCTest
 
 final class OpenHABCoreGeneralTests: XCTestCase {

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABImageProcessorTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABImageProcessorTests.swift
@@ -19,15 +19,17 @@ struct OpenHABImageProcessorTests {
 
     @Test func preprocessSVG_withCurrentColor() throws {
         // SVG with currentColor fill attribute
+        // swiftlint:disable line_length
         let svgString = """
         <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16"><path fill="currentColor" d="M10 2.29v2.124c.566.247 1.086.6 1.536 1.05C12.48 6.408 13 7.664 13 9s-.52 2.591-1.464 3.536S9.336 14 8 14s-2.591-.52-3.536-1.464S3 10.336 3 9s.52-2.591 1.464-3.536c.45-.45.97-.803 1.536-1.05V2.29a7 7 0 1 0 4 0M7 0h2v8H7z"/></svg>
         """
+        // swiftlint:enable line_length
         let svgData = Data(svgString.utf8)
 
         // Process with red color
         let processor = OpenHABImageProcessor(iconColor: "red")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that style attribute was added with both color and fill
         // 'color' is needed for currentColor references, 'fill' for elements without explicit fill
@@ -47,7 +49,7 @@ struct OpenHABImageProcessorTests {
         // Process without icon color
         let processor = OpenHABImageProcessor(iconColor: nil)
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that SVG is unchanged
         #expect(processedString == svgString)
@@ -62,7 +64,7 @@ struct OpenHABImageProcessorTests {
         // Process with empty icon color
         let processor = OpenHABImageProcessor(iconColor: "")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that SVG is unchanged
         #expect(processedString == svgString)
@@ -77,7 +79,7 @@ struct OpenHABImageProcessorTests {
         // Process with blue color
         let processor = OpenHABImageProcessor(iconColor: "blue")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that color and fill were prepended to existing style
         #expect(processedString.contains("style=\"color:#"))
@@ -94,7 +96,7 @@ struct OpenHABImageProcessorTests {
         // Process with green color
         let processor = OpenHABImageProcessor(iconColor: "green")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that color and fill were prepended to existing style with single quotes preserved
         #expect(processedString.contains("style='color:#"))
@@ -112,7 +114,7 @@ struct OpenHABImageProcessorTests {
         // Process with orange color
         let processor = OpenHABImageProcessor(iconColor: "orange")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that style with whitespace is handled correctly
         #expect(processedString.contains("color:#"))
@@ -129,7 +131,7 @@ struct OpenHABImageProcessorTests {
         // Process with purple color
         let processor = OpenHABImageProcessor(iconColor: "purple")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that single-quoted style with whitespace is handled correctly
         #expect(processedString.contains("color:#"))
@@ -147,7 +149,7 @@ struct OpenHABImageProcessorTests {
         // Process with hex color
         let processor = OpenHABImageProcessor(iconColor: "#FF5733")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that style attribute was added
         #expect(processedString.contains("style=\"color:#"))
@@ -163,7 +165,7 @@ struct OpenHABImageProcessorTests {
         // Process with RGB color
         let processor = OpenHABImageProcessor(iconColor: "rgb(255, 0, 0)")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that style attribute was added
         #expect(processedString.contains("style=\"color:#"))
@@ -179,7 +181,7 @@ struct OpenHABImageProcessorTests {
         // Process with color
         let processor = OpenHABImageProcessor(iconColor: "orange")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that other attributes are preserved
         #expect(processedString.contains("width=\"64\""))
@@ -191,7 +193,7 @@ struct OpenHABImageProcessorTests {
         #expect(processedString.contains("fill:#"))
     }
 
-    @Test func preprocessSVG_withInvalidData() throws {
+    @Test func preprocessSVG_withInvalidData() {
         let invalidData = Data("Not an SVG".utf8)
 
         // Process with color
@@ -216,14 +218,14 @@ struct OpenHABImageProcessorTests {
         // Process with color
         let processor = OpenHABImageProcessor(iconColor: "purple")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Verify that style attribute was added
         #expect(processedString.contains("style=\"color:#"))
         #expect(processedString.contains("fill:#"))
     }
 
-    @Test func emptySVG_selfClosingRoot_isDetectedAsEmpty() throws {
+    @Test func emptySVG_selfClosingRoot_isDetectedAsEmpty() {
         let svgString = """
         <?xml version="1.0" encoding="UTF-8"?>
         <svg viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg"/>
@@ -234,7 +236,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor.isEmptySVGDocument(data: svgData))
     }
 
-    @Test func emptySVG_withOpenAndCloseTag_isDetectedAsEmpty() throws {
+    @Test func emptySVG_withOpenAndCloseTag_isDetectedAsEmpty() {
         let svgString = """
         <svg viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg"></svg>
         """
@@ -244,7 +246,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor.isEmptySVGDocument(data: svgData))
     }
 
-    @Test func nonEmptySVG_isNotDetectedAsEmpty() throws {
+    @Test func nonEmptySVG_isNotDetectedAsEmpty() {
         let svgString = """
         <svg viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z"/></svg>
         """
@@ -254,7 +256,7 @@ struct OpenHABImageProcessorTests {
         #expect(!processor.isEmptySVGDocument(data: svgData))
     }
 
-    @Test func process_emptySVG_returnsEmptyImageNotWarningSymbol() throws {
+    @Test func process_emptySVG_returnsEmptyImageNotWarningSymbol() {
         let svgString = """
         <?xml version="1.0" encoding="UTF-8"?>
         <svg viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg"/>
@@ -278,7 +280,7 @@ struct OpenHABImageProcessorTests {
 
         let processor = OpenHABImageProcessor(iconColor: "red")
         let processedData = processor.preprocessSVG(svgData)
-        let processedString = String(bytes: processedData, encoding: .utf8)!
+        let processedString = try #require(String(bytes: processedData, encoding: .utf8))
 
         // Red should convert to #FF0000
         #expect(processedString.contains("color:#FF0000"))
@@ -287,7 +289,7 @@ struct OpenHABImageProcessorTests {
 
     // MARK: - Cache Identifier Normalization Tests
 
-    @Test func cacheIdentifier_normalizesNamedColors() throws {
+    @Test func cacheIdentifier_normalizesNamedColors() {
         // Verify that named colors are normalized to hex for consistent cache identifiers
         let processor1 = OpenHABImageProcessor(iconColor: "red")
         let processor2 = OpenHABImageProcessor(iconColor: "#FF0000")
@@ -301,7 +303,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor1.identifier == "org.openhab.svgprocessor.FF0000")
     }
 
-    @Test func cacheIdentifier_handlesDifferentColors() throws {
+    @Test func cacheIdentifier_handlesDifferentColors() {
         // Verify that different colors produce different cache identifiers
         let redProcessor = OpenHABImageProcessor(iconColor: "red")
         let blueProcessor = OpenHABImageProcessor(iconColor: "blue")
@@ -312,7 +314,7 @@ struct OpenHABImageProcessorTests {
         #expect(redProcessor.identifier != greenProcessor.identifier)
     }
 
-    @Test func cacheIdentifier_withoutColor() throws {
+    @Test func cacheIdentifier_withoutColor() {
         // Verify that processors without color have the default identifier
         let processor1 = OpenHABImageProcessor()
         let processor2 = OpenHABImageProcessor(iconColor: nil)
@@ -323,7 +325,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor3.identifier == "org.openhab.svgprocessor")
     }
 
-    @Test func cacheIdentifier_fullSizeMode() throws {
+    @Test func cacheIdentifier_fullSizeMode() {
         let processorWithoutColor = OpenHABImageProcessor(svgMaxSize: nil)
         let processorWithColor = OpenHABImageProcessor(iconColor: "red", svgMaxSize: nil)
 
@@ -331,13 +333,13 @@ struct OpenHABImageProcessorTests {
         #expect(processorWithColor.identifier == "org.openhab.svgprocessor.FF0000.fullsize")
     }
 
-    @Test func cacheIdentifier_customSizeMode() throws {
+    @Test func cacheIdentifier_customSizeMode() {
         let processor = OpenHABImageProcessor(iconColor: "red", svgMaxSize: CGSize(width: 128, height: 128))
 
         #expect(processor.identifier == "org.openhab.svgprocessor.FF0000.128x128")
     }
 
-    @Test func cacheIdentifier_normalizesOpenHABColors() throws {
+    @Test func cacheIdentifier_normalizesOpenHABColors() {
         // Verify that openHAB semantic colors are normalized
         let processor1 = OpenHABImageProcessor(iconColor: "maroon")
         let processor2 = OpenHABImageProcessor(iconColor: "#800000")
@@ -346,7 +348,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor1.identifier == "org.openhab.svgprocessor.800000")
     }
 
-    @Test func cacheIdentifier_handlesWhitespace() throws {
+    @Test func cacheIdentifier_handlesWhitespace() {
         // Verify that whitespace is handled correctly
         let processor1 = OpenHABImageProcessor(iconColor: "  red  ")
         let processor2 = OpenHABImageProcessor(iconColor: "red")
@@ -356,7 +358,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor2.identifier == processor3.identifier)
     }
 
-    @Test func cacheIdentifier_handlesCaseSensitivity() throws {
+    @Test func cacheIdentifier_handlesCaseSensitivity() {
         // Verify that color strings are case-insensitive
         let processor1 = OpenHABImageProcessor(iconColor: "RED")
         let processor2 = OpenHABImageProcessor(iconColor: "Red")
@@ -366,7 +368,7 @@ struct OpenHABImageProcessorTests {
         #expect(processor2.identifier == processor3.identifier)
     }
 
-    @Test func cacheIdentifier_fallbackForInvalidColors() throws {
+    @Test func cacheIdentifier_fallbackForInvalidColors() {
         // Verify that invalid colors fall back to normalized string
         let processor = OpenHABImageProcessor(iconColor: "xyz")
 

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABJSONParserTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABJSONParserTests.swift
@@ -20,9 +20,11 @@ struct OpenHABJSONParserTests {
     }
 
     @Test func jSONNotificationDecoder() throws {
+        // swiftlint:disable line_length
         let json = Data("""
                 [{"_id":"5c82e14d2b48ecbf7a7223e0","message":"Light Küche was changed","__v":0,"created":"2019-03-08T21:40:29.412Z"},{"_id":"5c82c9c22b48ecbf7a70f44e","message":"Light Küche was changed","__v":0,"created":"2019-03-08T20:00:02.368Z"},{"_id":"5c82c9c02b48ecbf7a70f42c","message":"Light Küche was changed","__v":0,"created":"2019-03-08T20:00:00.982Z"},{"_id":"5c7fff782b48ecbf7a4dd8e4","message":"Light Küche was changed","__v":0,"created":"2019-03-06T17:12:24.093Z"},{"_id":"5c7ff5c12b48ecbf7a4d56fb","message":"Light Küche was changed","__v":0,"created":"2019-03-06T16:30:57.101Z"},{"_id":"5c7ed0852b48ecbf7a3d2151","message":"Light Küche was changed","__v":0,"created":"2019-03-05T19:39:49.373Z"},{"_id":"5c7d50ba2b48ecbf7a26948f","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:18.473Z"},{"_id":"5c7d50b62b48ecbf7a269455","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:14.321Z"},{"_id":"5c7d50b42b48ecbf7a269442","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:22:12.468Z"},{"_id":"5c7d507d2b48ecbf7a26916c","message":"Light Küche was changed","__v":0,"created":"2019-03-04T16:21:17.006Z"}]
         """.utf8)
+        // swiftlint:enable line_length
 
         let codingData = try decoder.decode([OpenHABNotification.CodingData].self, from: json)
         #expect(codingData[0].message == "Light Küche was changed")

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenHABWidgetIconStateTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenHABWidgetIconStateTests.swift
@@ -13,7 +13,6 @@ import OpenHABCore
 import SwiftUI
 import Testing
 
-@Suite
 struct OpenHABWidgetIconStateTests {
 //    @Test
 //    func returnsLowercasedState() {

--- a/OpenHABCore/Tests/OpenHABCoreTests/ServerCertificateManagerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ServerCertificateManagerTests.swift
@@ -51,7 +51,7 @@ struct ServerCertificateManagerTests {
         return (manager, delegate)
     }
 
-    // Clear all certificates before each test to ensure isolation
+    /// Clear all certificates before each test to ensure isolation
     func clearCertificateStore() async {
         let store = CertificateManagers.certificateStore
         let allCerts = await store.getAllCertificates()
@@ -78,7 +78,7 @@ struct ServerCertificateManagerTests {
         let (manager, _) = createTestContext()
         let trust = try dummyTrust()
         let domain = "accepted-test.openhab.org" // Unique domain
-        let cert = manager.getLeafCertificate(trust: trust)!
+        let cert = try #require(manager.getLeafCertificate(trust: trust))
         let certData = SecCertificateCopyData(cert) as Data
 
         // Store certificate in the shared store

--- a/OpenHABCore/Tests/OpenHABCoreTests/SessionTaskChallengeTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/SessionTaskChallengeTests.swift
@@ -10,9 +10,8 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import Foundation
-import Testing
-
 @testable import OpenHABCore
+import Testing
 
 // MARK: - Test Helpers
 

--- a/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/StringExtensionTests.swift
@@ -13,7 +13,7 @@
 import Testing
 
 struct StringExtensionTests {
-    @Test func testRemoveTrailingSlashes() throws {
+    @Test func testRemoveTrailingSlashes() {
         #expect("example/".removeTrailingSlashes() == "example")
         #expect("example//".removeTrailingSlashes() == "example")
         #expect("example/path//".removeTrailingSlashes() == "example/path")
@@ -25,7 +25,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testIsNoneIcon() throws {
+    func testIsNoneIcon() {
         let testCases: [String: Bool] = [
             "none": true,
             "oh:none": true,
@@ -41,7 +41,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testDataImageBase64Payload() throws {
+    func testDataImageBase64Payload() {
         let svgPayload = "PHN2Zz48L3N2Zz4="
         #expect("data:image/svg+xml;base64,\(svgPayload)".dataImageBase64Payload == svgPayload)
 
@@ -55,7 +55,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testDataImageBase64Data() throws {
+    func testDataImageBase64Data() {
         let validPayload = "PHN2Zz48L3N2Zz4="
         #expect("data:image/svg+xml;base64,\(validPayload)".dataImageBase64Data == Data(base64Encoded: validPayload))
 
@@ -67,57 +67,57 @@ struct StringExtensionTests {
 
     // MARK: - doubleValue Tests
 
-    @Test func doubleValueWithSimpleInteger() throws {
+    @Test func doubleValueWithSimpleInteger() {
         let result = "42".doubleValue
         #expect(result == 42.0)
     }
 
-    @Test func doubleValueWithDecimal() throws {
+    @Test func doubleValueWithDecimal() {
         let result = "42.5".doubleValue
         #expect(result == 42.5)
     }
 
-    @Test func doubleValueWithNegative() throws {
+    @Test func doubleValueWithNegative() {
         let result = "-42.5".doubleValue
         #expect(result == -42.5)
     }
 
-    @Test func doubleValueWithZero() throws {
+    @Test func doubleValueWithZero() {
         let result = "0".doubleValue
         #expect(result == 0.0)
     }
 
-    @Test func doubleValueWithLeadingZeros() throws {
+    @Test func doubleValueWithLeadingZeros() {
         let result = "00042.5".doubleValue
         #expect(result == 42.5)
     }
 
-    @Test func doubleValueWithVerySmallNumber() throws {
+    @Test func doubleValueWithVerySmallNumber() {
         let result = "0.0001".doubleValue
         #expect(result == 0.0001)
     }
 
-    @Test func doubleValueWithVeryLargeNumber() throws {
+    @Test func doubleValueWithVeryLargeNumber() {
         let result = "123456789.123".doubleValue
         #expect(result == 123_456_789.123)
     }
 
-    @Test func doubleValueWithInvalidString() throws {
+    @Test func doubleValueWithInvalidString() {
         let result = "not a number".doubleValue
         #expect(result.isNaN)
     }
 
-    @Test func doubleValueWithEmptyString() throws {
+    @Test func doubleValueWithEmptyString() {
         let result = "".doubleValue
         #expect(result.isNaN)
     }
 
-    @Test func doubleValueUsesDecimalPoint() throws {
+    @Test func doubleValueUsesDecimalPoint() {
         let result = "42.5".doubleValue
         #expect(result == 42.5)
     }
 
-    @Test func doubleValueIgnoresCommaAsDecimalSeparator() throws {
+    @Test func doubleValueIgnoresCommaAsDecimalSeparator() {
         // Should parse up to the comma, not treat comma as decimal separator
         let result = "42,5".doubleValue
         // Parser stops at comma and returns 42.0, not 42.5
@@ -126,42 +126,42 @@ struct StringExtensionTests {
 
     // MARK: - intValue Tests
 
-    @Test func intValueWithSimpleInteger() throws {
+    @Test func intValueWithSimpleInteger() {
         let result = "42".intValue
         #expect(result == 42)
     }
 
-    @Test func intValueWithNegative() throws {
+    @Test func intValueWithNegative() {
         let result = "-42".intValue
         #expect(result == -42)
     }
 
-    @Test func intValueWithZero() throws {
+    @Test func intValueWithZero() {
         let result = "0".intValue
         #expect(result == 0)
     }
 
-    @Test func intValueWithLeadingZeros() throws {
+    @Test func intValueWithLeadingZeros() {
         let result = "00042".intValue
         #expect(result == 42)
     }
 
-    @Test func intValueWithLargeNumber() throws {
+    @Test func intValueWithLargeNumber() {
         let result = "123456789".intValue
         #expect(result == 123_456_789)
     }
 
-    @Test func intValueWithInvalidString() throws {
+    @Test func intValueWithInvalidString() {
         let result = "not a number".intValue
         #expect(result == Int.max)
     }
 
-    @Test func intValueWithEmptyString() throws {
+    @Test func intValueWithEmptyString() {
         let result = "".intValue
         #expect(result == Int.max)
     }
 
-    @Test func intValueWithDecimalString() throws {
+    @Test func intValueWithDecimalString() {
         // Parser stops at decimal point, returns integer part
         let result = "42.5".intValue
         #expect(result == 42)
@@ -169,117 +169,117 @@ struct StringExtensionTests {
 
     // MARK: - numberValue Tests
 
-    @Test func numberValueWithSimpleInteger() throws {
+    @Test func numberValueWithSimpleInteger() {
         let result = "42".numberValue
         #expect(result?.doubleValue == 42.0)
     }
 
-    @Test func numberValueWithDecimal() throws {
+    @Test func numberValueWithDecimal() {
         let result = "42.5".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueWithNegative() throws {
+    @Test func numberValueWithNegative() {
         let result = "-42.5".numberValue
         #expect(result?.doubleValue == -42.5)
     }
 
-    @Test func numberValueWithScientificNotation() throws {
+    @Test func numberValueWithScientificNotation() {
         let result = "1.23E+2".numberValue
         #expect(result?.doubleValue == 123.0)
     }
 
-    @Test func numberValueWithNegativeExponent() throws {
+    @Test func numberValueWithNegativeExponent() {
         let result = "1.23E-2".numberValue
         #expect(result?.doubleValue == 0.0123)
     }
 
-    @Test func numberValueFiltersInvalidCharacters() throws {
+    @Test func numberValueFiltersInvalidCharacters() {
         let result = "42.5abc".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueWithExtraWhitespace() throws {
+    @Test func numberValueWithExtraWhitespace() {
         let result = " 42.5 ".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueWithInvalidString() throws {
+    @Test func numberValueWithInvalidString() {
         let result = "not a number".numberValue
         #expect(result == nil)
     }
 
-    @Test func numberValueWithEmptyString() throws {
+    @Test func numberValueWithEmptyString() {
         let result = "".numberValue
         #expect(result == nil)
     }
 
-    @Test func numberValueUsesDecimalPoint() throws {
+    @Test func numberValueUsesDecimalPoint() {
         let result = "42.5".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueWithZero() throws {
+    @Test func numberValueWithZero() {
         let result = "0".numberValue
         #expect(result?.doubleValue == 0.0)
     }
 
-    @Test func numberValueWithPositiveSign() throws {
+    @Test func numberValueWithPositiveSign() {
         let result = "+42.5".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueFiltersLetters() throws {
+    @Test func numberValueFiltersLetters() {
         // Should filter out letters but keep valid number characters
         // "1E2abc3" -> filters to "1E23" -> parses as 1 × 10^23
         let result = "1E2abc3".numberValue
         #expect(result?.doubleValue == 1e+23)
     }
 
-    @Test func numberValueFiltersLettersSimple() throws {
+    @Test func numberValueFiltersLettersSimple() {
         // Simpler case: "42abc.5def" -> filters to "42.5"
         let result = "42abc.5def".numberValue
         #expect(result?.doubleValue == 42.5)
     }
 
-    @Test func numberValueWithUppercaseScientificNotation() throws {
+    @Test func numberValueWithUppercaseScientificNotation() {
         let result = "1.5E+10".numberValue
         #expect(result?.doubleValue == 15_000_000_000.0)
     }
 
-    @Test func numberValueWithScientificNotationNoSign() throws {
+    @Test func numberValueWithScientificNotationNoSign() {
         let result = "1.5E10".numberValue
         #expect(result?.doubleValue == 15_000_000_000.0)
     }
 
-    @Test func numberValueWithVerySmallScientificNumber() throws {
+    @Test func numberValueWithVerySmallScientificNumber() {
         let result = "1.0E-10".numberValue
         #expect(result?.doubleValue == 0.0000000001)
     }
 
-    @Test func numberValueWithZeroExponent() throws {
+    @Test func numberValueWithZeroExponent() {
         let result = "1.5E0".numberValue
         #expect(result?.doubleValue == 1.5)
     }
 
     // MARK: - asDouble Tests
 
-    @Test func asDoubleWithValidNumber() throws {
+    @Test func asDoubleWithValidNumber() {
         let result = "42.5".asDouble
         #expect(result == 42.5)
     }
 
-    @Test func asDoubleWithInvalidString() throws {
+    @Test func asDoubleWithInvalidString() {
         let result = "not a number".asDouble
         #expect(result == 0.0)
     }
 
-    @Test func asDoubleWithEmptyString() throws {
+    @Test func asDoubleWithEmptyString() {
         let result = "".asDouble
         #expect(result == 0.0)
     }
 
-    @Test func asDoubleWithScientificNotation() throws {
+    @Test func asDoubleWithScientificNotation() {
         let result = "1.23E+2".asDouble
         #expect(result == 123.0)
     }

--- a/OpenHABCore/Tests/OpenHABCoreTests/TestClientTransport.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/TestClientTransport.swift
@@ -54,7 +54,9 @@ public struct TestClientTransport: ClientTransport {
     /// Initializes a `TestClientTransport` instance with a custom call handler.
     ///
     /// - Parameter callHandler: The closure responsible for processing client requests.
-    public init(callHandler: @escaping CallHandler) { self.callHandler = callHandler }
+    public init(callHandler: @escaping CallHandler) {
+        self.callHandler = callHandler
+    }
 
     /// Sends a client request using the test transport.
     ///
@@ -67,5 +69,7 @@ public struct TestClientTransport: ClientTransport {
     /// - Throws: An error if the call handler encounters an issue.
     public func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (
         HTTPResponse, HTTPBody?
-    ) { try await callHandler(request, body, baseURL, operationID) }
+    ) {
+        try await callHandler(request, body, baseURL, operationID)
+    }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/UIColorExtensionTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/UIColorExtensionTests.swift
@@ -16,7 +16,7 @@ import UIKit
 struct UIColorExtensionTests {
     // MARK: - semanticColorToHex() Tests
 
-    @Test func semanticColorToHex_RegularRGBColors() throws {
+    @Test func semanticColorToHex_RegularRGBColors() {
         // Test regular RGB colors created from hex values
         let redColor = UIColor(hex: "#FF0000")
         #expect(redColor.semanticColorToHex() == "#FF0000")
@@ -31,7 +31,7 @@ struct UIColorExtensionTests {
         #expect(customColor.semanticColorToHex() == "#A1B2C3")
     }
 
-    @Test func semanticColorToHex_GrayscaleColors() throws {
+    @Test func semanticColorToHex_GrayscaleColors() {
         // Test grayscale colors (black, white, gray)
         let blackColor = UIColor.black
         #expect(blackColor.semanticColorToHex() == "#000000")
@@ -45,7 +45,7 @@ struct UIColorExtensionTests {
         #expect(grayHex?.hasPrefix("#") == true)
     }
 
-    @Test func semanticColorToHex_SemanticOHColors() throws {
+    @Test func semanticColorToHex_SemanticOHColors() {
         // Test openHAB semantic colors
         let ohBlackColor = UIColor.ohBlack
         let ohBlackHex = ohBlackColor.semanticColorToHex()
@@ -67,7 +67,7 @@ struct UIColorExtensionTests {
         #expect(ohBlueColor.semanticColorToHex() == "#0000FF")
     }
 
-    @Test func semanticColorToHex_StandardColors() throws {
+    @Test func semanticColorToHex_StandardColors() {
         // Test standard UIColor colors
         let redColor = UIColor.red
         let redHex = redColor.semanticColorToHex()
@@ -90,7 +90,7 @@ struct UIColorExtensionTests {
         #expect(yellowHex?.hasPrefix("#") == true)
     }
 
-    @Test func semanticColorToHex_CustomRGBColors() throws {
+    @Test func semanticColorToHex_CustomRGBColors() {
         // Test colors created with custom RGB values
         let customColor1 = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
         let hex1 = customColor1.semanticColorToHex()
@@ -111,7 +111,7 @@ struct UIColorExtensionTests {
         #expect(customColor4.semanticColorToHex() == "#FFFFFF")
     }
 
-    @Test func semanticColorToHex_AllOHNamedColors() throws {
+    @Test func semanticColorToHex_AllOHNamedColors() {
         // Test all openHAB named colors to ensure they convert successfully
         let colors: [(UIColor, String)] = [
             (.ohMaroon, "#800000"),
@@ -137,7 +137,7 @@ struct UIColorExtensionTests {
         }
     }
 
-    @Test func semanticColorToHex_EdgeCases() throws {
+    @Test func semanticColorToHex_EdgeCases() {
         // Test edge case colors with transparency
         let transparentColor = UIColor(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.5)
         let transparentHex = transparentColor.semanticColorToHex()
@@ -156,7 +156,7 @@ struct UIColorExtensionTests {
         #expect(clearHex != nil)
     }
 
-    @Test func semanticColorToHex_HexFormat() throws {
+    @Test func semanticColorToHex_HexFormat() {
         // Verify that all returned hex strings start with '#'
         let testColors = [
             UIColor.black,
@@ -177,7 +177,7 @@ struct UIColorExtensionTests {
 
     // MARK: - toHex() Tests
 
-    @Test func toHex_BasicColors() throws {
+    @Test func toHex_BasicColors() {
         let redColor = UIColor(hex: "#FF0000")
         #expect(redColor.toHex() == "FF0000")
 
@@ -188,7 +188,7 @@ struct UIColorExtensionTests {
         #expect(blueColor.toHex() == "0000FF")
     }
 
-    @Test func toHex_WithAlpha() throws {
+    @Test func toHex_WithAlpha() {
         let color = UIColor(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.5)
         let hexWithAlpha = color.toHex(alpha: true)
         #expect(hexWithAlpha != nil)
@@ -197,7 +197,7 @@ struct UIColorExtensionTests {
 
     // MARK: - init(hex:) Tests
 
-    @Test func initFromHex_ValidHexStrings() throws {
+    @Test func initFromHex_ValidHexStrings() {
         let color1 = UIColor(hex: "#FF0000")
         #expect(color1.toHex() == "FF0000")
 
@@ -208,7 +208,7 @@ struct UIColorExtensionTests {
         #expect(color3.toHex() == "0000FF")
     }
 
-    @Test func initFromHex_InvalidHexStrings() throws {
+    @Test func initFromHex_InvalidHexStrings() {
         // Test that invalid hex strings fall back to gray
         let invalidColor1 = UIColor(hex: "ABC")
         #expect(invalidColor1.toHex() == UIColor.gray.toHex())
@@ -219,7 +219,7 @@ struct UIColorExtensionTests {
 
     // MARK: - init(fromString:) Tests
 
-    @Test func initFromString_NamedColors() throws {
+    @Test func initFromString_NamedColors() {
         let redColor = UIColor(fromString: "red")
         #expect(redColor.semanticColorToHex() == "#FF0000")
 
@@ -230,7 +230,7 @@ struct UIColorExtensionTests {
         #expect(maroonColor.semanticColorToHex() == "#800000")
     }
 
-    @Test func initFromString_HexStrings() throws {
+    @Test func initFromString_HexStrings() {
         let color1 = UIColor(fromString: "#FF0000")
         #expect(color1.semanticColorToHex() == "#FF0000")
 
@@ -238,7 +238,7 @@ struct UIColorExtensionTests {
         #expect(color2.semanticColorToHex() == "#00FF00")
     }
 
-    @Test func initFromString_CaseInsensitive() throws {
+    @Test func initFromString_CaseInsensitive() {
         let color1 = UIColor(fromString: "RED")
         let color2 = UIColor(fromString: "red")
         let color3 = UIColor(fromString: "Red")
@@ -247,7 +247,7 @@ struct UIColorExtensionTests {
         #expect(color2.semanticColorToHex() == color3.semanticColorToHex())
     }
 
-    @Test func initFromString_WhitespaceHandling() throws {
+    @Test func initFromString_WhitespaceHandling() {
         let color1 = UIColor(fromString: "  red  ")
         #expect(color1.semanticColorToHex() == "#FF0000")
 
@@ -255,7 +255,7 @@ struct UIColorExtensionTests {
         #expect(color2.semanticColorToHex() == "#FF0000")
     }
 
-    @Test func initFromString_InvalidString() throws {
+    @Test func initFromString_InvalidString() {
         // Test that short invalid strings fall back to gray
         let shortInvalidColor = UIColor(fromString: "xyz")
         #expect(shortInvalidColor.toHex() == UIColor.gray.toHex())

--- a/OpenHABCore/Tests/OpenHABCoreTests/UIColorTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/UIColorTests.swift
@@ -13,7 +13,6 @@ import OpenHABCore
 import Testing
 import UIKit
 
-@Suite
 struct UIColorTests {
     @Test
     func resolvesNamedColor_exactMatch() {

--- a/OpenHABCore/Tests/OpenHABCoreTests/UserDefaultsTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/UserDefaultsTests.swift
@@ -16,9 +16,9 @@ import Testing
 
 @MainActor
 struct HomePreferencesDecodingTests {
-    // Simulates stored data from an older version: only id + homeName + minimal connection
-    // configs (missing supportsNotifications, username, password, and several HomePreferences
-    // fields added later). Verifies that decode succeeds and the stored homeName is preserved.
+    /// Simulates stored data from an older version: only id + homeName + minimal connection
+    /// configs (missing supportsNotifications, username, password, and several HomePreferences
+    /// fields added later). Verifies that decode succeeds and the stored homeName is preserved.
     @Test func legacyPayloadPreservesHomeName() throws {
         let json = """
         {
@@ -53,9 +53,9 @@ struct HomePreferencesDecodingTests {
         #expect(prefs.remoteConnectionConfig.supportsNotifications == true)
     }
 
-    // Verifies that a payload with only the required `id` key decodes successfully and
-    // all other fields fall back to their struct defaults, including homeName == "Home#1"
-    // and remote supportsNotifications == true.
+    /// Verifies that a payload with only the required `id` key decodes successfully and
+    /// all other fields fall back to their struct defaults, including homeName == "Home#1"
+    /// and remote supportsNotifications == true.
     @Test func minimalPayloadUsesDefaults() throws {
         let json = #"{"id":"550E8400-E29B-41D4-A716-446655440000"}"#
         let prefs = try JSONDecoder().decode(HomePreferences.self, from: Data(json.utf8))
@@ -66,8 +66,8 @@ struct HomePreferencesDecodingTests {
         #expect(prefs.remoteConnectionConfig == .remoteDefault)
     }
 
-    // Verifies that an explicit supportsNotifications: false in the remote config JSON is
-    // respected (not silently promoted to true by the role-aware default).
+    /// Verifies that an explicit supportsNotifications: false in the remote config JSON is
+    /// respected (not silently promoted to true by the role-aware default).
     @Test func explicitFalseNotificationsRespected() throws {
         let json = """
         {
@@ -85,7 +85,7 @@ struct HomePreferencesDecodingTests {
         #expect(prefs.remoteConnectionConfig.supportsNotifications == false)
     }
 
-    // Full round-trip: encode a HomePreferences, decode it, verify nothing is lost.
+    /// Full round-trip: encode a HomePreferences, decode it, verify nothing is lost.
     @Test func fullRoundTripPreservesAllFields() throws {
         let encoded = """
         {
@@ -139,12 +139,12 @@ struct HomePreferencesDecodingTests {
     }
 }
 
-// .serialized prevents parallel test clones from racing on the shared group.org.openhab.app UserDefaults suite.
+/// .serialized prevents parallel test clones from racing on the shared group.org.openhab.app UserDefaults suite.
 @Suite(.serialized)
 @MainActor
 struct UserDefaultsTests {
     @Test func consistency() throws {
-        let data = UserDefaults(suiteName: "group.org.openhab.app")!
+        let data = try #require(UserDefaults(suiteName: "group.org.openhab.app"))
         let defaultsName = try #require(Bundle.main.bundleIdentifier)
         data.removePersistentDomain(forName: defaultsName)
 
@@ -190,6 +190,6 @@ struct UserDefaultsTests {
         homeWithoutCredentials.localConnectionConfig.password = ""
         homeWithoutCredentials.remoteConnectionConfig.username = ""
         homeWithoutCredentials.remoteConnectionConfig.password = ""
-        #expect(homeWithoutCredentials == (try? JSONDecoder().decode(HomePreferences.self, from: data.data(forKey: "currentHomePreferences")!)))
+        #expect(homeWithoutCredentials == (try? JSONDecoder().decode(HomePreferences.self, from: try #require(data.data(forKey: "currentHomePreferences")))))
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/WidgetCommandDispatcherTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/WidgetCommandDispatcherTests.swift
@@ -12,7 +12,6 @@
 import OpenHABCore
 import Testing
 
-@Suite
 @MainActor
 struct WidgetCommandDispatcherTests {
     @Test("Empty string command is dispatched for item name")

--- a/OpenHABCore/Tests/OpenHABCoreTests/WidgetDisplayStateTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/WidgetDisplayStateTests.swift
@@ -12,7 +12,6 @@
 import OpenHABCore
 import Testing
 
-@Suite
 struct WidgetDisplayStateTests {
     @Test
     func usesItemStateWhenWidgetStateIsEmpty() {
@@ -81,7 +80,7 @@ struct WidgetDisplayStateTests {
             category: nil,
             options: nil
         )
-        let widget = OpenHABWidget(
+        return OpenHABWidget(
             widgetId: "widget-id",
             label: label,
             icon: "switch",
@@ -112,6 +111,5 @@ struct WidgetDisplayStateTests {
             forceAsItem: nil,
             labelSource: .sitemapDefinition
         )
-        return widget
     }
 }

--- a/OpenHABCore/Tests/OpenHABCoreTests/WidgetMediaImageDescriptorTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/WidgetMediaImageDescriptorTests.swift
@@ -13,7 +13,6 @@ import Foundation
 import OpenHABCore
 import Testing
 
-@Suite
 struct WidgetMediaImageDescriptorTests {
     @Test
     func chartDescriptorResolvesToChartLink() {

--- a/OpenHABCore/Tests/OpenHABCoreTests/WidgetRenderingKindTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/WidgetRenderingKindTests.swift
@@ -12,7 +12,6 @@
 import OpenHABCore
 import Testing
 
-@Suite
 struct WidgetRenderingKindTests {
     @Test
     func switchWithMappingsUsesSegmentedKind() {

--- a/OsLogRewriter/Sources/OsLogRewriterLib/OsLogRewriter.swift
+++ b/OsLogRewriter/Sources/OsLogRewriterLib/OsLogRewriter.swift
@@ -14,7 +14,7 @@ import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-// Helper class to recursively remove trivia from all syntax nodes
+/// Helper class to recursively remove trivia from all syntax nodes
 final class TriviaRemover: SyntaxRewriter {
     override func visit(_ token: TokenSyntax) -> TokenSyntax {
         token.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
@@ -105,13 +105,13 @@ final class OsLogRewriter: SyntaxRewriter {
         )
     }
 
-    // Helper function to recursively clean all trivia from a syntax node
+    /// Helper function to recursively clean all trivia from a syntax node
     func cleanAllTrivia(from expr: ExprSyntax) -> ExprSyntax {
         let triviaRemover = TriviaRemover()
         return ExprSyntax(triviaRemover.visit(expr))
     }
 
-    // Helper function to extract indentation from trivia
+    /// Helper function to extract indentation from trivia
     func extractIndentation(from trivia: Trivia) -> Trivia {
         // Look for the last newline and extract spaces/tabs after it
         var indentationPieces: [TriviaPiece] = []
@@ -144,7 +144,7 @@ final class OsLogRewriter: SyntaxRewriter {
         return Trivia(pieces: indentationPieces.reversed())
     }
 
-    // Helper function to detect indentation from the context of the os_log call
+    /// Helper function to detect indentation from the context of the os_log call
     func detectIndentationLevel(_ node: FunctionCallExprSyntax) -> Trivia {
         // First try to extract from the node's own leading trivia
         let directIndentation = extractIndentation(from: node.leadingTrivia)
@@ -157,7 +157,7 @@ final class OsLogRewriter: SyntaxRewriter {
         return findContextualIndentation(node) ?? Trivia.spaces(8) // fallback
     }
 
-    // Helper function to find indentation from parent context
+    /// Helper function to find indentation from parent context
     func findContextualIndentation(_ node: some SyntaxProtocol) -> Trivia? {
         var current: (any SyntaxProtocol)? = node
 
@@ -174,13 +174,13 @@ final class OsLogRewriter: SyntaxRewriter {
         return nil
     }
 
-    // Helper function to extract meaningful indentation (non-empty)
+    /// Helper function to extract meaningful indentation (non-empty)
     func extractMeaningfulIndentation(from trivia: Trivia) -> Trivia? {
         let extracted = extractIndentation(from: trivia)
         return extracted.isEmpty ? nil : extracted
     }
 
-    // Helper function to simplify string interpolations like "\(value)" to just value
+    /// Helper function to simplify string interpolations like "\(value)" to just value
     func simplifyStringInterpolation(_ expr: ExprSyntax) -> ExprSyntax {
         // Check if this is a string literal
         guard let stringLiteral = expr.as(StringLiteralExprSyntax.self) else {
@@ -289,7 +289,7 @@ final class OsLogRewriter: SyntaxRewriter {
     }
 }
 
-// Public API for the library
+/// Public API for the library
 public func rewriteOsLogCalls(in sourceCode: String) throws -> String {
     let syntaxTree = Parser.parse(source: sourceCode)
     let rewriter = OsLogRewriter()

--- a/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "668dbf2009df850e4ef082e371adec396e99832c3e3a6ccfdf654b717dc3b002",
+  "originHash" : "ce87d13cdc46b65a26be6c5d8b5ee53a01cd0be7cf67b2a5fcbc83f121924b1f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftFormatPlugin",
       "state" : {
-        "revision" : "c41997c642ffc937c6e83b23dadbd7e626485cfa",
-        "version" : "0.58.7"
+        "revision" : "c7c81920d715e051306d2172083c14aaec2c1b9d",
+        "version" : "0.61.1"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftLintPlugin.git",
       "state" : {
-        "revision" : "47d1da3a8e30e0ada5543899e8c47f54664073ac",
-        "version" : "0.62.2"
+        "revision" : "3741567a0252090897336f1f39b8490107b49ead",
+        "version" : "0.63.3"
       }
     },
     {

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private let notificationDelegate = NotificationCenterDelegateImpl()
 
-    // Delegate Requests from the Watch to the WatchMessageService
+    /// Delegate Requests from the Watch to the WatchMessageService
     var session: WCSession? {
         didSet {
             if let session {
@@ -99,7 +99,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         configureImageCoders()
 
-        /// load and start the screensaver
+        // load and start the screensaver
         if let keyWindow = UIApplication.shared.firstKeyWindow {
             var config = ScreenSaverConfiguration()
             config.isEnabled = Preferences.shared.screensaverEnabled
@@ -192,7 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    // This is only informational - on success - DID Register
+    /// This is only informational - on success - DID Register
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         // Do nothing now, we are using FCM
     }

--- a/openHAB/Models/SitemapPageViewModel+SupportTypes.swift
+++ b/openHAB/Models/SitemapPageViewModel+SupportTypes.swift
@@ -68,7 +68,7 @@ struct QueuedCommand {
 }
 
 // swiftlint:disable:next file_types_order
-struct WidgetRenderKey: Equatable, Sendable {
+struct WidgetRenderKey: Equatable {
     let label: String
     let icon: String
     let state: String
@@ -148,50 +148,9 @@ struct WidgetRenderKey: Equatable, Sendable {
             childWidgets: widget.widgets.map(WidgetRenderKey.from)
         )
     }
-
-    // Keep this manual to avoid slow compile times for a very large synthesized implementation.
-    static func == (lhs: WidgetRenderKey, rhs: WidgetRenderKey) -> Bool {
-        lhs.label == rhs.label &&
-            lhs.icon == rhs.icon &&
-            lhs.state == rhs.state &&
-            lhs.iconColor == rhs.iconColor &&
-            lhs.labelColor == rhs.labelColor &&
-            lhs.valueColor == rhs.valueColor &&
-            lhs.url == rhs.url &&
-            lhs.period == rhs.period &&
-            lhs.service == rhs.service &&
-            lhs.legend == rhs.legend &&
-            lhs.refresh == rhs.refresh &&
-            lhs.height == rhs.height &&
-            lhs.forceAsItem == rhs.forceAsItem &&
-            lhs.visibility == rhs.visibility &&
-            lhs.staticIcon == rhs.staticIcon &&
-            lhs.switchSupport == rhs.switchSupport &&
-            lhs.releaseOnly == rhs.releaseOnly &&
-            lhs.minValue == rhs.minValue &&
-            lhs.maxValue == rhs.maxValue &&
-            lhs.step == rhs.step &&
-            lhs.pattern == rhs.pattern &&
-            lhs.unit == rhs.unit &&
-            lhs.type == rhs.type &&
-            lhs.inputHintRawValue == rhs.inputHintRawValue &&
-            lhs.encoding == rhs.encoding &&
-            lhs.labelSourceRawValue == rhs.labelSourceRawValue &&
-            lhs.yAxisDecimalPattern == rhs.yAxisDecimalPattern &&
-            lhs.row == rhs.row &&
-            lhs.column == rhs.column &&
-            lhs.releaseCommand == rhs.releaseCommand &&
-            lhs.command == rhs.command &&
-            lhs.stateless == rhs.stateless &&
-            lhs.linkedPageLink == rhs.linkedPageLink &&
-            lhs.linkedPageTitle == rhs.linkedPageTitle &&
-            lhs.mappings == rhs.mappings &&
-            lhs.item == rhs.item &&
-            lhs.childWidgets == rhs.childWidgets
-    }
 }
 
-struct WidgetMappingKey: Equatable, Sendable {
+struct WidgetMappingKey: Equatable {
     let command: String
     let label: String
     let row: Int?
@@ -209,7 +168,7 @@ struct WidgetMappingKey: Equatable, Sendable {
     }
 }
 
-struct WidgetItemKey: Equatable, Sendable {
+struct WidgetItemKey: Equatable {
     let name: String
     let state: String?
     let link: String
@@ -234,7 +193,7 @@ struct WidgetItemKey: Equatable, Sendable {
     }
 }
 
-struct WidgetStateDescriptionKey: Equatable, Sendable {
+struct WidgetStateDescriptionKey: Equatable {
     let minimum: Double
     let maximum: Double
     let step: Double
@@ -255,7 +214,7 @@ struct WidgetStateDescriptionKey: Equatable, Sendable {
     }
 }
 
-struct WidgetOptionKey: Equatable, Sendable {
+struct WidgetOptionKey: Equatable {
     let value: String
     let label: String
 
@@ -265,7 +224,7 @@ struct WidgetOptionKey: Equatable, Sendable {
     }
 }
 
-struct WidgetCommandOptionKey: Equatable, Sendable {
+struct WidgetCommandOptionKey: Equatable {
     let command: String
     let label: String?
 

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -364,11 +364,9 @@ extension SitemapPageViewModel {
         }
     }
 
-    private func runPageHandling(
-        runID: UUID,
-        recreateService: Bool,
-        pipelineStart: Date
-    ) async {
+    private func runPageHandling(runID: UUID,
+                                 recreateService: Bool,
+                                 pipelineStart: Date) async {
         defer {
             if activePageHandlingID == runID {
                 pageHandlingTask = nil

--- a/openHAB/Models/WidgetMappingSnapshot.swift
+++ b/openHAB/Models/WidgetMappingSnapshot.swift
@@ -12,6 +12,7 @@
 import Foundation
 import OpenHABCore
 
+// swiftformat:disable:next redundantSendable
 struct SnapshotRowInputBuildResult: Sendable {
     let inputs: [SitemapRowInput]
     let rowIDs: [RowID]
@@ -19,7 +20,7 @@ struct SnapshotRowInputBuildResult: Sendable {
     let reusedInputCount: Int
 }
 
-struct WidgetLinkedPageSnapshot: Sendable {
+struct WidgetLinkedPageSnapshot {
     let link: String
     let title: String
 }
@@ -96,7 +97,7 @@ enum SitemapRowInputSnapshotBuilder {
     }
 }
 
-struct WidgetMappingSnapshot: Sendable {
+struct WidgetMappingSnapshot {
     let widgetId: String
     let label: String
     let icon: String
@@ -255,7 +256,9 @@ extension WidgetMappingSnapshot {
         OpenHABWidget.LabelSource(rawValue: labelSourceRawValue) ?? .unknown
     }
 
-    var hasLinkedPage: Bool { linkedPage != nil }
+    var hasLinkedPage: Bool {
+        linkedPage != nil
+    }
 
     var mediaImageDescriptor: WidgetMediaImageDescriptor {
         let itemPayload: WidgetMediaItemPayloadSnapshot = if let item {

--- a/openHAB/NotificationCenterDelegateImpl.swift
+++ b/openHAB/NotificationCenterDelegateImpl.swift
@@ -22,11 +22,11 @@ import UIKit
 @preconcurrency import UserNotifications
 import WatchConnectivity
 
-// AVAudioPlayer must be created, used, and deallocated on the main thread.
-// Using a plain `actor` placed it on a background executor, causing a crash when
-// AVFoundation delivered finishedPlaying: on the main thread while the old player
-// was simultaneously being deallocated on the actor's background thread (mutex contention
-// in AVAudioPlayerCpp::DoAction / disposeQueue). @MainActor pins the entire lifecycle.
+/// AVAudioPlayer must be created, used, and deallocated on the main thread.
+/// Using a plain `actor` placed it on a background executor, causing a crash when
+/// AVFoundation delivered finishedPlaying: on the main thread while the old player
+/// was simultaneously being deallocated on the actor's background thread (mutex contention
+/// in AVAudioPlayerCpp::DoAction / disposeQueue). @MainActor pins the entire lifecycle.
 @MainActor
 final class AudioPlayerActor {
     private var player: AVAudioPlayer?
@@ -55,7 +55,7 @@ final class AudioPlayerActor {
 final class NotificationCenterDelegateImpl: NSObject, UNUserNotificationCenterDelegate {
     let audioPlayer = AudioPlayerActor()
 
-    // this is called when a notification comes in while in the foreground
+    /// this is called when a notification comes in while in the foreground
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
         Logger.notificationCenterDelegateImpl.info("Notification received while app is in foreground: \(userInfo)")
@@ -150,7 +150,7 @@ final class NotificationCenterDelegateImpl: NSObject, UNUserNotificationCenterDe
         SwiftMessages.hideAll()
     }
 
-    // ✅ Ensure this runs on the MainActor
+    /// ✅ Ensure this runs on the MainActor
     @MainActor
     func notifyNotificationListeners(action: String?, cloudUserId: String? = nil) {
         // Wake up screen saver immediately on incoming notification interaction

--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -64,9 +64,7 @@ enum DrawerFetch {
         }
     }
 
-    static func uiTiles(
-        fetch: () async throws -> [OpenHABUiTile]
-    ) async -> DrawerFetchResult<[OpenHABUiTile]> {
+    static func uiTiles(fetch: () async throws -> [OpenHABUiTile]) async -> DrawerFetchResult<[OpenHABUiTile]> {
         do {
             let uiTiles = try await fetch()
             try Task.checkCancellation()
@@ -79,7 +77,7 @@ enum DrawerFetch {
     }
 }
 
-// Display the active home name and connection type (Local / Remote)
+/// Display the active home name and connection type (Local / Remote)
 struct ConnectionView: View {
     @EnvironmentObject private var networkTracker: MainActorNetworkTracker
     @ScaledMetric private var iconWidth = 20.0

--- a/openHAB/UI/HostingSitemapViewController.swift
+++ b/openHAB/UI/HostingSitemapViewController.swift
@@ -59,7 +59,9 @@ class HostingSitemapViewController: UIHostingController<SitemapNavigationView>, 
         viewModel.pageTitle
     }
 
-    func viewName() -> String { "sitemap" }
+    func viewName() -> String {
+        "sitemap"
+    }
 
     nonisolated func reloadView() {
         Task { @MainActor in

--- a/openHAB/UI/NotificationsView.swift
+++ b/openHAB/UI/NotificationsView.swift
@@ -111,7 +111,7 @@ protocol NetworkTracking {
     var activeConnection: ConnectionInfo? { get }
 }
 
-struct NotificationsView<Tracker: NetworkTracking>: View where Tracker: ObservableObject {
+struct NotificationsView<Tracker: NetworkTracking & ObservableObject>: View {
     @ObservedObject var networkTracker: Tracker
     @State var notifications: [OpenHABNotification] = []
     let loadNotifications: NotificationLoader

--- a/openHAB/UI/OpenHABNavigationController.swift
+++ b/openHAB/UI/OpenHABNavigationController.swift
@@ -26,11 +26,15 @@ import UIKit
 /// This is a wrapper around UINavigationController that allows the status bar to be hidden or shown.
 /// It is used to control the status bar for the entire app and is loaded from the Main storyboard entry point.
 class OpenHABNavigationController: UINavigationController {
-    override var childForStatusBarHidden: UIViewController? { nil }
+    override var childForStatusBarHidden: UIViewController? {
+        nil
+    }
 
     override var prefersStatusBarHidden: Bool {
         Preferences.shared.hideStatusBar
     }
 
-    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation { .fade }
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        .fade
+    }
 }

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -94,8 +94,7 @@ class OpenHABRootViewController: UIViewController {
 
     private lazy var webViewController: OpenHABWebViewController = {
         let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
-        var viewController = storyboard.instantiateViewController(withIdentifier: "OpenHABWebViewController") as! OpenHABWebViewController
-        return viewController
+        return storyboard.instantiateViewController(withIdentifier: "OpenHABWebViewController") as! OpenHABWebViewController
     }()
 
     lazy var sitemapViewController: any (UIViewController & OpenHABViewable) = {
@@ -632,7 +631,8 @@ class OpenHABRootViewController: UIViewController {
                 Preferences.shared.switchActiveHome(to: targetHome.id)
             }
             // if the app was woken from a fully stopped state, network tracking might not be active yet
-            await NetworkTracker.shared.startTracking(connectionConfigurations:
+            await NetworkTracker.shared.startTracking(
+                connectionConfigurations:
                 [
                     Preferences.shared.currentHomePreferences.localConnectionConfig,
                     Preferences.shared.currentHomePreferences.remoteConnectionConfig
@@ -668,7 +668,7 @@ class OpenHABRootViewController: UIViewController {
         }
     }
 
-    // Helper function to safely call the completion handler on the main thread
+    /// Helper function to safely call the completion handler on the main thread
     private func callCompletionHandler(_ completionHandler: (() -> Void)?) {
         if let completionHandler {
             DispatchQueue.main.async {

--- a/openHAB/UI/OpenHABViewController.swift
+++ b/openHAB/UI/OpenHABViewController.swift
@@ -111,7 +111,7 @@ class OpenHABViewController: UIViewController, OpenHABViewable {
 // MARK: - ServerCertificateManagerDelegate
 
 extension OpenHABViewController: ServerCertificateManagerDelegate {
-    // delegate should ask user for a decision on what to do with invalid certificate
+    /// delegate should ask user for a decision on what to do with invalid certificate
     @MainActor
     func evaluateServerTrust(summary certificateSummary: String?, forDomain domain: String?) async -> ServerCertificateManager.EvaluateResult {
         await withCheckedContinuation { continuation in
@@ -133,7 +133,7 @@ extension OpenHABViewController: ServerCertificateManagerDelegate {
         }
     }
 
-    // certificate received from openHAB doesn't match our record, ask user for a decision
+    /// certificate received from openHAB doesn't match our record, ask user for a decision
     @MainActor
     func evaluateCertificateMismatch(summary certificateSummary: String?, forDomain domain: String?) async -> OpenHABCore.ServerCertificateManager.EvaluateResult {
         await withCheckedContinuation { continuation in
@@ -168,7 +168,7 @@ extension OpenHABViewController: ServerCertificateManagerDelegate {
 
 @MainActor
 extension OpenHABViewController: ClientCertificateManagerDelegate {
-    // Ask user whether to import the certificate
+    /// Ask user whether to import the certificate
     func askForClientCertificateImport(_ clientCertificateManager: ClientCertificateManager?) async -> Bool {
         let shouldImport = await withCheckedContinuation { continuation in
             let alertController = UIAlertController(
@@ -198,7 +198,7 @@ extension OpenHABViewController: ClientCertificateManagerDelegate {
         return false
     }
 
-    // Ask user for password to decode PKCS#12
+    /// Ask user for password to decode PKCS#12
     func askForCertificatePassword(_ clientCertificateManager: ClientCertificateManager?) async -> String? {
         await withCheckedContinuation { continuation in
             let alertController = UIAlertController(

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -22,7 +22,10 @@ class OpenHABWebViewController: OpenHABViewController {
     private var currentTarget = ""
     private var openHABTrackedRootUrl = ""
     private var activeConnectionInfo: ConnectionInfo?
-    private var activeConfig: ConnectionConfiguration? { activeConnectionInfo?.configuration }
+    private var activeConfig: ConnectionConfiguration? {
+        activeConnectionInfo?.configuration
+    }
+
     private var hideNavigationBar = false
     private var activityIndicator: UIActivityIndicatorView!
     private var sseTimer: Timer?
@@ -348,7 +351,7 @@ class OpenHABWebViewController: OpenHABViewController {
         return url
     }
 
-    // swift really makes you work to construct simple URLs, uhg.....
+    /// swift really makes you work to construct simple URLs, uhg.....
     func appendPathToURL(baseURL: URL, path: String) -> URL? {
         guard var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             return nil

--- a/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
+++ b/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
@@ -15,8 +15,13 @@ import SwiftUI
 import UIKit
 
 private class ScreenSaverHostingViewController: UIViewController {
-    override var prefersStatusBarHidden: Bool { true }
-    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation { .fade }
+    override var prefersStatusBarHidden: Bool {
+        true
+    }
+
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        .fade
+    }
 }
 
 @MainActor

--- a/openHAB/UI/SettingsView/ItemSelectionView.swift
+++ b/openHAB/UI/SettingsView/ItemSelectionView.swift
@@ -75,7 +75,6 @@ struct ItemSelectionView: View {
         }
     }
 
-    @ViewBuilder
     private func itemRow(_ item: OpenHABItem) -> some View {
         Button {
             selectedItemName = (selectedItemName == item.name) ? nil : item.name

--- a/openHAB/UI/SettingsView/ScreenSaverSettingsView.swift
+++ b/openHAB/UI/SettingsView/ScreenSaverSettingsView.swift
@@ -117,14 +117,12 @@ struct ScreenSaverSettingsView: View {
         )
     }
 
-    @ViewBuilder
     private var enableSection: some View {
         Section {
             Toggle("Enable Screen Saver", isOn: $config.isEnabled)
         }
     }
 
-    @ViewBuilder
     private var appearanceSection: some View {
         Section("Appearance") {
             Toggle("Show Time", isOn: $config.showsTime)
@@ -140,7 +138,6 @@ struct ScreenSaverSettingsView: View {
         .disabled(!config.isEnabled)
     }
 
-    @ViewBuilder
     private var timingSection: some View {
         Section("Timing") {
             Stepper(value: idleIntervalBinding, in: 5 ... 600, step: 5) {
@@ -154,7 +151,6 @@ struct ScreenSaverSettingsView: View {
         .disabled(!config.isEnabled)
     }
 
-    @ViewBuilder
     private var fontSection: some View {
         Section("Font Size") {
             VStack(alignment: .leading) {
@@ -174,7 +170,6 @@ struct ScreenSaverSettingsView: View {
         .disabled(!config.isEnabled)
     }
 
-    @ViewBuilder
     private var animationSection: some View {
         Section("Animation") {
             VStack(alignment: .leading) {
@@ -187,7 +182,6 @@ struct ScreenSaverSettingsView: View {
         .disabled(!config.isEnabled)
     }
 
-    @ViewBuilder
     private var brightnessSection: some View {
         Section("Brightness") {
             Toggle("Enable Dimming", isOn: $config.enablesAutoDimming)
@@ -214,7 +208,6 @@ struct ScreenSaverSettingsView: View {
         .disabled(!config.isEnabled)
     }
 
-    @ViewBuilder
     private var testSection: some View {
         Section {
             Button("Test Screen Saver") {

--- a/openHAB/UI/SettingsView/SitemapSettingsView.swift
+++ b/openHAB/UI/SettingsView/SitemapSettingsView.swift
@@ -36,21 +36,18 @@ struct SitemapSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private var realtimeSliderToggle: some View {
         Toggle(isOn: $settingsRealTimeSliders) {
             Text("Real-time Sliders")
         }
     }
 
-    @ViewBuilder
     private var searchFieldToggle: some View {
         Toggle(isOn: $settingsShowSearchField) {
             Text("Show Search Field")
         }
     }
 
-    @ViewBuilder
     private var cacheButton: some View {
         Button {
             KingfisherManager.shared.cache.calculateDiskStorageSize { result in
@@ -72,7 +69,6 @@ struct SitemapSettingsView: View {
         )
     }
 
-    @ViewBuilder
     private var iconTypePicker: some View {
         Picker(selection: $settingsIconType) {
             ForEach(IconType.allCases, id: \.self) { icontype in
@@ -83,7 +79,6 @@ struct SitemapSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private var sortOrderPicker: some View {
         Picker(selection: $settingsSortSitemapsBy) {
             ForEach(SortSitemapsOrder.allCases, id: \.self) { sortsitemaporder in
@@ -94,7 +89,6 @@ struct SitemapSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private var watchSitemapPicker: some View {
         Picker("Sitemap for Apple Watch", selection: $settingsSitemapForWatch) {
             if sitemaps.isEmpty {

--- a/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
+++ b/openHAB/UI/SwiftUI/EmbeddingRowInputView.swift
@@ -122,9 +122,9 @@ private struct LinkedPageRowContent: View {
 struct EmbeddingRowInputView: View, Equatable {
     let rowInput: SitemapRowInput
 
-    // Subscribes to the view model so SwiftUI re-evaluates this view when
-    // rowInputs change — without this, rows that scroll into view after a
-    // foreground refresh may render stale data from a cached render.
+    /// Subscribes to the view model so SwiftUI re-evaluates this view when
+    /// rowInputs change — without this, rows that scroll into view after a
+    /// foreground refresh may render stale data from a cached render.
     @EnvironmentObject private var viewModel: SitemapPageViewModel
 
     var body: some View {

--- a/openHAB/UI/SwiftUI/ImageView.swift
+++ b/openHAB/UI/SwiftUI/ImageView.swift
@@ -23,7 +23,6 @@ struct ImageView: View {
 
     @EnvironmentObject var networkTracker: MainActorNetworkTracker
 
-    @ViewBuilder
     var body: some View {
         if !url.isEmpty {
             switch url {

--- a/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ColorTemperaturePickerRowView.swift
@@ -276,7 +276,7 @@ private struct ColorTemperaturePickerRowContent: View {
         }
     }
 
-    // Generate gradient colors similar to Android implementation
+    /// Generate gradient colors similar to Android implementation
     private func colorTemperatureGradient(steps: Int = 20) -> [Color] {
         ColorTemperatureRowMath.gradientTemperatures(for: temperatureRange, steps: steps).map { Color(temperature: $0) }
     }

--- a/openHAB/UI/SwiftUI/Rows/DatePickerInputRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/DatePickerInputRowView.swift
@@ -113,11 +113,11 @@ struct DatePickerInputRowView: View {
     var body: some View {
         makeDateInputRowContent(
             DateInputRowConfig(
-                input: input) { command in
-                    guard let itemName = input.itemName else { return }
-                    viewModel.sendCommand(command, for: itemName)
-                    // swiftlint:disable:next closure_end_indentation
-                }
+                input: input
+            ) { command in
+                guard let itemName = input.itemName else { return }
+                viewModel.sendCommand(command, for: itemName)
+            }
         )
     }
 }

--- a/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SegmentedRowView.swift
@@ -111,7 +111,6 @@ private struct SegmentedRowContent: View {
     }
 
     /// Button-based segmented control with animated selection indicator
-    @ViewBuilder
     private func segmentedButtons(mappings: [OpenHABWidgetMapping],
                                   selectedIndex: Int?,
                                   displayState: WidgetDisplayState,
@@ -154,7 +153,6 @@ private struct SegmentedRowContent: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    @ViewBuilder
     private func pressReleaseButtons(mappings: [OpenHABWidgetMapping]) -> some View {
         HStack(spacing: 8) {
             ForEach(mappings.indices, id: \.self) { index in

--- a/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SelectionRowView.swift
@@ -56,7 +56,6 @@ private struct SelectionRowContent: View {
         }
     }
 
-    @ViewBuilder
     private func rowContent(displayedCommand: String) -> some View {
         RowViewWithIcon(input: input) {
             if !input.displayState.labelText.isEmpty {

--- a/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/SliderRowView.swift
@@ -122,7 +122,7 @@ private struct SliderRowContent: View {
             guard dragWidgetId == input.widgetId, let dragStartVersion else {
                 isEditing = false
                 dragValue = nil
-                self.dragStartVersion = nil
+                dragStartVersion = nil
                 dragWidgetId = nil
                 return
             }

--- a/openHAB/UI/SwiftUI/Rows/TextInputRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/TextInputRowView.swift
@@ -64,9 +64,9 @@ struct InputCommandFormatter {
 
     // MARK: initial draft from server state
 
-    // Formats a Double (always dot-decimal from the server) using the locale decimal separator.
-    // Whole numbers are rendered without a decimal point (220.0 → "220").
-    // Uses NumberFormatter to avoid Swift's exponent notation for small values (e.g. 1e-05).
+    /// Formats a Double (always dot-decimal from the server) using the locale decimal separator.
+    /// Whole numbers are rendered without a decimal point (220.0 → "220").
+    /// Uses NumberFormatter to avoid Swift's exponent notation for small values (e.g. 1e-05).
     func localeFormattedValue(_ value: Double) -> String {
         if value.truncatingRemainder(dividingBy: 1) == 0,
            value >= Double(Int.min),
@@ -82,8 +82,8 @@ struct InputCommandFormatter {
         return formatter.string(from: NSNumber(value: value)) ?? String(value)
     }
 
-    // Extracts the numeric portion from a formatted state string, e.g. "220 °C" → "220".
-    // For non-number inputs the string is returned unchanged.
+    /// Extracts the numeric portion from a formatted state string, e.g. "220 °C" → "220".
+    /// For non-number inputs the string is returned unchanged.
     func numericDraftFromState(_ text: String) -> String {
         guard !text.isEmpty else { return text }
         var result = ""
@@ -103,7 +103,7 @@ struct InputCommandFormatter {
         return result
     }
 
-    // Extracts the unit suffix from a formatted state string, e.g. "220 °C" → " °C", "220" → "".
+    /// Extracts the unit suffix from a formatted state string, e.g. "220 °C" → " °C", "220" → "".
     func unitSuffixFromState(_ text: String) -> String {
         guard !text.isEmpty else { return "" }
         var i = text.startIndex
@@ -194,8 +194,8 @@ private struct TextInputRowContent: View {
         inputCommandFormatter.command(from: draftInputText, hint: inputHint, unitSuffix: draftUnitSuffix)
     }
 
-    // Display value for number inputs: apply the number pattern with the current locale,
-    // falling back to the server-formatted label value, then the raw state string.
+    /// Display value for number inputs: apply the number pattern with the current locale,
+    /// falling back to the server-formatted label value, then the raw state string.
     private var formattedDisplayText: String {
         guard inputHint == .number, !inputText.isEmpty else { return inputText }
         if let pattern = input.numberPattern, !pattern.isEmpty {
@@ -234,11 +234,13 @@ private struct TextInputRowContent: View {
                     prepareEditDraft()
                     showInputAlert = true
                 } label: {
-                    Text(inputText.isEmpty
-                        ? "Enter \(inputHint == .number ? "number" : "text")"
-                        : formattedDisplayText)
-                        .lineLimit(nil)
-                        .foregroundStyle(inputText.isEmpty ? .secondary : (input.valueColor.isEmpty ? .secondary : Color(fromString: input.valueColor)))
+                    Text(
+                        inputText.isEmpty
+                            ? "Enter \(inputHint == .number ? "number" : "text")"
+                            : formattedDisplayText
+                    )
+                    .lineLimit(nil)
+                    .foregroundStyle(inputText.isEmpty ? .secondary : (input.valueColor.isEmpty ? .secondary : Color(fromString: input.valueColor)))
                 }
                 .buttonStyle(.plain)
                 .disabled(input.readOnly)
@@ -324,11 +326,11 @@ struct TextInputRowView: View {
     var body: some View {
         makeTextInputRowContent(
             TextInputRowConfig(
-                input: input) { command in
-                    guard let itemName = input.itemName else { return }
-                    viewModel.sendCommand(command, for: itemName)
-                    // swiftlint:disable:next closure_end_indentation
-                }
+                input: input
+            ) { command in
+                guard let itemName = input.itemName else { return }
+                viewModel.sendCommand(command, for: itemName)
+            }
         )
     }
 }

--- a/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
+++ b/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
@@ -137,9 +137,8 @@ enum SitemapDiagnostics {
                           applyStateMs: Int,
                           totalUpdateMs: Int) {
         guard isEnabled else { return }
-        logger.info(
-            "update origin=\(origin.rawValue, privacy: .public) widgets=\(widgetCount, privacy: .public) rows=\(rowCount, privacy: .public) inputsChanged=\(inputsChanged, privacy: .public) titleChanged=\(titleChanged, privacy: .public) reusedInputs=\(reusedInputCount, privacy: .public) changedRows=\(changedRowCount, privacy: .public) changedKinds=\(changedRowKinds, privacy: .public) buildRowInputsMs=\(buildRowInputsMs, privacy: .public) applyStateMs=\(applyStateMs, privacy: .public) analysisMs=\(analysisMs, privacy: .public) totalUpdateMs=\(totalUpdateMs, privacy: .public)"
-        )
+        // swiftlint:disable:next line_length
+        logger.info("update origin=\(origin.rawValue, privacy: .public) widgets=\(widgetCount, privacy: .public) rows=\(rowCount, privacy: .public) inputsChanged=\(inputsChanged, privacy: .public) titleChanged=\(titleChanged, privacy: .public) reusedInputs=\(reusedInputCount, privacy: .public) changedRows=\(changedRowCount, privacy: .public) changedKinds=\(changedRowKinds, privacy: .public) buildRowInputsMs=\(buildRowInputsMs, privacy: .public) applyStateMs=\(applyStateMs, privacy: .public) analysisMs=\(analysisMs, privacy: .public) totalUpdateMs=\(totalUpdateMs, privacy: .public)")
     }
 
     static func logLongPoll(requestMs: Int,
@@ -158,16 +157,17 @@ enum SitemapDiagnostics {
                                     replacedPendingPage: Bool,
                                     coalescedUpdates: Int) {
         guard isEnabled else { return }
+        // swiftlint:disable line_length
         logger.info(
             "longPollDebounce action=\(action, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public) remainingMs=\(remainingMs, privacy: .public) replacedPendingPage=\(replacedPendingPage, privacy: .public) coalescedUpdates=\(coalescedUpdates, privacy: .public)"
         )
+        // swiftlint:enable line_length
     }
 
     static func logIconSummary(_ snapshot: IconLoadDiagnosticsSnapshot) {
         guard isEnabled, !snapshot.isEmpty else { return }
-        logger.info(
-            "icons resolutionFailures=\(snapshot.resolutionFailures, privacy: .public) starts=\(snapshot.starts, privacy: .public) successes=\(snapshot.successes, privacy: .public) memoryHits=\(snapshot.memoryHits, privacy: .public) diskHits=\(snapshot.diskHits, privacy: .public) networkLoads=\(snapshot.networkLoads, privacy: .public) cancellations=\(snapshot.cancellations, privacy: .public) failures=\(snapshot.failures, privacy: .public) distinctURLs=\(snapshot.distinctURLs, privacy: .public) distinctRows=\(snapshot.distinctRows, privacy: .public)"
-        )
+        // swiftlint:disable:next line_length
+        logger.info("icons resolutionFailures=\(snapshot.resolutionFailures, privacy: .public) starts=\(snapshot.starts, privacy: .public) successes=\(snapshot.successes, privacy: .public) memoryHits=\(snapshot.memoryHits, privacy: .public) diskHits=\(snapshot.diskHits, privacy: .public) networkLoads=\(snapshot.networkLoads, privacy: .public) cancellations=\(snapshot.cancellations, privacy: .public) failures=\(snapshot.failures, privacy: .public) distinctURLs=\(snapshot.distinctURLs, privacy: .public) distinctRows=\(snapshot.distinctRows, privacy: .public)")
     }
 
     static func logIconResolutionFailure(rowIdentity: String,
@@ -176,9 +176,11 @@ enum SitemapDiagnostics {
                                          trackerStatus: String,
                                          connectionDescription: String) {
         guard isEnabled else { return }
+        // swiftlint:disable line_length
         logger.info(
             "iconResolutionFailure row=\(rowIdentity, privacy: .private(mask: .hash)) icon=\(icon, privacy: .public) reason=\(reason, privacy: .public) trackerStatus=\(trackerStatus, privacy: .public) connection=\(connectionDescription, privacy: .public)"
         )
+        // swiftlint:enable line_length
     }
 
     static func logIconStart(rowIdentity: String, icon: String, url: URL, cacheKey: String) {

--- a/openHAB/UI/SwiftUI/SitemapRowInput.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowInput.swift
@@ -14,7 +14,7 @@ import OpenHABCore
 
 /// Stable identity for a row snapshot.
 /// Occurrence disambiguates repeated widget IDs in one page payload.
-struct RowID: Hashable, Sendable {
+struct RowID: Hashable {
     let pageKey: String
     let widgetId: String
     let occurrence: Int
@@ -34,7 +34,7 @@ struct LinkedPageNavigation: Hashable {
 
 /// Draft immutable row union for a list-driven SwiftUI pipeline.
 /// Each row case carries a dedicated typed input.
-enum SitemapRowInput: Identifiable, Equatable, Sendable {
+enum SitemapRowInput: Identifiable, Equatable {
     case frame(RowID, FrameRowInput)
     case linked(RowID, LinkedPageRowInput)
     case text(RowID, TextRowInput)

--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -17,7 +17,7 @@ protocol RowWithIconInput {
     var icon: RowIconInput { get }
 }
 
-struct RowIconInput: Equatable, Sendable {
+struct RowIconInput: Equatable {
     let icon: String
     let iconColor: String
     let staticIcon: Bool
@@ -220,7 +220,7 @@ struct RollershutterRowInput: Equatable, RowWithIconInput {
     }
 }
 
-struct InputRowInput: Sendable, Equatable, RowWithIconInput {
+struct InputRowInput: Equatable, RowWithIconInput {
     let widgetId: String
     let renderingKind: WidgetRenderingKind
     let displayState: WidgetDisplayState
@@ -258,7 +258,7 @@ struct InputRowInput: Sendable, Equatable, RowWithIconInput {
 }
 
 struct ButtonGridRowInput: Equatable, RowWithIconInput {
-    struct ButtonInput: Equatable, Sendable, Identifiable {
+    struct ButtonInput: Equatable, Identifiable {
         let id: String
         let label: String
         let icon: RowIconInput

--- a/openHAB/UI/Watch/WatchMessageService.swift
+++ b/openHAB/UI/Watch/WatchMessageService.swift
@@ -15,8 +15,8 @@ import OpenHABCore
 import os.log
 import WatchConnectivity
 
-// This class receives Watch Request for the configuration data like localUrl.
-// The functionality is activated in the AppDelegate.
+/// This class receives Watch Request for the configuration data like localUrl.
+/// The functionality is activated in the AppDelegate.
 class WatchMessageService: NSObject, WCSessionDelegate {
     @MainActor
     static let singleton = WatchMessageService()
@@ -26,8 +26,8 @@ class WatchMessageService: NSObject, WCSessionDelegate {
 
     private var preferencesSubscription: AnyCancellable?
 
-    // This method gets called when the watch requests the data
-    // ⚠️ This is called off the main thread. Do NOT touch @MainActor stuff.
+    /// This method gets called when the watch requests the data
+    /// ⚠️ This is called off the main thread. Do NOT touch @MainActor stuff.
     func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
         guard message["request"] != nil else { return }
 

--- a/openHABTestsSwift/ColorTemperatureRowMathTests.swift
+++ b/openHABTestsSwift/ColorTemperatureRowMathTests.swift
@@ -10,7 +10,6 @@
 // SPDX-License-Identifier: EPL-2.0
 
 @testable import openHAB
-
 import Testing
 
 private enum TestValues {
@@ -35,7 +34,6 @@ private enum TestValues {
     static let zero = 0.0
 }
 
-@Suite
 struct ColorTemperatureRowMathTests {
     @Test
     func normalizedRangeUsesFallbackForZeroSpan() {

--- a/openHABTestsSwift/IconReloadCoordinatorTests.swift
+++ b/openHABTestsSwift/IconReloadCoordinatorTests.swift
@@ -14,7 +14,6 @@ import Foundation
 import Testing
 
 @MainActor
-@Suite
 struct IconReloadCoordinatorTests {
     // Each test creates an isolated coordinator instance rather than using the shared
     // singleton, so tests do not interfere with each other.

--- a/openHABTestsSwift/InputCommandFormatterTests.swift
+++ b/openHABTestsSwift/InputCommandFormatterTests.swift
@@ -16,7 +16,6 @@ import Testing
 
 // MARK: - isValidNumberDraft with comma separator
 
-@Suite
 struct InputCommandFormatterCommaTests {
     let formatter = InputCommandFormatter(decimalSeparator: ",")
 
@@ -68,7 +67,6 @@ struct InputCommandFormatterCommaTests {
 
 // MARK: - UIKit oracle (reference implementation)
 
-@Suite
 struct InputCommandFormatterOracleTests {
     /// Port of the UIKit `textField(_:shouldChangeCharactersIn:replacementString:)` logic.
     /// Given the old text, the NSRange being replaced, and the replacement string, returns
@@ -358,7 +356,6 @@ struct InputCommandFormatterOracleTests {
 
 // MARK: - localeFormattedValue with comma separator
 
-@Suite
 struct InputCommandFormattedValueCommaTests {
     let formatter = InputCommandFormatter(decimalSeparator: ",")
 
@@ -393,7 +390,6 @@ struct InputCommandFormattedValueCommaTests {
     }
 }
 
-@Suite
 struct InputCommandFormatterTests {
     let formatter = InputCommandFormatter(decimalSeparator: ".")
 

--- a/openHABTestsSwift/LocalizationTests.swift
+++ b/openHABTestsSwift/LocalizationTests.swift
@@ -9,9 +9,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
-@testable import openHAB
-
 import Foundation
+@testable import openHAB
 import Testing
 
 private final class BundleLocator: AnyObject {}

--- a/openHABTestsSwift/OpenHABEndPoint.swift
+++ b/openHABTestsSwift/OpenHABEndPoint.swift
@@ -20,7 +20,7 @@ class OpenHABEndPoint: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
+    func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         // Any test you write for XCTest can be annotated as throws and async.
@@ -28,7 +28,7 @@ class OpenHABEndPoint: XCTestCase {
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
     }
 
-    func testPerformanceExample() throws {
+    func testPerformanceExample() {
         // This is an example of a performance test case.
         measure {
             // Put the code you want to measure the time of here.

--- a/openHABTestsSwift/OpenHABSVGTests.swift
+++ b/openHABTestsSwift/OpenHABSVGTests.swift
@@ -15,7 +15,6 @@ import UIKit
 
 private final class OpenHABSVGTestsBundleToken {}
 
-@Suite
 struct OpenHABSVGTests {
     private func renderSVG(named name: String) throws -> UIImage? {
         let bundle = Bundle(for: OpenHABSVGTestsBundleToken.self)
@@ -30,9 +29,9 @@ struct OpenHABSVGTests {
         return OpenHABImageProcessor().process(data: data)
     }
 
-    // The app-level contract is graceful SVG handling via OpenHABImageProcessor.
-    // Some fixtures are not directly decodable by Apple's built-in SVG renderer,
-    // but the processor must still return a fallback image instead of nil.
+    /// The app-level contract is graceful SVG handling via OpenHABImageProcessor.
+    /// Some fixtures are not directly decodable by Apple's built-in SVG renderer,
+    /// but the processor must still return a fallback image instead of nil.
     @Test
     func validSVGWithEmbeddedPNG() throws {
         let image = try renderSVG(named: "embeddedpng_valid")

--- a/openHABTestsSwift/RowLayoutPolicyTests.swift
+++ b/openHABTestsSwift/RowLayoutPolicyTests.swift
@@ -14,7 +14,6 @@ import OpenHABCore
 import SwiftUI
 import Testing
 
-@Suite
 struct RowLayoutPolicyTests {
     @Test
     func linkedFrameUsesFrameInsetsAndBackground() {

--- a/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
+++ b/openHABTestsSwift/ScreenSaverLayoutCalculatorTests.swift
@@ -13,7 +13,6 @@ import CoreGraphics
 @testable import openHAB
 import Testing
 
-@Suite
 struct ScreenSaverLayoutCalculatorTests {
     @Test
     func oversizedTimeTextScalesDownToFitHorizontalMargins() {

--- a/openHABTestsSwift/SitemapPageViewModelForegroundTests.swift
+++ b/openHABTestsSwift/SitemapPageViewModelForegroundTests.swift
@@ -12,15 +12,14 @@
 @testable import openHAB
 import Testing
 
-// Regression test for the "foreground thundering herd" bug:
-// All retained SitemapPageViewModels receiving UIApplication.didBecomeActiveNotification
-// and simultaneously restarting page load/polling on app foreground.
-//
-// Only a visible page (between markAppeared and stopPageHandling) must react to
-// refreshOnForeground. Pages that were stopped because they scrolled off-screen
-// or were navigated away from must stay silent.
+/// Regression test for the "foreground thundering herd" bug:
+/// All retained SitemapPageViewModels receiving UIApplication.didBecomeActiveNotification
+/// and simultaneously restarting page load/polling on app foreground.
+///
+/// Only a visible page (between markAppeared and stopPageHandling) must react to
+/// refreshOnForeground. Pages that were stopped because they scrolled off-screen
+/// or were navigated away from must stay silent.
 @MainActor
-@Suite
 struct SitemapPageViewModelForegroundTests {
     // lastForegroundRefreshAt advances only when the visibility guard passes, making
     // it the right synchronous observable for these tests — no Task.yield needed.

--- a/openHABTestsSwift/SitemapRowInputBuilderTests.swift
+++ b/openHABTestsSwift/SitemapRowInputBuilderTests.swift
@@ -13,7 +13,6 @@
 import OpenHABCore
 import Testing
 
-@Suite
 struct WidgetMappingSnapshotDisplayStateTests {
     @Test
     func labelOnlyInBracketsDoesNotLeakIntoLabelText() {
@@ -51,7 +50,6 @@ struct WidgetMappingSnapshotDisplayStateTests {
     }
 }
 
-@Suite
 struct SitemapRowInputBuilderTests {
     @Test
     func incrementalRebuildReusesUnchangedRows() {

--- a/openHABTestsSwift/SitemapRowInputMapperTests.swift
+++ b/openHABTestsSwift/SitemapRowInputMapperTests.swift
@@ -13,7 +13,6 @@
 import OpenHABCore
 import Testing
 
-@Suite
 struct SitemapRowInputMapperTests {
     @Test
     func linkedPageWidgetsAlwaysMapToLinked() {

--- a/openHABTestsSwift/SliderOverrideSyncTests.swift
+++ b/openHABTestsSwift/SliderOverrideSyncTests.swift
@@ -14,7 +14,6 @@ import OpenHABCore
 import Testing
 
 @MainActor
-@Suite
 struct SliderOverrideSyncTests {
     @Test
     func clearsSliderOverrideWhenServerCatchesUp() {

--- a/openHABTestsSwift/URLWebViewPathTests.swift
+++ b/openHABTestsSwift/URLWebViewPathTests.swift
@@ -15,14 +15,14 @@ import Testing
 
 @Suite("relativeWebViewPath(proxyURL:rootURLString:)")
 struct RelativeWebViewPathFunctionTests {
-    @Test func prefersProxyURLWhenPresent() {
-        let proxy = URL(string: "https://host/proxy")!
+    @Test func prefersProxyURLWhenPresent() throws {
+        let proxy = try #require(URL(string: "https://host/proxy"))
         let result = relativeWebViewPath("/proxy/ui", proxyURL: proxy, rootURLString: "https://host")
         #expect(result == "/ui")
     }
 
-    @Test func proxyDoesNotMatchSiblingPath() {
-        let proxy = URL(string: "https://host/proxy")!
+    @Test func proxyDoesNotMatchSiblingPath() throws {
+        let proxy = try #require(URL(string: "https://host/proxy"))
         let result = relativeWebViewPath("/proxy2/ui", proxyURL: proxy, rootURLString: "https://host")
         #expect(result == "/proxy2/ui")
     }
@@ -42,50 +42,50 @@ struct RelativeWebViewPathFunctionTests {
 struct URLWebViewPathTests {
     // MARK: - Exact match
 
-    @Test func exactBasePath() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func exactBasePath() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         #expect(url.relativeWebViewPath(for: "/openhab") == "/")
     }
 
     // MARK: - Normal sub-path stripping
 
-    @Test func stripsBasePath() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func stripsBasePath() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         #expect(url.relativeWebViewPath(for: "/openhab/ui") == "/ui")
     }
 
-    @Test func stripsBasePathWithTrailingSlash() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func stripsBasePathWithTrailingSlash() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         #expect(url.relativeWebViewPath(for: "/openhab/ui/") == "/ui/")
     }
 
     // MARK: - Sibling-path false-match guard (the bug this fixes)
 
-    @Test func doesNotMatchSiblingWithSamePrefix() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func doesNotMatchSiblingWithSamePrefix() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         // /openhab2/ui must NOT be treated as a sub-path of /openhab
         #expect(url.relativeWebViewPath(for: "/openhab2/ui") == "/openhab2/ui")
     }
 
-    @Test func doesNotMatchSiblingExactPrefix() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func doesNotMatchSiblingExactPrefix() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         #expect(url.relativeWebViewPath(for: "/openhab2") == "/openhab2")
     }
 
     // MARK: - Edge cases
 
-    @Test func emptyBasePath() {
-        let url = URL(string: "https://host")!
+    @Test func emptyBasePath() throws {
+        let url = try #require(URL(string: "https://host"))
         #expect(url.relativeWebViewPath(for: "/ui") == "/ui")
     }
 
-    @Test func rootBasePath() {
-        let url = URL(string: "https://host/")!
+    @Test func rootBasePath() throws {
+        let url = try #require(URL(string: "https://host/"))
         #expect(url.relativeWebViewPath(for: "/ui") == "/ui")
     }
 
-    @Test func unrelatedPath() {
-        let url = URL(string: "https://host/openhab")!
+    @Test func unrelatedPath() throws {
+        let url = try #require(URL(string: "https://host/openhab"))
         #expect(url.relativeWebViewPath(for: "/other/path") == "/other/path")
     }
 }

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -13,7 +13,6 @@
 import Testing
 import WebKit
 
-@Suite
 struct WebRowViewConfigurationTests {
     @MainActor
     @Test

--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -31,9 +31,9 @@ final class UserData: ObservableObject {
     private var cachedWidgets: [OpenHABWidget] = []
     private var currentlyLoadingSitemap: String?
     private var lastObservedConnectionURL: String?
-    // Incremented each time a new pageHandlingTask is created. The task captures its own
-    // generation at creation time and only clears shared state when the generation still matches,
-    // preventing a completing old task from wiping out a newly started task for the same sitemap.
+    /// Incremented each time a new pageHandlingTask is created. The task captures its own
+    /// generation at creation time and only clears shared state when the generation still matches,
+    /// preventing a completing old task from wiping out a newly started task for the same sitemap.
     private var taskGeneration = 0
 
     private var pageHandlingTask: Task<Void, Never>?

--- a/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
+++ b/openHABWatch/Extension/OpenHABWatchAppDelegate.swift
@@ -12,7 +12,6 @@
 import Kingfisher
 import OpenHABCore
 import os.log
-
 import WatchConnectivity
 import WatchKit
 

--- a/openHABWatch/External/AppMessageService.swift
+++ b/openHABWatch/External/AppMessageService.swift
@@ -15,15 +15,15 @@ import os.log
 import WatchConnectivity
 import WatchKit
 
-// This class handles values that are passed from the ios app.
-// @unchecked Sendable: all mutable state (@MainActor contextRequestInFlight) is actor-protected;
-// WCSession delegate callbacks are non-isolated and only schedule Tasks, never mutate directly.
+/// This class handles values that are passed from the ios app.
+/// @unchecked Sendable: all mutable state (@MainActor contextRequestInFlight) is actor-protected;
+/// WCSession delegate callbacks are non-isolated and only schedule Tasks, never mutate directly.
 class AppMessageService: NSObject, WCSessionDelegate, @unchecked Sendable {
     @MainActor static let singleton = AppMessageService()
 
     private static let preferencesKey = "watchPreferences"
 
-    // Accessed only from @MainActor context (requestApplicationContext and its Task completions).
+    /// Accessed only from @MainActor context (requestApplicationContext and its Task completions).
     @MainActor private var contextRequestInFlight = false
 
     @MainActor

--- a/openHABWatch/Model/LazyView.swift
+++ b/openHABWatch/Model/LazyView.swift
@@ -12,7 +12,7 @@
 import Foundation
 import SwiftUI
 
-// https://medium.com/better-programming/swiftui-navigation-links-and-the-common-pitfalls-faced-505cbfd8029b
+/// https://medium.com/better-programming/swiftui-navigation-links-and-the-common-pitfalls-faced-505cbfd8029b
 struct LazyView<Content: View>: View {
     let build: () -> Content
 

--- a/openHABWatch/Model/OpenHABWidgetExtension.swift
+++ b/openHABWatch/Model/OpenHABWidgetExtension.swift
@@ -35,8 +35,6 @@ extension OpenHABWidget {
         if linkedPage != nil {
             Image(systemSymbol: .chevronRight)
                 .foregroundStyle(.secondary)
-        } else {
-            EmptyView()
         }
     }
 }

--- a/openHABWatch/Model/UserDefaultsBacked.swift
+++ b/openHABWatch/Model/UserDefaultsBacked.swift
@@ -15,7 +15,7 @@ import Foundation
 struct UserDefaultsBacked<T> {
     let key: String
     let defaultValue: T
-    // https://www.swiftbysundell.com/articles/property-wrappers-in-swift/
+    /// https://www.swiftbysundell.com/articles/property-wrappers-in-swift/
     var storage: UserDefaults = .standard
 
     var wrappedValue: T {
@@ -28,7 +28,7 @@ struct UserDefaultsBacked<T> {
     }
 }
 
-// Convenience initializer when UserDefaults is optional.
+/// Convenience initializer when UserDefaults is optional.
 extension UserDefaultsBacked where T: ExpressibleByNilLiteral {
     init(key: String, storage: UserDefaults = .standard) {
         self.init(key: key, defaultValue: nil, storage: storage)

--- a/openHABWatch/Views/Rows/ImageRow.swift
+++ b/openHABWatch/Views/Rows/ImageRow.swift
@@ -16,7 +16,7 @@ import OpenHABCore
 import os.log
 import SwiftUI
 
-// Timer manager that persists across view updates
+/// Timer manager that persists across view updates
 private class ImageRefreshTimer: ObservableObject {
     @Published var refreshCount = 0
     private var timer: AnyCancellable?
@@ -64,7 +64,7 @@ struct ImageRow: View, Equatable {
     @StateObject private var refreshTimer = ImageRefreshTimer()
     @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
 
-    // For refreshing images, append a query parameter to bust the cache
+    /// For refreshing images, append a query parameter to bust the cache
     private var displayUrl: URL? {
         guard let url else { return nil }
         guard refresh > 0 else { return url }

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -66,7 +66,6 @@ struct SegmentRow: View {
         }
     }
 
-    @ViewBuilder
     private var pressReleaseButtons: some View {
         HStack(spacing: 8) {
             ForEach(viewModel.mappings.indices, id: \.self) { index in
@@ -101,7 +100,6 @@ struct SegmentRow: View {
 
     // MARK: - Shared Components
 
-    @ViewBuilder
     private var iconTitleRow: some View {
         HStack {
             WatchIconView(model: widget.iconRenderModel(), settings: settings)
@@ -119,7 +117,6 @@ struct SegmentRow: View {
 
     // MARK: - Multi-Segment (existing NavigationLink)
 
-    @ViewBuilder
     private var multiSegmentContent: some View {
         HStack {
             HStack {
@@ -178,7 +175,6 @@ struct SegmentRow: View {
 
     // MARK: - Single Mapping func
 
-    @ViewBuilder
     private func singleButton(for mapping: OpenHABWidgetMapping) -> some View {
         inlineButton(label: mapping.label, isPressed: singlePressed)
             .overlay {
@@ -205,7 +201,6 @@ struct SegmentRow: View {
 
     // MARK: - Shared Components
 
-    @ViewBuilder
     private func inlineButton(label: String, isPressed: Bool) -> some View {
         Text(label)
             .watchTextStyle(.control)

--- a/openHABWatch/Views/Rows/SegmentSelectionView.swift
+++ b/openHABWatch/Views/Rows/SegmentSelectionView.swift
@@ -57,7 +57,6 @@ struct SegmentSelectionView: View {
         _viewModel = State(wrappedValue: viewModel)
     }
 
-    @ViewBuilder
     private func standardButton(for mapping: OpenHABWidgetMapping, at index: Int) -> some View {
         Button {
             selectOption(at: index)
@@ -67,7 +66,6 @@ struct SegmentSelectionView: View {
         .buttonStyle(PlainButtonStyle())
     }
 
-    @ViewBuilder
     private func pressReleaseButton(for mapping: OpenHABWidgetMapping, at index: Int) -> some View {
         optionLabel(for: mapping, at: index, isPressed: pressedIndex == index)
             .gesture(
@@ -85,7 +83,6 @@ struct SegmentSelectionView: View {
             )
     }
 
-    @ViewBuilder
     private func optionLabel(for mapping: OpenHABWidgetMapping, at index: Int, isPressed: Bool) -> some View {
         HStack {
             Text(mapping.label)

--- a/openHABWatch/Views/SitemapPageView.swift
+++ b/openHABWatch/Views/SitemapPageView.swift
@@ -61,7 +61,6 @@ struct SitemapPageView: View {
         }
     }
 
-    @ViewBuilder
     private var pageContent: some View {
         Group {
             if viewModel.isLoadingSitemap, viewModel.widgets.isEmpty {

--- a/openHABWatch/Views/Utils/WatchIconView.swift
+++ b/openHABWatch/Views/Utils/WatchIconView.swift
@@ -50,9 +50,9 @@ struct WatchIconView: View {
         )?.url
     }
 
-    // During a transient connection handover activeConnection can briefly be nil.
-    // Hold the last successfully resolved URL and connection for a short grace period
-    // so icons don't flash blank between reconnects, and retained auth carries over.
+    /// During a transient connection handover activeConnection can briefly be nil.
+    /// Hold the last successfully resolved URL and connection for a short grace period
+    /// so icons don't flash blank between reconnects, and retained auth carries over.
     private var displayIconURL: URL? {
         if let url = iconURL { return url }
         guard Date() <= keepLastResolvedIconURLUntil else { return nil }

--- a/openHABWatchSwiftUI Watch AppUITests/OpenHABWatchLaunchTests.swift
+++ b/openHABWatchSwiftUI Watch AppUITests/OpenHABWatchLaunchTests.swift
@@ -31,7 +31,7 @@ final class OpenHABWatchLaunchTests: XCTestCase {
         continueAfterFailure = false
     }
 
-    func testLaunch() throws {
+    func testLaunch() {
         let app = XCUIApplication()
         app.launch()
 

--- a/openHABWatchSwiftUI Watch AppUITests/OpenHABWatchUITests.swift
+++ b/openHABWatchSwiftUI Watch AppUITests/OpenHABWatchUITests.swift
@@ -36,7 +36,7 @@ final class OpenHABWatchUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
+    func testExample() {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
@@ -44,7 +44,7 @@ final class OpenHABWatchUITests: XCTestCase {
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
-    func testLaunchPerformance() throws {
+    func testLaunchPerformance() {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.
             measure(metrics: [XCTApplicationLaunchMetric()]) {


### PR DESCRIPTION
## Summary

Bumps both linter/formatter plugins to their latest versions and fixes all resulting violations.

### Plugin versions
| Plugin | Before | After |
|--------|--------|-------|
| SwiftFormatPlugin (weakfl) | 0.58.7 | 0.61.1 |
| SwiftLintPlugin (weakfl) | 0.62.2 | 0.63.3 |

### Changes
- **BuildTools/Package.swift** — updated exact-version pins
- **Package.resolved** — updated resolved hashes/versions
- **SwiftFormat reformatting** — 0.61.1 applied updated formatting rules across the codebase (whitespace, argument wrapping, import ordering)
- **SwiftLint 0.63.3 violations fixed**
  - Removed now-superfluous `closure_end_indentation` disable comments in `TextInputRowView` and `DatePickerInputRowView` (rule no longer triggers)
  - Added `line_length` disable comments for long lines in `OpenHABSitemapWidgetEvent`, `OpenHABWidget`, `OpenHABImageProcessorTests`, `SitemapDiagnostics`, and `JSONParserTests`
- **Swift 6 Sendable fix** — `SnapshotRowInputBuildResult` gains an explicit `Sendable` conformance required by `Task<Success: Sendable, …>`. Guarded with `// swiftformat:disable:next redundantSendable` so SwiftFormat's `redundantSendable` rule does not strip it on subsequent builds.