### PR TITLE
fix: hide UIKit nav bar on sitemap when returning from pushed screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ skills-lock.json
 BonjourDiscoveryTool/.build
 BonjourDiscoveryTool/.swiftpm
 BonjourDiscoveryTool/bonjour-discovery
+
+.xcodebuildmcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@
 
 ## git
 - Always use git commit with -s -S 
+- If using XcodeBuildMCP, use the installed XcodeBuildMCP skill before calling XcodeBuildMCP tools.

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -180,6 +180,13 @@ class OpenHABRootViewController: UIViewController {
             switchToSavedView()
             isDemoMode = Preferences.shared.currentHomePreferences.demomode
         }
+        // Restore correct nav bar state when returning from pushed screens (e.g. notifications, home
+        // selection). Those screens call setNavigationBarHidden(false) before pushing; popping back
+        // lands here but does not re-hide the bar, causing the UIKit hamburger and the SwiftUI one
+        // inside SitemapNavigationView to appear simultaneously.
+        if currentView === sitemapViewController {
+            navigationController?.setNavigationBarHidden(true, animated: animated)
+        }
         ImageDownloader.default.authenticationChallengeResponder = self
     }
 


### PR DESCRIPTION
## Summary

- `modalDismissed(to: .notifications/.homeSelection)` calls `setNavigationBarHidden(false, ...)` before pushing the respective screen onto the UINavigationController stack
- When the user pops back, `OpenHABRootViewController.viewWillAppear` fires but never re-hides the navigation bar
- This leaves the UIKit hamburger button (added in `setupSideMenu`) visible simultaneously with the SwiftUI hamburger button inside `SitemapNavigationView` — two hamburger icons in different colours on the sitemap screen
- Fix: call `setNavigationBarHidden(true, animated:)` in `viewWillAppear` whenever the sitemap view controller is the active child view

Fixes #1236 (double hamburger menu on sitemap, reported against 3.2.66 (275))

## Test plan

- [ ] Open the app on the sitemap view — only one hamburger icon visible in the top-right
- [ ] Open the side menu → Notifications → pop back → confirm only one hamburger icon
- [ ] Open the side menu → Home Selection → pop back → confirm only one hamburger icon
- [ ] Switch to MainUI webview, open side menu → Notifications → pop back → UIKit nav bar still visible (correct behaviour for webview)