### PR TITLE
Include group items in Shortcuts intent pickers

### DIFF
--- a/AppIntents/iOS16/SetColorValue.swift
+++ b/AppIntents/iOS16/SetColorValue.swift
@@ -36,7 +36,7 @@ struct SetColorValue: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .color }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.color) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetContactStateValue.swift
+++ b/AppIntents/iOS16/SetContactStateValue.swift
@@ -36,7 +36,7 @@ struct SetContactStateValue: AppIntent, CustomIntentMigratedAppIntent, Predictab
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .contact }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.contact) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetDateTimeValue.swift
+++ b/AppIntents/iOS16/SetDateTimeValue.swift
@@ -33,7 +33,7 @@ struct SetDateTimeValue: AppIntent, PredictableIntent {
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .dateTime }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.dateTime) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetDimmerRollerValue.swift
+++ b/AppIntents/iOS16/SetDimmerRollerValue.swift
@@ -36,7 +36,7 @@ struct SetDimmerRollerValue: AppIntent, CustomIntentMigratedAppIntent, Predictab
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .dimmer || $0.type == .rollershutter }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.dimmer) || $0.isOfTypeOrGroupType(.rollershutter) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetLocationValue.swift
+++ b/AppIntents/iOS16/SetLocationValue.swift
@@ -39,7 +39,7 @@ struct SetLocationValue: AppIntent, PredictableIntent {
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .location }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.location) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetNumberValue.swift
+++ b/AppIntents/iOS16/SetNumberValue.swift
@@ -33,7 +33,7 @@ struct SetNumberValue: AppIntent, CustomIntentMigratedAppIntent, PredictableInte
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .number || $0.type == .numberWithDimension }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.number) || $0.isOfTypeOrGroupType(.numberWithDimension) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetPlayerValue.swift
+++ b/AppIntents/iOS16/SetPlayerValue.swift
@@ -45,7 +45,7 @@ struct SetPlayerValue: AppIntent, PredictableIntent {
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .player }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.player) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetStringValue.swift
+++ b/AppIntents/iOS16/SetStringValue.swift
@@ -33,7 +33,7 @@ struct SetStringValue: AppIntent, CustomIntentMigratedAppIntent, PredictableInte
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .stringItem }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.stringItem) }
             return items.map(\.name)
         }
     }

--- a/AppIntents/iOS16/SetSwitchState.swift
+++ b/AppIntents/iOS16/SetSwitchState.swift
@@ -53,7 +53,7 @@ struct SetSwitchState: AppIntent, CustomIntentMigratedAppIntent, PredictableInte
         func results() async throws -> [String] {
             await Preferences.prepareForAppExtensionAccess()
             let allItems = await OpenHABItemCache.instance.getAllCachedItems()
-            let items = allItems.flatMap(\.value).filter { $0.type == .switchItem }
+            let items = allItems.flatMap(\.value).filter { $0.isOfTypeOrGroupType(.switchItem) }
             return items.map(\.name)
         }
     }

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenHABItemCache.swift
@@ -143,6 +143,7 @@ public actor OpenHABItemCache {
         let name: String
         let label: String
         let type: String?
+        let groupType: String?
     }
 
     public static let instance = OpenHABItemCache()
