### PR TITLE
fix: render Image/Chart/Video widgets as media even when linkedPage is present

### DIFF
--- a/openHAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5d09299cca05d481ff6456cdbd90914f268a8a34e524c80fef53066ee94ce606",
+  "originHash" : "6a0dbe66704e542f2c43f6f9ff3e1a2ae7244ffe448c8d1a8779c162f17fe8eb",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftFormatPlugin",
       "state" : {
-        "revision" : "c41997c642ffc937c6e83b23dadbd7e626485cfa",
-        "version" : "0.58.7"
+        "revision" : "c7c81920d715e051306d2172083c14aaec2c1b9d",
+        "version" : "0.61.1"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weakfl/SwiftLintPlugin.git",
       "state" : {
-        "revision" : "47d1da3a8e30e0ada5543899e8c47f54664073ac",
-        "version" : "0.62.2"
+        "revision" : "3741567a0252090897336f1f39b8490107b49ead",
+        "version" : "0.63.3"
       }
     },
     {

--- a/openHAB/Models/WidgetMappingSnapshot.swift
+++ b/openHAB/Models/WidgetMappingSnapshot.swift
@@ -343,7 +343,9 @@ private extension OpenHABWidgetMapping {
 
 extension SitemapRowInputMapper {
     static func map(snapshot: WidgetMappingSnapshot, rowID: RowID) -> SitemapRowInput {
-        if let input = linkedPageRowInput(from: snapshot) {
+        let kind = snapshot.renderingKind
+        let isMediaKind = kind == .image || kind == .chart || kind == .video || kind == .webview || kind == .mapview
+        if !isMediaKind, let input = linkedPageRowInput(from: snapshot) {
             return .linked(rowID, input)
         }
 
@@ -617,7 +619,9 @@ extension SitemapRowInputMapper {
             labelSourceRawValue: snapshot.labelSourceRawValue,
             preferredRowHeight: snapshot.preferredRowHeight,
             coordinateLatitude: hasValidCoordinate ? coordinate?.latitude : nil,
-            coordinateLongitude: hasValidCoordinate ? coordinate?.longitude : nil
+            coordinateLongitude: hasValidCoordinate ? coordinate?.longitude : nil,
+            linkedPageLink: snapshot.linkedPage?.link,
+            linkedPageTitle: snapshot.linkedPage?.title
         )
     }
 

--- a/openHAB/UI/SwiftUI/Rows/MediaRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/MediaRowView.swift
@@ -26,6 +26,19 @@ struct MediaRowView: View {
     }
 
     var body: some View {
+        let content = mediaContent
+        if let link = input.linkedPageLink {
+            NavigationLink(value: LinkedPageNavigation(pageLink: link, pageTitle: input.linkedPageTitle ?? "")) {
+                content
+            }
+            .buttonStyle(.plain)
+        } else {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var mediaContent: some View {
         switch input.renderingKind {
         case .image, .chart:
             ImageRowView(input: input)

--- a/openHAB/UI/SwiftUI/SitemapRowInputMapper.swift
+++ b/openHAB/UI/SwiftUI/SitemapRowInputMapper.swift
@@ -31,7 +31,9 @@ enum SitemapRowInputMapper {
     }
 
     static func map(widget: OpenHABWidget, rowID: RowID) -> SitemapRowInput {
-        if let input = LinkedPageRowInput.from(widget: widget) {
+        let kind = widget.renderingKind
+        let isMediaKind = kind == .image || kind == .chart || kind == .video || kind == .webview || kind == .mapview
+        if !isMediaKind, let input = LinkedPageRowInput.from(widget: widget) {
             return .linked(rowID, input)
         }
 

--- a/openHAB/UI/SwiftUI/WidgetRowInputs.swift
+++ b/openHAB/UI/SwiftUI/WidgetRowInputs.swift
@@ -441,6 +441,8 @@ struct MediaRowInput: Equatable {
     let preferredRowHeight: Double?
     let coordinateLatitude: Double?
     let coordinateLongitude: Double?
+    let linkedPageLink: String?
+    let linkedPageTitle: String?
 
     static func from(widget: OpenHABWidget) -> MediaRowInput {
         let coordinate = widget.coordinate
@@ -462,7 +464,9 @@ struct MediaRowInput: Equatable {
             labelSourceRawValue: widget.labelSource.rawValue,
             preferredRowHeight: WidgetMappingSnapshot.preferredRowHeight(type: widget.type, label: widget.label, height: widget.height),
             coordinateLatitude: hasValidCoordinate ? coordinate.latitude : nil,
-            coordinateLongitude: hasValidCoordinate ? coordinate.longitude : nil
+            coordinateLongitude: hasValidCoordinate ? coordinate.longitude : nil,
+            linkedPageLink: widget.linkedPage?.link,
+            linkedPageTitle: widget.linkedPage?.title
         )
     }
 

--- a/openHABTestsSwift/SitemapRowInputMapperTests.swift
+++ b/openHABTestsSwift/SitemapRowInputMapperTests.swift
@@ -175,6 +175,53 @@ struct SitemapRowInputMapperTests {
 
         #expect(input.url == "http://default.example.invalid/video.m3u8")
     }
+
+    @Test
+    func mediaWidgetsWithLinkedPageStillMapToMedia() {
+        let mediaWidgets: [OpenHABWidget] = [
+            makeImageWidget(widgetID: "image"),
+            makeChartWidget(widgetID: "chart"),
+            makeVideoWidget(widgetID: "video", url: "http://example.invalid/v.m3u8", itemState: "OFF")
+        ]
+
+        for (index, widget) in mediaWidgets.enumerated() {
+            widget.linkedPage = makeLinkedPage()
+            let rowID = RowID(pageKey: "testPage", widgetId: widget.widgetId, occurrence: index + 1)
+
+            let widgetMapped = SitemapRowInputMapper.map(widget: widget, rowID: rowID)
+            let snapshotMapped = SitemapRowInputMapper.map(snapshot: WidgetMappingSnapshot(widget: widget), rowID: rowID)
+
+            guard case .media = widgetMapped else {
+                #expect(Bool(false), "Expected .media for linked \(widget.widgetId), got \(widgetMapped)")
+                continue
+            }
+            guard case .media = snapshotMapped else {
+                #expect(Bool(false), "Expected .media for linked snapshot \(widget.widgetId), got \(snapshotMapped)")
+                continue
+            }
+        }
+    }
+
+    @Test
+    func imageWidgetWithEmbeddedJPEGAndLinkedPageShowsEmbeddedData() {
+        // swiftlint:disable:next line_length
+        let jpegBase64 = "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AKwAB/9k="
+        let widget = makeImageWidget(widgetID: "imgWithLinked")
+        widget.item = makeItem(name: "CameraSnapshot", type: "Image", state: "data:image/jpeg;base64,\(jpegBase64)")
+        widget.linkedPage = makeLinkedPage()
+        let rowID = RowID(pageKey: "testPage", widgetId: widget.widgetId, occurrence: 1)
+
+        let mapped = SitemapRowInputMapper.map(snapshot: WidgetMappingSnapshot(widget: widget), rowID: rowID)
+
+        guard case let .media(_, mediaInput) = mapped else {
+            #expect(Bool(false), "Expected .media row for image widget with linked page")
+            return
+        }
+        guard case .embedded = mediaInput.imageDescriptor.resolveImagePayload(rootUrl: "http://server.invalid") else {
+            #expect(Bool(false), "Expected .embedded payload for Image item with base64 JPEG state")
+            return
+        }
+    }
 }
 
 private extension SitemapRowInputMapperTests {
@@ -319,6 +366,22 @@ private extension SitemapRowInputMapperTests {
         widget.type = .video
         widget.url = url
         widget.item = makeItem(name: "VideoItem", type: "String", state: itemState)
+        return widget
+    }
+
+    func makeImageWidget(widgetID: String) -> OpenHABWidget {
+        let widget = OpenHABWidget()
+        widget.widgetId = widgetID
+        widget.type = .image
+        widget.url = "http://example.invalid/proxy?widgetId=\(widgetID)"
+        return widget
+    }
+
+    func makeChartWidget(widgetID: String) -> OpenHABWidget {
+        let widget = OpenHABWidget()
+        widget.widgetId = widgetID
+        widget.type = .chart
+        widget.item = makeItem(name: "ChartItem", type: "Number", state: "42")
         return widget
     }
 }


### PR DESCRIPTION
## Summary

- Image/Chart/Video widgets backed by IpCamera, DoorBird, or similar bindings carry a `linkedPage` in the sitemap response alongside their embedded content. The mapper was routing any widget with a `linkedPage` to `.linked()` before checking the rendering kind, so these widgets were displayed as plain navigation rows instead of showing their inline content.
- Fix: skip the `linkedPage` routing for media rendering kinds (`.image`, `.chart`, `.video`, `.webview`, `.mapview`). `MediaRowInput` now carries the optional linked-page destination, and `MediaRowView` wraps the content in a `NavigationLink` when one is present — so tapping the image still opens the sub-page.
- Also bumps `Package.resolved`: SwiftFormatPlugin 0.58.7→0.61.1, SwiftLintPlugin 0.62.2→0.63.3.

## Test plan

- [ ] Build and run on device/simulator with a sitemap containing an Image widget that has a `linkedPage` (e.g. IpCamera or DoorBird binding) — image renders inline instead of a navigation row
- [ ] Tapping the image navigates to the linked sub-page
- [ ] Image/Chart/Video widgets *without* a `linkedPage` continue to render as before
- [ ] Regular non-media widgets with `linkedPage` still render as navigation rows
- [ ] New unit tests pass: `mediaWidgetsWithLinkedPageStillMapToMedia` and `imageWidgetWithEmbeddedJPEGAndLinkedPageShowsEmbeddedData`