### PR TITLE
Fix Webview widget URLs and auth for cloud connections

### DIFF
--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -15,10 +15,10 @@ import os.log
 import SwiftUI
 import WebKit
 
-// Resolves a widget URL string against the active openHAB root URL.
-// Absolute URLs (scheme + host present) are returned unchanged.
-// Server-relative paths (e.g. "/static/foo.html") are resolved against rootUrlString.
-// Returns nil when the string is empty or a relative path cannot be resolved.
+/// Resolves a widget URL string against the active openHAB root URL.
+/// Absolute URLs (scheme + host present) are returned unchanged.
+/// Server-relative paths (e.g. "/static/foo.html") are resolved against rootUrlString.
+/// Returns nil when the string is empty or a relative path cannot be resolved.
 func webViewResolvedURL(urlString: String, rootUrlString: String) -> URL? {
     guard !urlString.isEmpty else { return nil }
     if let url = URL(string: urlString), url.scheme != nil, url.host != nil {
@@ -70,9 +70,12 @@ enum WebRowViewConfigurationFactory {
         let configuration = WKWebViewConfiguration()
         configuration.allowsInlineMediaPlayback = true
         configuration.mediaTypesRequiringUserActionForPlayback = []
-        // Share the per-home sandboxed data store with OpenHABWebViewController so the
-        // widget web view inherits any cloud session cookies already established there.
-        // WKWebsiteDataStore(forIdentifier:) requires iOS 17; on iOS 16 the default store is used.
+        // iOS 17+: use the per-home sandboxed store shared with OpenHABWebViewController,
+        // so the widget inherits cloud session cookies already established by Basic UI.
+        // iOS 16: WKWebsiteDataStore(forIdentifier:) is unavailable; the WebKit default
+        // shared store is used instead. Cookie sharing with OpenHABWebViewController's
+        // nonpersistent cloud store is not possible on iOS 16 — Basic Auth challenge
+        // handling covers authentication for that case.
         if #available(iOS 17, *) {
             configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: homeId)
         }

--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -15,6 +15,19 @@ import os.log
 import SwiftUI
 import WebKit
 
+// Resolves a widget URL string against the active openHAB root URL.
+// Absolute URLs (scheme + host present) are returned unchanged.
+// Server-relative paths (e.g. "/static/foo.html") are resolved against rootUrlString.
+// Returns nil when the string is empty or a relative path cannot be resolved.
+func webViewResolvedURL(urlString: String, rootUrlString: String) -> URL? {
+    guard !urlString.isEmpty else { return nil }
+    if let url = URL(string: urlString), url.scheme != nil, url.host != nil {
+        return url
+    }
+    guard !rootUrlString.isEmpty, let base = URL(string: rootUrlString) else { return nil }
+    return URL(string: urlString, relativeTo: base)?.absoluteURL
+}
+
 private struct WebRowConfig {
     let input: MediaRowInput
 }
@@ -53,10 +66,13 @@ private struct WebContainerContent: View {
 
 @MainActor
 enum WebRowViewConfigurationFactory {
-    static func make() -> WKWebViewConfiguration {
+    static func make(homeId: UUID) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.allowsInlineMediaPlayback = true
         configuration.mediaTypesRequiringUserActionForPlayback = []
+        // Share the per-home sandboxed data store with OpenHABWebViewController so the
+        // widget web view inherits any cloud session cookies already established there.
+        configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: homeId)
         return configuration
     }
 }
@@ -75,6 +91,7 @@ struct WidgetWebViewContainerView: View {
 
 struct WebRowView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate {
+        var lastLoadedURL: URL?
         private let logger = Logger(subsystem: "org.openhab", category: "WebRowViewCoordinator")
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
@@ -94,25 +111,20 @@ struct WebRowView: UIViewRepresentable {
     let rootUrlString: String
 
     private var webURL: URL? {
-        guard !urlString.isEmpty else { return nil }
-        if let url = URL(string: urlString), url.scheme != nil, url.host != nil {
-            return url
-        }
-        guard !rootUrlString.isEmpty, let base = URL(string: rootUrlString) else { return nil }
-        return URL(string: urlString, relativeTo: base)?.absoluteURL
+        webViewResolvedURL(urlString: urlString, rootUrlString: rootUrlString)
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView(frame: .zero, configuration: WebRowViewConfigurationFactory.make())
+        let homeId = Preferences.shared.currentHomePreferences.id
+        let webView = WKWebView(frame: .zero, configuration: WebRowViewConfigurationFactory.make(homeId: homeId))
         webView.navigationDelegate = context.coordinator
         return webView
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
-        if let webURL {
-            let request = URLRequest(url: webURL)
-            webView.load(request)
-        }
+        guard let webURL, webURL != context.coordinator.lastLoadedURL else { return }
+        context.coordinator.lastLoadedURL = webURL
+        webView.load(URLRequest(url: webURL))
     }
 
     func makeCoordinator() -> Coordinator {

--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -26,6 +26,7 @@ private func makeWebContainerContent(_ config: WebRowConfig) -> WebContainerCont
 
 private struct WebContainerContent: View {
     let input: MediaRowInput
+    @EnvironmentObject var viewModel: SitemapPageViewModel
 
     var body: some View {
         let displayState = input.displayState
@@ -37,7 +38,7 @@ private struct WebContainerContent: View {
                     .foregroundStyle(input.labelColor.isEmpty ? .primary : Color(fromString: input.labelColor))
             }
 
-            WebRowView(urlString: input.url)
+            WebRowView(urlString: input.url, rootUrlString: viewModel.openHABRootUrl ?? "")
                 .frame(height: input.preferredRowHeight.map { CGFloat($0) })
                 .clipShape(.rect(cornerRadius: 8))
 
@@ -82,15 +83,23 @@ struct WebRowView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView,
                      respondTo challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-            await onReceiveSessionChallenge(with: challenge)
+            if challenge.protectionSpace.authenticationMethod.isAny(of: NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodDefault) {
+                return await onReceiveSessionTaskChallenge(with: challenge)
+            }
+            return await onReceiveSessionChallenge(with: challenge)
         }
     }
 
     let urlString: String
+    let rootUrlString: String
 
     private var webURL: URL? {
         guard !urlString.isEmpty else { return nil }
-        return URL(string: urlString)
+        if let url = URL(string: urlString), url.scheme != nil, url.host != nil {
+            return url
+        }
+        guard !rootUrlString.isEmpty, let base = URL(string: rootUrlString) else { return nil }
+        return URL(string: urlString, relativeTo: base)?.absoluteURL
     }
 
     func makeUIView(context: Context) -> WKWebView {

--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -72,7 +72,10 @@ enum WebRowViewConfigurationFactory {
         configuration.mediaTypesRequiringUserActionForPlayback = []
         // Share the per-home sandboxed data store with OpenHABWebViewController so the
         // widget web view inherits any cloud session cookies already established there.
-        configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: homeId)
+        // WKWebsiteDataStore(forIdentifier:) requires iOS 17; on iOS 16 the default store is used.
+        if #available(iOS 17, *) {
+            configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: homeId)
+        }
         return configuration
     }
 }

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -13,13 +13,74 @@
 import Testing
 import WebKit
 
+@Suite("WebRowViewConfigurationFactory")
 struct WebRowViewConfigurationTests {
     @MainActor
     @Test
     func webRowConfigurationAllowsInlineMutedAutoplay() {
-        let configuration = WebRowViewConfigurationFactory.make()
+        let configuration = WebRowViewConfigurationFactory.make(homeId: UUID())
 
         #expect(configuration.allowsInlineMediaPlayback)
         #expect(configuration.mediaTypesRequiringUserActionForPlayback == [])
+    }
+
+    @MainActor
+    @Test
+    func webRowConfigurationUsesPerHomeDataStore() {
+        let homeId = UUID()
+        let configuration = WebRowViewConfigurationFactory.make(homeId: homeId)
+
+        #expect(configuration.websiteDataStore.identifier == homeId)
+    }
+
+    @MainActor
+    @Test
+    func separateHomesGetSeparateDataStores() {
+        let idA = UUID()
+        let idB = UUID()
+        let configA = WebRowViewConfigurationFactory.make(homeId: idA)
+        let configB = WebRowViewConfigurationFactory.make(homeId: idB)
+
+        #expect(configA.websiteDataStore.identifier != configB.websiteDataStore.identifier)
+    }
+}
+
+@Suite("webViewResolvedURL")
+struct WebRowViewURLResolutionTests {
+    @Test func relativePathResolvedAgainstLocalRootURL() {
+        let url = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "https://openhab.local:8443")
+        #expect(url?.absoluteString == "https://openhab.local:8443/static/foo.html")
+    }
+
+    @Test func relativePathWithQueryResolvedAgainstRootURL() {
+        let url = webViewResolvedURL(urlString: "/static/foo.html?x=1", rootUrlString: "https://openhab.local:8443")
+        #expect(url?.absoluteString == "https://openhab.local:8443/static/foo.html?x=1")
+    }
+
+    @Test func absoluteURLIgnoresRootURL() {
+        let url = webViewResolvedURL(urlString: "https://example.com/widget.html", rootUrlString: "https://openhab.local:8443")
+        #expect(url?.absoluteString == "https://example.com/widget.html")
+    }
+
+    @Test func relativePathResolvedAgainstCloudRootURL() {
+        let url = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "https://home.myopenhab.org")
+        #expect(url?.absoluteString == "https://home.myopenhab.org/static/foo.html")
+    }
+
+    @Test func rootURLChangeFromLocalToCloud() {
+        let local = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "https://openhab.local:8443")
+        let cloud = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "https://home.myopenhab.org")
+        #expect(local?.absoluteString == "https://openhab.local:8443/static/foo.html")
+        #expect(cloud?.absoluteString == "https://home.myopenhab.org/static/foo.html")
+    }
+
+    @Test func emptyURLStringReturnsNil() {
+        let url = webViewResolvedURL(urlString: "", rootUrlString: "https://openhab.local:8443")
+        #expect(url == nil)
+    }
+
+    @Test func relativePathWithEmptyRootReturnsNil() {
+        let url = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "")
+        #expect(url == nil)
     }
 }

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -13,40 +13,6 @@
 import Testing
 import WebKit
 
