### PR TITLE
fix: refresh sub-page items when app returns to foreground

### DIFF
--- a/openHAB/UI/SwiftUI/SitemapNavigationView.swift
+++ b/openHAB/UI/SwiftUI/SitemapNavigationView.swift
@@ -15,9 +15,7 @@ import SFSafeSymbols
 import SwiftUI
 
 struct SitemapNavigationView: View {
-    @Environment(\.scenePhase) private var scenePhase
     @StateObject var viewModel = SitemapPageViewModel()
-    @State private var hasSeenActivePhase = false
     @State private var isSearchPresented = false
     @FocusState private var isLegacySearchFocused: Bool
     let onShowSideMenu: () -> Void
@@ -28,19 +26,6 @@ struct SitemapNavigationView: View {
                 .navigationDestination(for: LinkedPageNavigation.self) { nav in
                     SitemapPageView(viewModel: SitemapPageViewModel(pageUrl: nav.pageLink, title: nav.pageTitle))
                 }
-        }
-        .onChange(of: scenePhase) { newPhase in
-            switch newPhase {
-            case .active:
-                // Skip only the first activation to avoid racing the initial .task startup.
-                guard hasSeenActivePhase else {
-                    hasSeenActivePhase = true
-                    return
-                }
-                viewModel.refreshOnForeground()
-            default:
-                break
-            }
         }
     }
 

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -16,7 +16,12 @@ import UIKit
 
 struct SitemapPageView: View {
     @StateObject var viewModel = SitemapPageViewModel()
+    @Environment(\.scenePhase) private var scenePhase
     @State private var idleTimerDisabled = false
+    // Sub-pages are created while the app is already active, so the first .active transition they
+    // observe is a genuine return from background — don't skip it. Root pages start false to skip
+    // the launch-time .active that races the initial .task startup.
+    @State private var hasSeenActivePhase: Bool
 
     private var isLinkedPage: Bool {
         viewModel.isLinked
@@ -75,6 +80,15 @@ struct SitemapPageView: View {
                 UIApplication.shared.isIdleTimerDisabled = false
             }
         }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                guard hasSeenActivePhase else {
+                    hasSeenActivePhase = true
+                    return
+                }
+                viewModel.refreshOnForeground()
+            }
+        }
         .navigationTitle(viewModel.pageTitle)
         .navigationBarTitleDisplayMode(.large)
         .alert("Error", isPresented: Binding(
@@ -92,6 +106,7 @@ struct SitemapPageView: View {
 
     init(viewModel: SitemapPageViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        _hasSeenActivePhase = State(initialValue: viewModel.isLinked)
     }
 }
 


### PR DESCRIPTION
## Summary

The `scenePhase .active` observer was only wired up on `SitemapNavigationView`, calling `refreshOnForeground()` on the **root** page view model only. Sub-pages pushed onto the `NavigationStack` each own a separate `SitemapPageViewModel` that never received a foreground refresh signal — leaving widget states stale until the next long-poll cycle (~30 s).

**Fix:** Move the observer to `SitemapPageView` so every page instance handles its own foreground refresh:

- `hasSeenActivePhase` is seeded from `viewModel.isLinked`:
  - **Root page** → `false`: skip the launch-time `.active` to avoid racing the initial `.task` startup
  - **Sub-pages** → `true`: they're created while the app is already active, so the first `.active` they observe is always a genuine return from background — refresh immediately
- The existing `isPageVisibleForRefresh` guard in `refreshOnForeground()` ensures only the page currently on screen actually fires work, so non-visible pages (root while a sub-page is open, and vice versa) are no-ops

Fixes #1148

## Test plan

- [ ] Navigate to a sub-page on the sitemap
- [ ] Background the app (home button / swipe up)
- [ ] Change a widget state from another client (e.g. openHAB web UI)
- [ ] Return the app to the foreground — sub-page items should update within a second, not wait for the next long-poll cycle
- [ ] Repeat with the root sitemap page to confirm root-page refresh still works
- [ ] Lock the phone while on a sub-page, change a state, unlock — confirm immediate update