### PR TITLE
fix: throw on uncached fetch failure in GetItemStateIntent

### DIFF
--- a/AppIntents/Intents/GetItemStateIntent.swift
+++ b/AppIntents/Intents/GetItemStateIntent.swift
@@ -44,11 +44,14 @@ private struct LocalizedItemState: CustomLocalizedStringResourceConvertible {
 
 enum ItemStateError: Error, CustomLocalizedStringResourceConvertible {
     case itemNotInHome(String, String)
+    case itemNotFound(String)
 
     var localizedStringResource: LocalizedStringResource {
         switch self {
         case let .itemNotInHome(itemName, homeName):
             "Item '\(itemName)' is not in home '\(homeName)'"
+        case let .itemNotFound(itemName):
+            "Item '\(itemName)' not found"
         }
     }
 }
@@ -88,8 +91,9 @@ struct GetItemStateIntent: AppIntent {
             mismatchError: ItemStateError.itemNotInHome
         )
 
-        let freshItem = await OpenHABItemCache.instance.getItemUncached(name: itemEntity.itemName, home: homeId)
-        let item = freshItem ?? itemEntity.item
+        guard let item = await OpenHABItemCache.instance.getItemUncached(name: itemEntity.itemName, home: homeId) else {
+            throw ItemStateError.itemNotFound(itemEntity.itemName)
+        }
         let rawState = item.state ?? "Unknown state"
 
         // Prefer the server-formatted state, then fall back to local number formatting,


### PR DESCRIPTION
## Summary

- `GetItemStateIntent` silently fell back to the stale `itemEntity.item` embedded at configuration time when `getItemUncached` returned `nil` (network failure, auth failure, or missing item)
- This made failed live fetches indistinguishable from successful ones — Siri/Shortcuts would report "Unknown state" as a valid result
- The iOS 16 `GetItemState` adapter already throws `itemNotFound` on `nil`; this aligns the iOS 17+ path with that behaviour
- Added `itemNotFound` case to `ItemStateError` and replaced the `??` fallback with a `guard`/`throw`

## Test plan

- [ ] Disable network access and trigger the intent — confirm Siri reports an error rather than a stale or "Unknown state" result
- [ ] Trigger with a valid item while connected — confirm state is returned normally
- [ ] Trigger with an item name that no longer exists on the server — confirm error is surfaced