### PR TITLE
fix: stop webview reloading on foreground when default path is set

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/ETagChecker.swift
@@ -16,7 +16,8 @@ import os.log
 public enum ETagCheckResult: Sendable {
     case unchanged // Content hasn't changed, skip reloading and depend on the webview's cache
     case changed // Content has changed, reload
-    case failed(any Error) // Check failed, reload
+    case noETagSupport // Server returned no ETag header; caller decides whether to reload
+    case failed(any Error) // Network or protocol error; caller decides whether to reload
 }
 
 /// Service for checking if remote content has changed using HTTP ETags
@@ -68,7 +69,7 @@ public actor ETagChecker {
 
             guard let newETag else {
                 Logger.etagChecker.debug("No ETag header in response for \(urlString)")
-                return .changed // Server doesn't support ETags, always reload
+                return .noETagSupport
             }
 
             let normalizedNewETag = normalizeETag(newETag)

--- a/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/ETagCheckerTests.swift
@@ -184,8 +184,8 @@ struct ETagCheckerTests {
         }
     }
 
-    @Test("Returns changed when no ETag header present")
-    func changedWhenNoETagHeader() async throws {
+    @Test("Returns noETagSupport when no ETag header present")
+    func noETagSupportWhenNoETagHeader() async throws {
         MockURLProtocol.reset()
 
         let testURL = try #require(URL(string: "https://example.com/no-etag"))
@@ -199,8 +199,8 @@ struct ETagCheckerTests {
 
         let result = await checker.checkIfChanged(url: testURL)
 
-        guard case .changed = result else {
-            Issue.record("Expected .changed (no ETag), got \(result)")
+        guard case .noETagSupport = result else {
+            Issue.record("Expected .noETagSupport, got \(result)")
             return
         }
     }

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -37,6 +37,12 @@ class OpenHABWebViewController: OpenHABViewController {
     private var etagChecker: ETagChecker?
     private var etagCheckerConfigURL: String? // Track which config the checker was created for
     private var lastLoadedURL: String? // Track the last successfully loaded URL from didFinish
+    // Keyed on the WKNavigation returned by webView.load so overlapping loads and external
+    // (SPA-triggered) navigations each resolve their own identity independently.
+    // Promoted to loadedTarget/loadedHomeID in didFinish; removed in all failure callbacks.
+    private var pendingNavigations: [WKNavigation: (target: String, homeID: UUID)] = [:]
+    private var loadedTarget: String? // promoted from pendingNavigations in didFinish
+    private var loadedHomeID: UUID? // promoted from pendingNavigations in didFinish
     private var isConfirmingExternalURL = false
     private var externalURLCooldownUntil: Date?
 
@@ -232,12 +238,12 @@ class OpenHABWebViewController: OpenHABViewController {
     }
 
     @MainActor
-    private func performLoadWebView(newTarget: String, path: String?, force: Bool) async {
+    private func performLoadWebView(newTarget: String, path: String? = nil, urlOverride: URL? = nil, force: Bool) async {
         guard let activeConfig else { return }
         currentTarget = newTarget
         let url = URL(string: activeConfig.url)
 
-        if let modifiedUrl = modifyUrl(orig: url, path: path) {
+        if let modifiedUrl = urlOverride ?? modifyUrl(orig: url, path: path) {
             acceptsCommands = false
             var request = URLRequest(url: modifiedUrl)
 
@@ -260,6 +266,12 @@ class OpenHABWebViewController: OpenHABViewController {
             // create new (or resuse existing)
             let newWebview = webView(for: Preferences.shared.currentHomePreferences.id, isCloudConnection: isCloudConnection)
             if newWebview != webView {
+                // Drop all pending navigation entries before removing the delegate.
+                // stopLoading() cancels in-flight navigations, but with no delegate the
+                // cancellation callbacks never arrive, leaving stale entries in the map.
+                // Every entry currently in the map belongs to this webview; the new load
+                // below will insert its own fresh entry.
+                pendingNavigations.removeAll()
                 // Detach old instance
                 webView.stopLoading()
                 webView.navigationDelegate = nil
@@ -274,7 +286,10 @@ class OpenHABWebViewController: OpenHABViewController {
             // Without this, navigating away from a goFullscreen page keeps the bar hidden.
             setHideNavigationBar(shouldHide: false)
             Logger.viewController.info("Loading URL: \(modifiedUrl)")
-            webView.load(request)
+            // Key the identity on the WKNavigation object so each load's callbacks operate
+            // on their own entry; overlapping loads and non-performLoadWebView navigations
+            // (SPA full-page loads, reloads) never touch each other's pending state.
+            if let nav = webView.load(request) { pendingNavigations[nav] = (target: newTarget, homeID: Preferences.shared.currentHomePreferences.id) }
         }
     }
 
@@ -291,10 +306,8 @@ class OpenHABWebViewController: OpenHABViewController {
         // Create checker if needed (lazy initialization) or if config changed
         let configKey = "\(activeConfig.url):\(activeConfig.username)"
         if etagChecker == nil || etagCheckerConfigURL != configKey {
-            let httpClient = HTTPClient(baseURL: nil, connectionConfiguration: activeConfig)
-            etagChecker = ETagChecker(httpClient: httpClient)
+            etagChecker = ETagChecker(httpClient: HTTPClient(baseURL: nil, connectionConfiguration: activeConfig))
             etagCheckerConfigURL = configKey
-            Logger.viewController.debug("Created new ETagChecker for config: \(configKey)")
         }
 
         guard let checker = etagChecker else {
@@ -302,35 +315,100 @@ class OpenHABWebViewController: OpenHABViewController {
             return
         }
 
-        // Check if content changed
-        let result = await checker.checkIfChanged(url: fullURL)
+        // Check against the canonical server root, not the configured default SPA path.
+        // The default path is a frontend route served by the same index.html; checking it
+        // risks a URL that returns no ETag, redirects differently, or has a route-specific
+        // ETag that changes independently of the actual app bundle.
+        let canonicalURL = activeConnectionInfo?.proxyURL ?? url
+
+        // Snapshot both the full ConnectionInfo and home ID before the async check.
+        // configKey omits proxy URL so local/cloud transitions with the same URL/username
+        // would pass a key-string guard. etagCheckerConfigURL only updates when a new checker
+        // is created, so it misses changes that occur while a request is in flight.
+        // Snapshotting the home ID separately covers same-connection home switches where the
+        // network tracker hasn't published a new ConnectionInfo yet.
+        let snapshotConnectionInfo = activeConnectionInfo
+        let snapshotHomeID = Preferences.shared.currentHomePreferences.id
+
+        let result = await checker.checkIfChanged(url: canonicalURL)
+
+        // Discard stale results. Full ConnectionInfo equality (which includes proxyURL) covers
+        // proxy transitions that share the same configured URL/username. Home ID equality
+        // covers home switches before the network tracker publishes the new connection.
+        guard activeConnectionInfo == snapshotConnectionInfo,
+              Preferences.shared.currentHomePreferences.id == snapshotHomeID else {
+            Logger.viewController.info("ETag check result discarded: connection or home changed during check")
+            return
+        }
+
+        // webView.url reflects pushState SPA navigation; lastLoadedURL is only updated on
+        // full-page didFinish. Prefer the live URL so we don't miss mid-session navigation.
+        let displayedURL = webView.url?.absoluteString ?? lastLoadedURL
+
+        // Normalized target origin, shared across all switch cases.
+        let normalizedCanonical = normalizeURLForComparison(canonicalURL.absoluteString, includeBasePath: false)
+
+        /// Returns true when the origin, loaded config, and loaded home all match the target.
+        /// Uses loadedTarget/loadedHomeID (promoted in didFinish only) so a failed or
+        /// in-progress navigation never causes a stale page to be incorrectly preserved.
+        func isCurrentContent(_ urlString: String?) -> Bool {
+            guard let n = normalizedCanonical,
+                  let o = normalizeURLForComparison(urlString, includeBasePath: false) else { return false }
+            return o == n && loadedTarget == newTarget && loadedHomeID == Preferences.shared.currentHomePreferences.id
+        }
 
         switch result {
         case .unchanged:
-            // When ETag is unchanged, the base resource (HTML/JS) hasn't changed
-            // Compare base URLs (origin) only, since paths are handled by client-side routing
-            let normalizedTarget = normalizeURLForComparison(fullURL.absoluteString, includeBasePath: false)
-            let normalizedLoaded = normalizeURLForComparison(lastLoadedURL, includeBasePath: false)
+            // When ETag is unchanged, the base resource (HTML/JS) hasn't changed.
+            // Compare origins only — paths are handled by client-side routing.
+            Logger.viewController.debug("ETag unchanged: loaded=\(normalizeURLForComparison(displayedURL, includeBasePath: false) ?? "nil") target=\(normalizedCanonical ?? "nil")")
 
-            Logger.viewController.debug("ETag unchanged - comparing base URLs: loaded=\(normalizedLoaded ?? "nil") vs target=\(normalizedTarget ?? "nil")")
-
-            if let normalizedTarget, let normalizedLoaded, normalizedLoaded == normalizedTarget {
-                Logger.viewController.info("ETag unchanged and same base URL, skipping load")
+            if isCurrentContent(displayedURL) {
+                Logger.viewController.info("ETag unchanged, same config and home — skipping load")
                 currentTarget = newTarget
                 showActivityIndicator(show: false)
-                // Don't load - same server, same content version, already displayed
             } else {
-                Logger.viewController.info("ETag unchanged but different base URL, loading \(fullURL.absoluteString)")
+                Logger.viewController.info("ETag unchanged but config/home changed, loading \(fullURL.absoluteString)")
                 await performLoadWebView(newTarget: newTarget, path: path, force: false)
             }
 
         case .changed:
-            Logger.viewController.info("ETag changed, loading \(fullURL.absoluteString)")
-            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            // Reload at the user's current SPA position to preserve navigation state.
+            // Only when the webview is showing content for the active config and home;
+            // after any configuration change the displayed URL must not be reused.
+            if let currentURL = webView.url, isCurrentContent(currentURL.absoluteString) {
+                Logger.viewController.info("ETag changed, reloading at current position: \(currentURL.absoluteString)")
+                await performLoadWebView(newTarget: newTarget, urlOverride: currentURL, force: false)
+            } else {
+                Logger.viewController.info("ETag changed, loading \(fullURL.absoluteString)")
+                await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            }
+
+        case .noETagSupport:
+            // Server returned no ETag — we can't determine whether content changed.
+            // Preserve content already in the webview for the active config/home rather than
+            // forcing a reload on every foreground activation.
+            if isCurrentContent(displayedURL) {
+                Logger.viewController.info("ETag not supported by server, active config displayed — preserving page")
+                currentTarget = newTarget
+                showActivityIndicator(show: false)
+            } else {
+                Logger.viewController.info("ETag not supported by server, loading \(fullURL.absoluteString)")
+                await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            }
 
         case let .failed(error):
-            Logger.viewController.info("ETag check failed: \(error.localizedDescription), loading anyway")
-            await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            // Treat transient failures as "assume unchanged" when the active config/home
+            // content is displayed. Reloading on every failure resets the user's SPA
+            // position and is disruptive when the server is temporarily unreachable.
+            if isCurrentContent(displayedURL) {
+                Logger.viewController.info("ETag check failed, active config displayed — preserving page: \(error.localizedDescription)")
+                currentTarget = newTarget
+                showActivityIndicator(show: false)
+            } else {
+                Logger.viewController.info("ETag check failed, loading \(fullURL.absoluteString): \(error.localizedDescription)")
+                await performLoadWebView(newTarget: newTarget, path: path, force: false)
+            }
         }
     }
 
@@ -679,6 +757,7 @@ extension OpenHABWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: any Error) {
         Logger.viewController.error("didFail - webView.url: \(String(describing: webView.url?.description))")
 
+        if let navigation { pendingNavigations.removeValue(forKey: navigation) }
         setHideNavigationBar(shouldHide: false)
         if let urlError = error as? URLError, urlError.code == .cancelled {
             return // Ignore cancelled requests
@@ -781,6 +860,13 @@ extension OpenHABWebViewController: WKNavigationDelegate {
 
         // Track the successfully loaded URL for ETag comparison
         lastLoadedURL = webView.url?.absoluteString
+        // Promote this navigation's identity to loaded state. Only updates when the navigation
+        // was initiated by performLoadWebView; SPA-triggered or external full-page navigations
+        // are not in pendingNavigations and leave loadedTarget/loadedHomeID unchanged.
+        if let identity = pendingNavigations.removeValue(forKey: navigation) {
+            loadedTarget = identity.target
+            loadedHomeID = identity.homeID
+        }
 
         showActivityIndicator(show: false)
         UIView.animate(withDuration: 0.2) {
@@ -827,6 +913,7 @@ extension OpenHABWebViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+        pendingNavigations.removeValue(forKey: navigation)
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
             return

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -352,16 +352,17 @@ class OpenHABWebViewController: OpenHABViewController {
         /// Uses loadedTarget/loadedHomeID (promoted in didFinish only) so a failed or
         /// in-progress navigation never causes a stale page to be incorrectly preserved.
         func isCurrentContent(_ urlString: String?) -> Bool {
-            guard let n = normalizedCanonical,
-                  let o = normalizeURLForComparison(urlString, includeBasePath: false) else { return false }
-            return o == n && loadedTarget == newTarget && loadedHomeID == Preferences.shared.currentHomePreferences.id
+            guard let normalizedCanonical,
+                  let normalizedURL = normalizeURLForComparison(urlString, includeBasePath: false) else { return false }
+            return normalizedURL == normalizedCanonical && loadedTarget == newTarget && loadedHomeID == Preferences.shared.currentHomePreferences.id
         }
 
         switch result {
         case .unchanged:
             // When ETag is unchanged, the base resource (HTML/JS) hasn't changed.
             // Compare origins only — paths are handled by client-side routing.
-            Logger.viewController.debug("ETag unchanged: loaded=\(normalizeURLForComparison(displayedURL, includeBasePath: false) ?? "nil") target=\(normalizedCanonical ?? "nil")")
+            // swiftformat:disable:next redundantSelf
+            Logger.viewController.debug("ETag unchanged: loaded=\(self.normalizeURLForComparison(displayedURL, includeBasePath: false) ?? "nil") target=\(normalizedCanonical ?? "nil")")
 
             if isCurrentContent(displayedURL) {
                 Logger.viewController.info("ETag unchanged, same config and home — skipping load")


### PR DESCRIPTION
## Summary

Fixes a regression from #1066 where configuring a default Main UI path (e.g. `/locations`) caused the webview to reload and navigate back to that path on every foreground activation, losing the user's current SPA position.

- **Root cause**: ETag checks ran against the default SPA path rather than the canonical server root. Routes like `/locations` may return no ETag, redirect differently, or carry a route-specific ETag unrelated to the app bundle — causing `ETagChecker` to return `.changed` on every foreground activation.
- **ETagChecker**: add `.noETagSupport` case so "no ETag header" is distinct from a genuine content change; callers can preserve already-loaded content instead of always reloading.
- **Canonical URL**: ETag checks now run against the server root (proxy URL or base URL, no default path appended).
- **SPA position preserved on genuine change**: `.changed` reloads at `webView.url` (the user's current SPA position) when origin matches, rather than at the default path.
- **Preserve on no-ETag / failure**: `.noETagSupport` and `.failed` preserve same-config, same-home content rather than treating inability-to-check as proof of change. After a home or connection switch the old page is not preserved.
- **Stale-task guard**: snapshots the full `ConnectionInfo` (covers proxy URL transitions missed by the old key-string comparison) and home ID (covers same-connection home switches before the network tracker publishes) before the async check; discards results if either changed.
- **Config/home identity check**: preservation requires `loadedTarget == newTarget` and `loadedHomeID == currentHomeID` in addition to origin equality, so homes sharing an endpoint, credential changes, and proxy transitions all trigger a fresh load.
- **Navigation-keyed pending identity**: pending identity is stored in `[WKNavigation: (target, homeID)]` keyed on the object returned by `webView.load`; overlapping loads and external (SPA-triggered) navigations each resolve their own entry independently. Promoted to `loadedTarget`/`loadedHomeID` only in `didFinish`; removed in all failure callbacks including before early-returns to avoid map leaks.
- **Webview replacement**: clears `pendingNavigations` before removing the delegate so in-flight navigations on the detached webview don't accumulate stale entries when their cancellation callbacks are suppressed.

## Test plan

- [ ] Launch app with a default Main UI path configured (e.g. `/locations`) — page loads at that path
- [ ] Navigate within the SPA to a different page (e.g. `/overview`)
- [ ] Background and foreground the app — confirm the SPA position is preserved and no reload occurs
- [ ] Pull to force-reload — confirm it reloads correctly
- [ ] Switch homes sharing the same server — confirm the new home's webview loads
- [ ] Change credentials — confirm a fresh load occurs rather than preserving the old page
- [ ] Run `ETagCheckerTests` — all tests pass