@@ -235,7 +236,7 @@ public actor OpenHABItemCache {
         // fallback for intents that target a home the current process hasn't loaded.
         var allStubs = loadedStubs()
         for (homeId, homeItems) in items {
-            allStubs[homeId.uuidString] = homeItems.map { ItemStub(name: $0.name, label: $0.label, type: $0.type?.rawValue) }
+            allStubs[homeId.uuidString] = homeItems.map { ItemStub(name: $0.name, label: $0.label, type: $0.type?.rawValue, groupType: $0.groupType?.rawValue) }
         }
         guard let data = try? JSONEncoder().encode(allStubs) else { return }
         cachedStubs = allStubs
@@ -244,7 +245,7 @@ public actor OpenHABItemCache {
 
     private func persistedItem(name: String, home: UUID) -> OpenHABItem? {
         guard let stub = loadedStubs()[home.uuidString]?.first(where: { $0.name == name }) else { return nil }
-        return OpenHABItem(name: stub.name, type: stub.type ?? "", state: nil, link: "", label: stub.label, groupType: nil, stateDescription: nil, commandDescription: nil, members: [], category: nil, options: nil)
+        return OpenHABItem(name: stub.name, type: stub.type ?? "", state: nil, link: "", label: stub.label, groupType: stub.groupType, stateDescription: nil, commandDescription: nil, members: [], category: nil, options: nil)
     }
 
     private func persistedItems(home: UUID) -> [OpenHABItem] {
@@ -255,7 +256,7 @@ public actor OpenHABItemCache {
                 state: nil,
                 link: "",
                 label: $0.label,
-                groupType: nil,
+                groupType: $0.groupType,
                 stateDescription: nil,
                 commandDescription: nil,
                 members: [],
@@ -275,7 +276,7 @@ public actor OpenHABItemCache {
     public func forceCacheReload(homes: [UUID]) async {
         Logger.itemCache.info("force cache reload for homes: \(homes)")
         do {
-            let loadedItems = try await loadNonGroupItemsForHomes(homes)
+            let loadedItems = try await loadItemsForHomes(homes)
             Logger.itemCache.info("Store loaded items in cache")
             let now = Date.now
             for (homeId, homeItems) in loadedItems {
@@ -312,11 +313,6 @@ public actor OpenHABItemCache {
         itemsList
             .filtered(by: searchTerm, for: types)
             .map(\.name)
-    }
-
-    private func loadNonGroupItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
-        let allItemsArray = try await loadItemsForHomes(homes).map { (uuid, items) in (uuid, items.filter { $0.type != .group }) }
-        return Dictionary(uniqueKeysWithValues: allItemsArray)
     }
 
     private func loadItemsForHomes(_ homes: [UUID]) async throws -> [UUID: [OpenHABItem]] {
@@ -486,7 +482,8 @@ public extension OpenHABItem {
     /// - Parameter types: Optional array of item types to match. If nil, all items match.
     /// - Returns: True if the item matches the filter, false otherwise
     func matches(types: [OpenHABItem.ItemType]?) -> Bool {
-        types == nil || (type.flatMap { types?.contains($0) } == true)
+        guard let types else { return true }
+        return types.contains { isOfTypeOrGroupType($0) }
     }
 
     func searchScore(for searchTerm: String, additionalCandidates: [String] = []) -> Int? {

--- a/openHAB/Supporting Files/Localizable.xcstrings
+++ b/openHAB/Supporting Files/Localizable.xcstrings
@@ -8743,7 +8743,6 @@
       }
     },
     "message_not_decoded" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
## Summary

- Group items were silently stripped from the item cache by `loadNonGroupItemsForHomes`, so they never appeared in any Shortcuts intent picker — including `GetItemState` which has no type restriction
- `matches(types:)` only checked `item.type`, so `Group<Switch>` would fail a `[.switchItem]` filter even if it were in the cache
- The nine iOS 16 `Set*Value` intents each had their own hardcoded `$0.type == .X` filter that bypassed the shared matching logic entirely

Fixes all three issues by mirroring the `renderingKind` logic that already uses `isOfTypeOrGroupType` on the sitemap:

- `forceCacheReload` now calls `loadItemsForHomes` (all items) instead of `loadNonGroupItemsForHomes`
- `ItemStub` gains a `groupType` field so the cold-cache (stubs) path survives process restarts with correct type info
- `matches(types:)` uses `isOfTypeOrGroupType` so `Group<Rollershutter>` matches `[.rollershutter]`, `Group<Switch>` matches `[.switchItem]`, etc.
- All nine iOS 16 `Set*Value` `DynamicOptionsProvider` filters replaced with `isOfTypeOrGroupType`

Closes https://community.openhab.org/t/ios-shortcuts-access-to-group-items/169441

## Test plan

- [ ] Open Shortcuts on iOS, add a **Get Item State** action — group items now appear in the picker
- [ ] Add a **Set Switch** action — `Group<Switch>` items appear alongside plain Switch items
- [ ] Add a **Set Dimmer or Roller Shutter Value** action — `Group<Rollershutter>` and `Group<Dimmer>` items appear
- [ ] Verify type-specific intents (Color, Number, Player, etc.) only show matching group types, not untyped container groups
- [ ] Force-kill the app and re-open Shortcuts to exercise the stubs path — group items still appear with correct type filtering