### PR TITLE
fix: only hide navigation bar on explicit goFullscreen signal (#1017)

### DIFF
--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -270,6 +270,9 @@ class OpenHABWebViewController: OpenHABViewController {
                 webView = newWebview
                 attachWebViewToLayout(newWebview)
             }
+            // Reset fullscreen state so a new page must explicitly re-request it.
+            // Without this, navigating away from a goFullscreen page keeps the bar hidden.
+            setHideNavigationBar(shouldHide: false)
             Logger.viewController.info("Loading URL: \(modifiedUrl)")
             webView.load(request)
         }
@@ -659,6 +662,7 @@ extension OpenHABWebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {
         Logger.viewController.info("didStartProvisionalNavigation - webView.url: \(String(describing: webView.url?.description))")
+        setHideNavigationBar(shouldHide: false)
         showActivityIndicator(show: true)
     }
 
@@ -768,7 +772,6 @@ extension OpenHABWebViewController: WKNavigationDelegate {
         // Track the successfully loaded URL for ETag comparison
         lastLoadedURL = webView.url?.absoluteString
 
-        setHideNavigationBar(shouldHide: true)
         showActivityIndicator(show: false)
         UIView.animate(withDuration: 0.2) {
             self.loadingOverlay.alpha = 0


### PR DESCRIPTION
## Summary

- Removes the unconditional `setHideNavigationBar(shouldHide: true)` call from `webView(_:didFinish:)`. The navigation bar was hidden after every successful page load, making the app permanently unusable when a non-MainUI path was saved as the default webview path — the bar disappeared with no way to reach the side menu.
- Adds `setHideNavigationBar(shouldHide: false)` in `didStartProvisionalNavigation` so the bar is reset at the start of every main-frame navigation (app-initiated, redirect, form submission, or script-driven).
- Adds a matching reset in `performLoadWebView` as an early belt-and-suspenders reset for app-initiated loads.

The navigation bar is now hidden **only** when the loaded page explicitly calls `window.OHApp.goFullscreen()` via the JS bridge, which MainUI already does when it has its own navigation controls. Any page that does not send that signal — including BasicUI pages and incorrectly configured paths — keeps the native navigation bar visible so the user can always navigate back.

## Test plan

- [ ] Open the app with a valid MainUI default path → navigation bar hides as before after page load
- [ ] Set an invalid or BasicUI path as the default webview path → navigation bar remains visible, side menu is reachable
- [ ] Navigate within MainUI to a page that triggers a top-level redirect → navigation bar resets and is re-hidden only if the destination calls goFullscreen