### PR TITLE
Suggestion to make some or all sections of the popup menu collapsible

### DIFF
--- a/openHAB/UI/ToolbarMenu.swift
+++ b/openHAB/UI/ToolbarMenu.swift
@@ -60,6 +60,7 @@ struct ToolbarMenu: View {
     @Binding var isPresented: Bool
     @ObservedObject var menuData: MenuDataService
     @State var scrollViewContentSize: Double = 0
+    @State private var isTilesExpanded: Bool = true
     var onSelect: (TargetController) -> Void
     var onReload: (() -> Void)?
 
@@ -159,15 +160,40 @@ struct ToolbarMenu: View {
                     if menuData.isLoading {
                         loadingRow(label: String(localized: "Tiles"))
                     } else if !menuData.uiTiles.isEmpty {
-                        sectionHeader(String(localized: "Tiles"))
-                        ForEach(menuData.uiTiles, id: \.url) { tile in
-                            menuRow(
-                                icon: AnyView(ImageView(url: tile.imageUrl).aspectRatio(contentMode: .fit)),
-                                label: tile.name
-                            ) {
-                                select(.tile(tile.url))
+                        // Collapsible Tiles header with disclosure chevron
+                        Button {
+                            isTilesExpanded.toggle()
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemSymbol: isTilesExpanded ? .chevronDown : .chevronRight)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 10)
+                                Text(String(localized: "Tiles"))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(.secondary)
+                                    .textCase(.uppercase)
+                                Spacer(minLength: 0)
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.top, 10)
+                            .padding(.bottom, 2)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        if isTilesExpanded {
+                            ForEach(menuData.uiTiles, id: \.url) { tile in
+                                menuRow(
+                                    icon: AnyView(ImageView(url: tile.imageUrl).aspectRatio(contentMode: .fit)),
+                                    label: tile.name
+                                ) {
+                                    select(.tile(tile.url))
+                                }
                             }
                         }
+
                         Divider().padding(.horizontal, 12)
                     }
 
@@ -335,4 +361,3 @@ struct ToolbarMenu: View {
         onSelect(target)
     }
 }
-


### PR DESCRIPTION
@TAKeanice  Testing the new popup menu a bit more and me only using the Sitemap functionality of the app, there are sections of the popup which I never use, specifically the Tiles section, but also the Main UI section. Additionally it might also be helpful for @timbms to only show his long list of test sitemaps when necessary.

I only applied this to the Tiles section as a test, so you can see what you think about my suggestion.

https://github.com/user-attachments/assets/227c1d58-49ee-4492-8839-73183f5136a5

<img width="307" height="227" alt="Screenshot 2026-06-15 at 19 59 36" src="https://github.com/user-attachments/assets/50a05558-7c5f-4eef-be27-f94936ec41e3" />

