### PR TITLE
fix: defer sub-page navigation until root sitemap poll completes (#842)

### DIFF
--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -67,6 +67,7 @@ class SitemapPageViewModel: ObservableObject {
     private var lastUIUpdateAt: Date = .distantPast
     private var coalescedLongPollUpdateCount = 0
     private var pendingLongPollPage: OpenHABPage?
+    private var pendingLinkedPageNavigation: LinkedPageNavigation?
     private var longPollDebounceTask: Task<Void, Never>?
     private var foregroundObserverTask: Task<Void, Never>?
     private var rowInputRebuildTask: Task<Void, Never>?
@@ -553,6 +554,15 @@ extension SitemapPageViewModel {
         injectSendCommand(for: newWidgets)
         currentPage = page
 
+        // Apply a pending linked-page navigation on the first non-nil page update, regardless
+        // of origin. Checking only .initialPoll was insufficient because the loader emits
+        // .initialFetch(nil) when the server returns no page, skipping updateUI entirely;
+        // the next update arrives as .longPolling and the destination was never consumed.
+        if let nav = pendingLinkedPageNavigation {
+            pendingLinkedPageNavigation = nil
+            navigationPath.append(nav)
+        }
+
         // Phase 2: slider override sync
         _ = clearSyncedSliderOverrides(using: newWidgets)
         let firstApplyMs = Int((Date().timeIntervalSince(applyStartedAt) * 1000).rounded())
@@ -758,6 +768,7 @@ extension SitemapPageViewModel {
         defaultSitemapLabel = ""
         self.pageId = pageId ?? ""
         navigationPath = []
+        pendingLinkedPageNavigation = nil
         error = nil
     }
 
@@ -768,8 +779,9 @@ extension SitemapPageViewModel {
 
     @MainActor
     // swiftlint:disable:next async_without_await
-    func pushSitemap(name: String, path: String?) async {
+    func pushSitemap(name: String, path: String?, pendingNavigation: LinkedPageNavigation? = nil) async {
         configureSitemap(name: name, pageId: path)
+        pendingLinkedPageNavigation = pendingNavigation
         startPageHandling(forceRestart: true, reason: "push-sitemap")
     }
 

--- a/openHAB/UI/HostingSitemapViewController.swift
+++ b/openHAB/UI/HostingSitemapViewController.swift
@@ -91,10 +91,12 @@ class HostingSitemapViewController: UIHostingController<SitemapNavigationView>, 
             .appending(path: name)
             .appending(path: path)
 
-        // Load the root sitemap so the back button returns to it, then navigate to the sub-page
-        // within the existing SwiftUI NavigationStack so SwiftUI manages back-navigation.
-        await viewModel.pushSitemap(name: name, path: nil)
-        viewModel.navigateToLinkedPage(LinkedPageNavigation(pageLink: pageURL.absoluteString, pageTitle: name))
+        // Load the root sitemap so the back button returns to it, then navigate to the sub-page.
+        // The navigation is deferred until the initial root page poll completes so that it fires
+        // after SwiftUI's NavigationStack is in a stable rendered state. This avoids the cold-start
+        // race where navigateToLinkedPage was called before the NavigationStack existed.
+        let nav = LinkedPageNavigation(pageLink: pageURL.absoluteString, pageTitle: name)
+        await viewModel.pushSitemap(name: name, path: nil, pendingNavigation: nav)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- On cold start (app force-closed), tapping an enhanced notification action with a `ui:/basicui/app?w=<widgetId>&sitemap=<name>` target opened Basic UI but stayed on the root page instead of navigating to the requested widget.
- Root cause: `HostingSitemapViewController.pushSitemap` called `viewModel.navigateToLinkedPage` immediately after `viewModel.pushSitemap`. `viewModel.pushSitemap` only *schedules* an async page load — it returns before the first HTTP response arrives. On cold start the `UIHostingController` had just been added to the hierarchy and SwiftUI's `NavigationStack` had not yet completed its initial render, so the programmatic path mutation raced the NavigationStack's first-render state setup and was silently lost. On warm start (app previously on the sitemap view) the NavigationStack was already stable, so it worked.
- Fix: store the desired sub-page as `pendingLinkedPageNavigation` on `SitemapPageViewModel` and apply it inside `updateUI(with:origin:)` when `origin == .initialPoll` — i.e. after the root page has been fetched and the NavigationStack is guaranteed to be in a stable rendered state.

## Test plan

- [ ] Force-close the app. Trigger an enhanced notification with an action pointing to `ui:/basicui/app?w=<widgetId>&sitemap=<name>`. Tap the action button. App should open directly on the target widget page, not the sitemap root.
- [ ] With app running in background on the sitemap view, trigger the same notification action — should still navigate to the widget page as before.
- [ ] With app running in background on the webview, trigger the notification — should switch to Basic UI and navigate to the widget page.
- [ ] Notification action with no widget id (`ui:/basicui/app?sitemap=<name>`) — should open the sitemap root page as before.