### PR TITLE
fix: expose Location header on createSitemapEventSubscription 201 response

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Client.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Client.swift
@@ -2283,7 +2283,12 @@ public struct Client: APIProtocol {
             deserializer: { response, responseBody in
                 switch response.status.code {
                 case 201:
-                    return .created(.init())
+                    let headers: Operations.createSitemapEventSubscription.Output.Created.Headers = .init(Location: try converter.getOptionalHeaderFieldAsURI(
+                        in: response.headerFields,
+                        name: "Location",
+                        as: Swift.String.self
+                    ))
+                    return .created(.init(headers: headers))
                 case 200:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.createSitemapEventSubscription.Output.Ok.Body

--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
@@ -10000,8 +10000,29 @@ public enum Operations {
         }
         @frozen public enum Output: Sendable, Hashable {
             public struct Created: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/sitemaps/events/subscribe/POST/responses/201/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Newly created sitemap event subscription
+                    ///
+                    /// - Remark: Generated from `#/paths/sitemaps/events/subscribe/POST/responses/201/headers/Location`.
+                    public var Location: Swift.String?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - Location: Newly created sitemap event subscription
+                    public init(Location: Swift.String? = nil) {
+                        self.Location = Location
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createSitemapEventSubscription.Output.Created.Headers
                 /// Creates a new `Created`.
-                public init() {}
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                public init(headers: Operations.createSitemapEventSubscription.Output.Created.Headers = .init()) {
+                    self.headers = headers
+                }
             }
             /// Subscription created.
             ///
@@ -10009,14 +10030,6 @@ public enum Operations {
             ///
             /// HTTP response code: `201 created`.
             case created(Operations.createSitemapEventSubscription.Output.Created)
-            /// Subscription created.
-            ///
-            /// - Remark: Generated from `#/paths//sitemaps/events/subscribe/post(createSitemapEventSubscription)/responses/201`.
-            ///
-            /// HTTP response code: `201 created`.
-            public static var created: Self {
-                .created(.init())
-            }
             /// The associated value of the enum case if `self` is `.created`.
             ///
             /// - Throws: An error if `self` is not `.created`.

--- a/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
+++ b/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
@@ -5548,6 +5548,14 @@
         "responses": {
           "201": {
             "description": "Subscription created.",
+            "headers": {
+              "Location": {
+                "description": "Newly created sitemap event subscription",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",


### PR DESCRIPTION
## Summary

- openHAB 3.3+ returns the subscription URL in the `Location` HTTP response header of the `201 Created` response from `createSitemapEventSubscription`
- The previous spec only modelled the `200 OK` body, so the `Location` header on `201` was silently dropped
- Adds the `Location` header to the `201` response in `openapi.json` and regenerates `Client.swift` / `Types.swift` accordingly

## Test plan

- [ ] Verify generated `Client.swift` and `Types.swift` are consistent with `openapi.json`
- [ ] Confirm existing `openHABcreateSubscription()` still compiles against the updated types