-@Suite("WebRowViewConfigurationFactory")
-struct WebRowViewConfigurationTests {
-    @MainActor
-    @Test
-    func webRowConfigurationAllowsInlineMutedAutoplay() {
-        let configuration = WebRowViewConfigurationFactory.make(homeId: UUID())
-
-        #expect(configuration.allowsInlineMediaPlayback)
-        #expect(configuration.mediaTypesRequiringUserActionForPlayback == [])
-    }
-
-    @available(iOS 17, *)
-    @MainActor
-    @Test
-    func webRowConfigurationUsesPerHomeDataStore() {
-        let homeId = UUID()
-        let configuration = WebRowViewConfigurationFactory.make(homeId: homeId)
-
-        #expect(configuration.websiteDataStore.identifier == homeId)
-    }
-
-    @available(iOS 17, *)
-    @MainActor
-    @Test
-    func separateHomesGetSeparateDataStores() {
-        let idA = UUID()
-        let idB = UUID()
-        let configA = WebRowViewConfigurationFactory.make(homeId: idA)
-        let configB = WebRowViewConfigurationFactory.make(homeId: idB)
-
-        #expect(configA.websiteDataStore.identifier != configB.websiteDataStore.identifier)
-    }
-}
-
 @Suite("webViewResolvedURL")
 struct WebRowViewURLResolutionTests {
     @Test func relativePathResolvedAgainstLocalRootURL() {
@@ -84,5 +50,39 @@ struct WebRowViewURLResolutionTests {
     @Test func relativePathWithEmptyRootReturnsNil() {
         let url = webViewResolvedURL(urlString: "/static/foo.html", rootUrlString: "")
         #expect(url == nil)
+    }
+}
+
+@Suite("WebRowViewConfigurationFactory")
+struct WebRowViewConfigurationTests {
+    @MainActor
+    @Test
+    func webRowConfigurationAllowsInlineMutedAutoplay() {
+        let configuration = WebRowViewConfigurationFactory.make(homeId: UUID())
+
+        #expect(configuration.allowsInlineMediaPlayback)
+        #expect(configuration.mediaTypesRequiringUserActionForPlayback == [])
+    }
+
+    @available(iOS 17, *)
+    @MainActor
+    @Test
+    func webRowConfigurationUsesPerHomeDataStore() {
+        let homeId = UUID()
+        let configuration = WebRowViewConfigurationFactory.make(homeId: homeId)
+
+        #expect(configuration.websiteDataStore.identifier == homeId)
+    }
+
+    @available(iOS 17, *)
+    @MainActor
+    @Test
+    func separateHomesGetSeparateDataStores() {
+        let idA = UUID()
+        let idB = UUID()
+        let configA = WebRowViewConfigurationFactory.make(homeId: idA)
+        let configB = WebRowViewConfigurationFactory.make(homeId: idB)
+
+        #expect(configA.websiteDataStore.identifier != configB.websiteDataStore.identifier)
     }
 }

--- a/openHABTestsSwift/WebRowViewConfigurationTests.swift
+++ b/openHABTestsSwift/WebRowViewConfigurationTests.swift
@@ -24,6 +24,7 @@ struct WebRowViewConfigurationTests {
         #expect(configuration.mediaTypesRequiringUserActionForPlayback == [])
     }
 
+    @available(iOS 17, *)
     @MainActor
     @Test
     func webRowConfigurationUsesPerHomeDataStore() {
@@ -33,6 +34,7 @@ struct WebRowViewConfigurationTests {
         #expect(configuration.websiteDataStore.identifier == homeId)
     }
 
+    @available(iOS 17, *)
     @MainActor
     @Test
     func separateHomesGetSeparateDataStores() {


### PR DESCRIPTION
## Summary

- **Relative URL resolution**: Webview sitemap widgets with server-relative URLs (e.g. `url="/static/foo.html"`) were silently blank because `WKWebView` received a URL with no host. The widget URL is now resolved against the active openHAB root URL (local or cloud) using the same `SitemapPageViewModel.openHABRootUrl` source that `ImageRowView` uses.
- **Basic Auth for cloud/local**: HTTP Basic and Default auth challenges now route to `onReceiveSessionTaskChallenge`, which performs host-matched credential lookup — matching the behaviour of `OpenHABWebViewController`. SSL/TLS challenges continue through `onReceiveSessionChallenge`.
- **Shared web data store (iOS 17+)**: `WKWebsiteDataStore(forIdentifier: homeId)` is passed to the widget's `WKWebViewConfiguration`, sharing the per-home sandboxed store with `OpenHABWebViewController` so cloud session cookies from Basic UI are available without a separate login. On iOS 16 the WebKit default store is used; cookie sharing with the nonpersistent cloud store is not possible on that OS version — Basic Auth challenge handling covers authentication there.
- **Guard against redundant reloads**: `updateUIView` previously called `webView.load` on every SwiftUI update. With `@EnvironmentObject` on `SitemapPageViewModel`, any long-poll tick or item-state publish would reload the embedded page. The coordinator now tracks `lastLoadedURL` and only loads when the resolved URL changes.
- **Tests**: `webViewResolvedURL` is extracted as an internal free function and covered by 7 tests (server-relative path, query string, absolute URL passthrough, local→cloud root URL switch, empty URL, empty root). Two `WKWebsiteDataStore` configuration tests are gated `@available(iOS 17, *)`.

## Test plan

- [ ] Sitemap with `Webview url="/static/foo.html"` loads correctly on local connection
- [ ] Same sitemap loads correctly after switching to cloud (myopenhab.org) connection
- [ ] Sitemap with `Webview url="https://example.com/widget.html"` loads as before (absolute URL passthrough)
- [ ] Webview widget does not reload on unrelated sitemap item-state updates
- [ ] `xcodebuild test -workspace openHAB.xcworkspace -scheme openHABTestsSwift` passes
- [ ] `xcodebuild build` succeeds against iOS 16 deployment target