### PR TITLE
Renaming new WidgetKit watchOS complication entry for differentation

### DIFF
--- a/OpenHABWatchComplications/OpenHABWatchComplications.swift
+++ b/OpenHABWatchComplications/OpenHABWatchComplications.swift
@@ -43,7 +43,7 @@ struct OpenHABComplicationEntryView: View {
             .containerBackground(for: .widget) {
                 AccessoryWidgetBackground()
             }
-            .accessibilityLabel("openHAB")
+            .accessibilityLabel("openHAB App")
     }
 
     @ViewBuilder

--- a/OpenHABWatchComplications/OpenHABWatchComplications.swift
+++ b/OpenHABWatchComplications/OpenHABWatchComplications.swift
@@ -72,7 +72,7 @@ struct OpenHABWatchComplications: Widget {
         StaticConfiguration(kind: kind, provider: OpenHABWatchComplicationsProvider()) { entry in
             OpenHABComplicationEntryView(entry: entry)
         }
-        .configurationDisplayName("openHAB")
+        .configurationDisplayName("openHAB App")
         .description("Open the openHAB app.")
         .supportedFamilies([
             .accessoryCircular,


### PR DESCRIPTION
Renaming new WidgetKit watchOS complication entry for differentation, until or if the legacy entry can be purged.