### PR TITLE
Add sitemap startup diagnostics

### DIFF
--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -58,6 +58,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserDefaults.standard.register(defaults: appDefaults)
 
         Preferences.migratePreferences()
+        SitemapDiagnostics.markProcessLaunch(source: launchSource(launchOptions))
 
         // Firebase must be configured before the storyboard loads its root view controller,
         // because OpenHABRootViewController.viewDidLoad calls Crashlytics before the deferred
@@ -77,6 +78,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return true
+    }
+
+    private func launchSource(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> String {
+        guard let launchOptions, !launchOptions.isEmpty else { return "user" }
+        if launchOptions[.remoteNotification] != nil {
+            return "remoteNotification"
+        }
+        if launchOptions[.url] != nil {
+            return "url"
+        }
+        if launchOptions[.location] != nil {
+            return "location"
+        }
+        return "other"
     }
 
     /// Setup that can be deferred until after the UI appears

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -324,7 +324,6 @@ extension SitemapPageViewModel {
             return
         }
 
-        let pipelineStart = Date()
         let requestedKey = "\(defaultSitemap)|\(pageId)"
         if !forceRestart,
            let activeTask = pageHandlingTask,
@@ -358,15 +357,24 @@ extension SitemapPageViewModel {
         pageHandlingTask = Task {
             await runPageHandling(
                 runID: runID,
-                recreateService: recreateService,
-                pipelineStart: pipelineStart
+                reason: reason,
+                recreateService: recreateService
             )
         }
     }
 
     private func runPageHandling(runID: UUID,
-                                 recreateService: Bool,
-                                 pipelineStart: Date) async {
+                                 reason: String,
+                                 recreateService: Bool) async {
+        let pipelineStartedAt = Date()
+        var diagnostics = SitemapInitialLoadMeasurement(
+            reason: reason,
+            isLinkedPage: isLinkedPage,
+            hasCurrentPage: currentPage != nil,
+            connectionWasReady: networkTracker.activeConnection != nil,
+            pipelineStartedAt: pipelineStartedAt
+        )
+
         defer {
             if activePageHandlingID == runID {
                 pageHandlingTask = nil
@@ -375,19 +383,47 @@ extension SitemapPageViewModel {
         }
 
         do {
-            guard await ensureSitemapAvailableForHandling() else { return }
+            guard await ensureSitemapAvailableForHandling() else {
+                diagnostics.log(
+                    status: "failed",
+                    page: currentPage,
+                    rowCount: rowInputs.count,
+                    errorDescription: "No sitemap available"
+                )
+                return
+            }
 
-            guard let activeConnection = await waitForConnectionForHandling() else { return }
+            diagnostics.beginConnectionSelection()
+            guard let activeConnection = await waitForConnectionForHandling() else {
+                diagnostics.log(
+                    status: "failed",
+                    page: currentPage,
+                    rowCount: rowInputs.count,
+                    errorDescription: "No active connection"
+                )
+                return
+            }
 
+            diagnostics.beginServiceSetup(connection: activeConnection.configuration)
             try setupServiceIfNeeded(activeConnection: activeConnection, forceRecreate: recreateService)
 
             if defaultSitemapLabel.isEmpty {
+                diagnostics.beginLabelFetch()
                 await fetchSitemapLabel()
             }
 
-            guard let service = openAPIService else { return }
+            guard let service = openAPIService else {
+                diagnostics.log(
+                    status: "failed",
+                    page: currentPage,
+                    rowCount: rowInputs.count,
+                    errorDescription: "Sitemap service unavailable"
+                )
+                return
+            }
 
             var lastResponseAt: Date?
+            diagnostics.beginInitialRequest()
 
             for try await event in SitemapPageLoader.stream(
                 sitemapName: defaultSitemap,
@@ -417,11 +453,16 @@ extension SitemapPageViewModel {
                 case let .initialFetch(page):
                     isLoading = false
                     isUpdating = false
-                    let totalDurationMs = Date().timeIntervalSince(pipelineStart) * 1000
-                    logger.info("Sitemap pipeline ready in \(Int(totalDurationMs.rounded()), privacy: .public)ms")
+                    diagnostics.beginUIPreparation()
                     if let page {
                         await updateUI(with: page, origin: .initialPoll)
                     }
+                    diagnostics.log(
+                        status: page == nil ? "empty" : "success",
+                        page: page,
+                        rowCount: rowInputs.count
+                    )
+                    logger.info("Sitemap pipeline initial load completed")
                 case let .longPoll(page, requestMs):
                     let responseGapMs = lastResponseAt.map { Int((responseAt.timeIntervalSince($0) * 1000).rounded()) }
                     SitemapDiagnostics.logLongPoll(
@@ -436,6 +477,12 @@ extension SitemapPageViewModel {
                 lastResponseAt = responseAt
             }
         } catch {
+            diagnostics.log(
+                status: error is CancellationError ? "cancelled" : "failed",
+                page: currentPage,
+                rowCount: rowInputs.count,
+                errorDescription: error.localizedDescription
+            )
             handlePageHandlingError(error)
         }
     }

--- a/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
+++ b/openHAB/UI/SwiftUI/SitemapDiagnostics.swift
@@ -116,11 +116,195 @@ actor IconLoadDiagnostics {
 }
 
 @MainActor
+struct SitemapInitialLoadMeasurement {
+    private let pipelineStartedAt: Date
+    private let context: String
+    private let processAgeMs: Int
+    private let connectionWasReady: Bool
+    private var stage = "sitemapDiscovery"
+    private var stageStartedAt: Date
+    private var connection: ConnectionConfiguration?
+    private var discoveryMs = 0
+    private var connectionWaitMs = 0
+    private var serviceSetupMs = 0
+    private var labelFetchMs = 0
+    private var initialRequestStartedAt: Date?
+    private var initialRequestMs = 0
+    private var uiPreparationMs = 0
+    private var didLog = false
+
+    private var currentInitialRequestMs: Int {
+        initialRequestStartedAt.map { elapsedMs(since: $0) } ?? initialRequestMs
+    }
+
+    init(reason: String,
+         isLinkedPage: Bool,
+         hasCurrentPage: Bool,
+         connectionWasReady: Bool,
+         pipelineStartedAt: Date) {
+        context = SitemapDiagnostics.initialLoadContext(
+            reason: reason,
+            isLinkedPage: isLinkedPage,
+            hasCurrentPage: hasCurrentPage
+        )
+        processAgeMs = SitemapDiagnostics.processAgeMs
+        self.connectionWasReady = connectionWasReady
+        self.pipelineStartedAt = pipelineStartedAt
+        stageStartedAt = pipelineStartedAt
+    }
+
+    mutating func beginConnectionSelection() {
+        transition(to: "connectionSelection")
+    }
+
+    mutating func beginServiceSetup(connection: ConnectionConfiguration) {
+        self.connection = connection
+        transition(to: "serviceSetup")
+    }
+
+    mutating func beginLabelFetch() {
+        transition(to: "sitemapLabel")
+    }
+
+    mutating func beginInitialRequest() {
+        transition(to: "initialRequest")
+        initialRequestStartedAt = stageStartedAt
+    }
+
+    mutating func beginUIPreparation() {
+        transition(to: "uiPreparation")
+    }
+
+    mutating func log(status: String,
+                      page: OpenHABPage?,
+                      rowCount: Int,
+                      errorDescription: String = "") {
+        // The stream can later be cancelled after its initial fetch already logged success.
+        guard !didLog else { return }
+        didLog = true
+        finishCurrentStage()
+        SitemapDiagnostics.logInitialLoad(
+            context: context,
+            status: status,
+            stage: status == "success" || status == "empty" ? "complete" : stage,
+            processAgeMs: processAgeMs,
+            connectionWasReady: connectionWasReady,
+            connection: connection,
+            discoveryMs: discoveryMs,
+            connectionWaitMs: connectionWaitMs,
+            serviceSetupMs: serviceSetupMs,
+            labelFetchMs: labelFetchMs,
+            initialRequestMs: currentInitialRequestMs,
+            uiPreparationMs: uiPreparationMs,
+            totalMs: elapsedMs(since: pipelineStartedAt),
+            widgetCount: page?.widgets.count ?? 0,
+            rowCount: rowCount,
+            errorDescription: errorDescription
+        )
+    }
+
+    private mutating func transition(to nextStage: String) {
+        finishCurrentStage()
+        stage = nextStage
+        stageStartedAt = Date()
+    }
+
+    private mutating func finishCurrentStage() {
+        let duration = elapsedMs(since: stageStartedAt)
+        switch stage {
+        case "sitemapDiscovery":
+            discoveryMs = duration
+        case "connectionSelection":
+            connectionWaitMs = duration
+        case "serviceSetup":
+            serviceSetupMs = duration
+        case "sitemapLabel":
+            labelFetchMs = duration
+        case "initialRequest":
+            initialRequestMs = duration
+            initialRequestStartedAt = nil
+        case "uiPreparation":
+            uiPreparationMs = duration
+        default:
+            break
+        }
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int((Date().timeIntervalSince(start) * 1000).rounded())
+    }
+}
+
+@MainActor
 enum SitemapDiagnostics {
     private static let logger = Logger(subsystem: "org.openhab", category: "SitemapDiagnostics")
+    private static let processStartedAt = ProcessInfo.processInfo.systemUptime
 
     static var isEnabled: Bool {
         Preferences.shared.applicationPreferences.sitemapDiagnosticsLogging
+    }
+
+    static var processAgeMs: Int {
+        Int(((ProcessInfo.processInfo.systemUptime - processStartedAt) * 1000).rounded())
+    }
+
+    static func markProcessLaunch(source: String) {
+        guard isEnabled else { return }
+        logger.info("processLaunch source=\(source, privacy: .public)")
+    }
+
+    static func initialLoadContext(reason: String,
+                                   isLinkedPage: Bool,
+                                   hasCurrentPage: Bool) -> String {
+        if reason == "scene-became-active" {
+            return "foregroundResume"
+        }
+        if !isLinkedPage,
+           !hasCurrentPage,
+           reason == "manual" || reason == "connection-changed" {
+            return "coldStart"
+        }
+        if isLinkedPage {
+            return "linkedPage"
+        }
+        return reason
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    static func logInitialLoad(context: String,
+                               status: String,
+                               stage: String,
+                               processAgeMs: Int,
+                               connectionWasReady: Bool,
+                               connection: ConnectionConfiguration?,
+                               discoveryMs: Int,
+                               connectionWaitMs: Int,
+                               serviceSetupMs: Int,
+                               labelFetchMs: Int,
+                               initialRequestMs: Int,
+                               uiPreparationMs: Int,
+                               totalMs: Int,
+                               widgetCount: Int,
+                               rowCount: Int,
+                               errorDescription: String = "") {
+        guard isEnabled else { return }
+        let connectionKind = connection.map(connectionKind(for:)) ?? "none"
+        let connectionDescription = connection?.publicLogDescription ?? "none"
+        // swiftlint:disable line_length
+        logger.info(
+            "initialLoad context=\(context, privacy: .public) status=\(status, privacy: .public) stage=\(stage, privacy: .public) processAgeMs=\(processAgeMs, privacy: .public) connectionWasReady=\(connectionWasReady, privacy: .public) connectionKind=\(connectionKind, privacy: .public) connection=\(connectionDescription, privacy: .public) discoveryMs=\(discoveryMs, privacy: .public) connectionWaitMs=\(connectionWaitMs, privacy: .public) serviceSetupMs=\(serviceSetupMs, privacy: .public) labelFetchMs=\(labelFetchMs, privacy: .public) initialRequestMs=\(initialRequestMs, privacy: .public) uiPreparationMs=\(uiPreparationMs, privacy: .public) totalMs=\(totalMs, privacy: .public) widgets=\(widgetCount, privacy: .public) rows=\(rowCount, privacy: .public) error=\(errorDescription, privacy: .public)"
+        )
+        // swiftlint:enable line_length
+    }
+
+    static func connectionKind(for configuration: ConnectionConfiguration) -> String {
+        if configuration.isCloudConnection {
+            return "cloud"
+        }
+        if configuration.priority == 0 {
+            return "local"
+        }
+        return "remote"
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/openHABTestsSwift/SitemapDiagnosticsTests.swift
+++ b/openHABTestsSwift/SitemapDiagnosticsTests.swift
@@ -1,0 +1,81 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+@testable import openHAB
+import OpenHABCore
+import Testing
+
+@MainActor
+struct SitemapDiagnosticsTests {
+    @Test(arguments: ["manual", "connection-changed"])
+    func classifiesRootInitialLoadAsColdStart(reason: String) {
+        let context = SitemapDiagnostics.initialLoadContext(
+            reason: reason,
+            isLinkedPage: false,
+            hasCurrentPage: false
+        )
+
+        #expect(context == "coldStart")
+    }
+
+    @Test
+    func classifiesForegroundRefreshSeparately() {
+        let context = SitemapDiagnostics.initialLoadContext(
+            reason: "scene-became-active",
+            isLinkedPage: false,
+            hasCurrentPage: true
+        )
+
+        #expect(context == "foregroundResume")
+    }
+
+    @Test
+    func keepsWarmManualReloadContext() {
+        let context = SitemapDiagnostics.initialLoadContext(
+            reason: "manual",
+            isLinkedPage: false,
+            hasCurrentPage: true
+        )
+
+        #expect(context == "manual")
+    }
+
+    @Test
+    func classifiesLinkedPageSeparately() {
+        let context = SitemapDiagnostics.initialLoadContext(
+            reason: "manual",
+            isLinkedPage: true,
+            hasCurrentPage: false
+        )
+
+        #expect(context == "linkedPage")
+    }
+
+    @Test(arguments: [
+        (supportsNotifications: true, priority: 1, expected: "cloud"),
+        (supportsNotifications: false, priority: 0, expected: "local"),
+        (supportsNotifications: false, priority: 1, expected: "remote")
+    ])
+    func classifiesConnectionKind(supportsNotifications: Bool,
+                                  priority: Int,
+                                  expected: String) {
+        // isCloudConnection currently derives from supportsNotifications.
+        let configuration = ConnectionConfiguration(
+            url: "https://example.invalid",
+            username: "",
+            password: "",
+            supportsNotifications: supportsNotifications,
+            priority: priority
+        )
+
+        #expect(SitemapDiagnostics.connectionKind(for: configuration) == expected)
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in diagnostics for issue #1150 so cold sitemap startup can be separated into connection selection, request, and UI preparation costs.

The existing **Sitemap Diagnostics Logging** setting now records:

- process launch source and process age
- cold start, foreground resume, linked-page load, or other reload context
- whether a connection was already available
- local, remote, or cloud connection classification
- sitemap discovery, connection wait, service setup, label fetch, initial request, UI preparation, and total durations
- terminal status and failure stage
- widget and rendered row counts

The measurement emits only one terminal record per load. This matters when cancellation arrives after the initial fetch already logged success but while long polling is still active.

Related to #1150.

## Automated verification

```text
xcodebuildmcp simulator test \
  --workspace-path openHAB.xcworkspace \
  --scheme openHABTestsSwift \
  --simulator-id B04ACCC9-5413-4DAF-B683-8408A90CC15E \
  --extra-args -only-testing:openHABTestsSwift/SitemapDiagnosticsTests
```

Result: 5 tests passed, 0 failed.

The tests cover cold-start classification for both `manual` and `connection-changed`, foreground resume, linked pages, warm manual reloads, and local/remote/cloud connection classification.

## Manual testing required

Enable **Settings > Developer Settings > Sitemap Diagnostics Logging**, then capture logs from the `SitemapDiagnostics` category for each scenario below. Repeat each scenario several times so timings can be compared rather than relying on a single sample.

1. **Cold launch on local Wi-Fi**
   - Force-quit the app.
   - Confirm the local openHAB URL is reachable.
   - Launch the app and wait for the root sitemap.
   - Expect `context=coldStart` and `connectionKind=local`.

2. **Cold launch through openHAB Cloud**
   - Disable the home VPN/local route and use cellular or an external network.
   - Force-quit and launch the app.
   - Expect `context=coldStart` and `connectionKind=cloud`.

3. **Cold launch through a VPN/direct remote connection**
   - Connect the VPN so the non-cloud server URL is selected.
   - Force-quit and launch the app.
   - Expect `context=coldStart` and `connectionKind=local` or `remote`, according to the configured connection priority.

4. **Foreground resume without process termination**
   - Load a sitemap, background the app, then return to it.
   - Expect `context=foregroundResume`, not `coldStart`.
   - Existing sitemap content should remain visible while it refreshes.

5. **Long-background or OS-eviction reproduction for #1150**
   - Leave the app unused while using other memory-intensive apps, then reopen it.
   - A surviving process should report `foregroundResume`.
   - A process relaunched after eviction should emit `processLaunch` followed by `context=coldStart`.

For every scenario, verify:

- exactly one terminal `initialLoad` record is emitted per attempted initial load
- successful loads report `status=success` and `stage=complete`
- failures identify the active stage and include an error description
- `totalMs` is plausibly accounted for by `discoveryMs`, `connectionWaitMs`, `serviceSetupMs`, `labelFetchMs`, `initialRequestMs`, and `uiPreparationMs`
- Cloud startup delays can be attributed primarily to either connection selection or the initial sitemap request
- logs contain no credentials or sitemap contents

The most useful comparison for #1150 is `connectionWaitMs` versus `initialRequestMs` across local, VPN/direct, and Cloud cold launches.