### PR TITLE
Enable swipe from left and from right in OH admin pages

### DIFF
--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -119,9 +119,10 @@ class OpenHABWebViewController: OpenHABViewController {
         super.viewDidLoad()
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         attachWebViewToLayout(webView)
+        webView.allowsBackForwardNavigationGestures = true
 
         loadingOverlay.backgroundColor = .systemBackground
-        loadingOverlay.isHidden = true
+        loadingOverlay.isHidden = false
         loadingOverlay.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(loadingOverlay)
         NSLayoutConstraint.activate([
@@ -516,6 +517,8 @@ class OpenHABWebViewController: OpenHABViewController {
         if #available(iOS 16.4, *) {
             webview.isInspectable = true
         }
+
+        webview.allowsBackForwardNavigationGestures = true
 
         // Avoid safe-area content insets which can leave a small gap at the bottom on iPad until a reload.
         webview.scrollView.contentInsetAdjustmentBehavior = .never

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -39,6 +39,7 @@ class OpenHABWebViewController: OpenHABViewController {
     private var lastLoadedURL: String? // Track the last successfully loaded URL from didFinish
     private var isConfirmingExternalURL = false
     private var externalURLCooldownUntil: Date?
+    private weak var webHistoryBackGesture: UIScreenEdgePanGestureRecognizer?
 
     var hasLoadedPage: Bool {
         !currentTarget.isEmpty
@@ -119,7 +120,7 @@ class OpenHABWebViewController: OpenHABViewController {
         super.viewDidLoad()
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         attachWebViewToLayout(webView)
-        webView.allowsBackForwardNavigationGestures = true
+        configureWebHistoryGestures(for: webView)
 
         loadingOverlay.backgroundColor = .systemBackground
         loadingOverlay.isHidden = false
@@ -518,7 +519,7 @@ class OpenHABWebViewController: OpenHABViewController {
             webview.isInspectable = true
         }
 
-        webview.allowsBackForwardNavigationGestures = true
+        configureWebHistoryGestures(for: webview)
 
         // Avoid safe-area content insets which can leave a small gap at the bottom on iPad until a reload.
         webview.scrollView.contentInsetAdjustmentBehavior = .never
@@ -548,6 +549,56 @@ class OpenHABWebViewController: OpenHABViewController {
         ])
         view.setNeedsLayout()
         view.layoutIfNeeded()
+    }
+}
+
+extension OpenHABWebViewController: UIGestureRecognizerDelegate {
+    private func configureWebHistoryGestures(for webView: WKWebView) {
+        webView.allowsBackForwardNavigationGestures = false
+
+        guard webHistoryBackGesture?.view !== webView else {
+            return
+        }
+
+        if let webHistoryBackGesture {
+            webHistoryBackGesture.view?.removeGestureRecognizer(webHistoryBackGesture)
+        }
+
+        let backGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleWebHistoryEdgePan(_:)))
+        backGesture.edges = .left
+        backGesture.delegate = self
+        webView.addGestureRecognizer(backGesture)
+        webHistoryBackGesture = backGesture
+    }
+
+    @objc private func handleWebHistoryEdgePan(_ gesture: UIScreenEdgePanGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+
+        let translation = gesture.translation(in: webView)
+        let velocity = gesture.velocity(in: webView)
+        let hasIntent = abs(translation.x) > 35 || abs(velocity.x) > 250
+        guard hasIntent else { return }
+
+        guard gesture.edges == .left,
+              translation.x > 0 || velocity.x > 0 else { return }
+
+        navigateWebHistory(
+            direction: "back",
+            script: "if (window.history.length > 1) { window.history.back(); true; } else { false; }"
+        )
+    }
+
+    private func navigateWebHistory(direction: String, script: String) {
+        webView.evaluateJavaScript(script) { _, error in
+            if let error {
+                Logger.viewController.error("web history \(direction, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        gestureRecognizer === webHistoryBackGesture
     }
 }
 
@@ -841,21 +892,6 @@ extension OpenHABWebViewController: WKNavigationDelegate {
     }
 }
 
-private extension URL {
-    var isNativeWebURL: Bool {
-        guard let scheme = scheme?.lowercased() else { return true }
-        return ["http", "https", "about", "blob", "data", "javascript"].contains(scheme)
-    }
-
-    /// RFC 6454 origin: scheme + host + port, with default ports (80/443) omitted.
-    var webOrigin: String? {
-        guard let scheme = scheme?.lowercased(), let host else { return nil }
-        let defaultPort = scheme == "https" ? 443 : scheme == "http" ? 80 : nil
-        let portSuffix = (port != nil && port != defaultPort) ? ":\(port!)" : ""
-        return "\(scheme)://\(host)\(portSuffix)"
-    }
-}
-
 extension OpenHABWebViewController: WKUIDelegate {
     func webView(_ webView: WKWebView,
                  createWebViewWith configuration: WKWebViewConfiguration,
@@ -881,4 +917,19 @@ extension OpenHABWebViewController: WKUIDelegate {
         Preferences.shared.currentHomePreferences.alwaysAllowWebRTC ? .grant : .prompt
     }
     // swiftlint:enable async_without_await
+}
+
+private extension URL {
+    var isNativeWebURL: Bool {
+        guard let scheme = scheme?.lowercased() else { return true }
+        return ["http", "https", "about", "blob", "data", "javascript"].contains(scheme)
+    }
+
+    /// RFC 6454 origin: scheme + host + port, with default ports (80/443) omitted.
+    var webOrigin: String? {
+        guard let scheme = scheme?.lowercased(), let host else { return nil }
+        let defaultPort = scheme == "https" ? 443 : scheme == "http" ? 80 : nil
+        let portSuffix = (port != nil && port != defaultPort) ? ":\(port!)" : ""
+        return "\(scheme)://\(host)\(portSuffix)"
+    }
 }

--- a/openHAB/UI/SwiftUI/Rows/WebRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/WebRowView.swift
@@ -143,6 +143,7 @@ struct WebRowView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let homeId = Preferences.shared.currentHomePreferences.id
         let webView = WKWebView(frame: .zero, configuration: WebRowViewConfigurationFactory.make(homeId: homeId))
+        webView.allowsBackForwardNavigationGestures = true
         webView.navigationDelegate = context.coordinator
         return webView
     }


### PR DESCRIPTION
Keeping as draft until this can be properly checked with the current swipe from right to show the Sidemenu.

Possibly only integratable once the [sidemenu change to a popup](https://github.com/openhab/openhab-ios/pull/1165) has been implemented.