### PR TITLE
l10n: complete German translations

### DIFF
--- a/openHAB/Supporting Files/Localizable.xcstrings
+++ b/openHAB/Supporting Files/Localizable.xcstrings
@@ -1,17908 +1,18010 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+  "sourceLanguage": "en",
+  "strings": {
+    "": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       },
-      "shouldTranslate" : false
+      "shouldTranslate": false
     },
-    " - " : {
-      "comment" : "A separator text displayed between the temperature value and its description in the color temperature picker row.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+    " - ": {
+      "comment": "A separator text displayed between the temperature value and its description in the color temperature picker row.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " - "
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "__item_state_passthrough__" : {
-      "comment" : "Placeholder for a numeric or custom item state that should be displayed as-is.",
-      "extractionState" : "extracted_with_value",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@"
+    "__item_state_passthrough__": {
+      "comment": "Placeholder for a numeric or custom item state that should be displayed as-is.",
+      "extractionState": "extracted_with_value",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
         }
       }
     },
-    "/overview/" : {
-      "comment" : "A placeholder text in the text field of the default path setting.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+    "/overview/": {
+      "comment": "A placeholder text in the text field of the default path setting.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/overview/"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/overview/"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "%@" : {
-      "comment" : "The display representation of a Home.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
+    "%@": {
+      "comment": "The display representation of a Home.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
           }
         }
       }
     },
-    "%@ Settings" : {
-      "comment" : "The title of the settings view. The placeholder is replaced with the user's home name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-Einstellungen"
+    "%@ Settings": {
+      "comment": "The title of the settings view. The placeholder is replaced with the user's home name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "%@ value" : {
-      "comment" : "A text field displaying the current value of a setpoint.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Wert"
+    "%@ value": {
+      "comment": "A text field displaying the current value of a setpoint.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Wert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "%lld" : {
-      "comment" : "A label indicating that there are multiple commands currently being sent to the device. The number in the parentheses is the count of these commands.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+    "%lld": {
+      "comment": "A label indicating that there are multiple commands currently being sent to the device. The number in the parentheses is the count of these commands.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "%lld %%" : {
-      "comment" : "A label that shows the percentage of brightness. The value is rounded to the nearest whole number.",
-      "isCommentAutoGenerated" : true
+    "%lld %%": {
+      "comment": "A label that shows the percentage of brightness. The value is rounded to the nearest whole number.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld %%"
+          }
+        }
+      }
     },
-    "%lldK" : {
-      "comment" : "A text view displaying the selected color temperature in Kelvin. The value is shown in a smaller font next to a separator text (\" - \").",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+    "%lldK": {
+      "comment": "A text view displaying the selected color temperature in Kelvin. The value is shown in a smaller font next to a separator text (\" - \").",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "24-Hour Clock" : {
-      "comment" : "A toggle that allows the user to switch between 12-hour and 24-hour time formats.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24-Stunden Uhr"
+    "24-Hour Clock": {
+      "comment": "A toggle that allows the user to switch between 12-hour and 24-hour time formats.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-Stunden Uhr"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24-Hour Clock"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-Hour Clock"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "about_settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über"
+    "about_settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A propos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A propos"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Om"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Om"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Over"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Over"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         }
       }
     },
-    "Accepted Server Certificates" : {
-      "comment" : "A link to view and manage the user's accepted server certificates.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akzeptierte Server-Zertifikate"
+    "Accepted Server Certificates": {
+      "comment": "A link to view and manage the user's accepted server certificates.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzeptierte Server-Zertifikate"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accepted Server Certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accepted Server Certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Action" : {
-      "comment" : "Parameter title for an action in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktion"
+    "Action": {
+      "comment": "Parameter title for an action in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktion"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Action"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acción"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Action"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Azione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Handling"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Handling"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "activate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren"
+    "activate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activate"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activate"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activate"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attiva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiver"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiver"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activeren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activeren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activate"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activate"
           }
         }
       }
     },
-    "active_url" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktive URL"
+    "active_url": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktive URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL activa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL activa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL active"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL active"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL Attivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL Attivo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiv URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiv URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actieve URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actieve URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Активный URL-адрес"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активный URL-адрес"
           }
         }
       }
     },
-    "Added: %@" : {
-      "comment" : "A label displaying the date and time when a server certificate was added to the app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzugefügt am: %@"
+    "Added: %@": {
+      "comment": "A label displaying the date and time when a server certificate was added to the app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzugefügt am: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Added: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Always" : {
-      "comment" : "Button title for allowing the app to use the invalid server certificate, even if it is self-signed.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immer"
+    "Always": {
+      "comment": "Button title for allowing the app to use the invalid server certificate, even if it is self-signed.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siempre"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siempre"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sempre"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sempre"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altijd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altijd"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Always allow WebRTC" : {
-      "comment" : "A toggle that allows the user to enable or disable WebRTC.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WebRTC immer erlauben"
+    "Always allow WebRTC": {
+      "comment": "A toggle that allows the user to enable or disable WebRTC.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebRTC immer erlauben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always allow WebRTC"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always allow WebRTC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Always send credentials" : {
-      "comment" : "A toggle that lets the user specify whether to always send basic authentication credentials with requests.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anmeldedaten immer senden"
+    "Always send credentials": {
+      "comment": "A toggle that lets the user specify whether to always send basic authentication credentials with requests.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmeldedaten immer senden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always send credentials"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always send credentials"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "always_allow_webrtc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WebRTC immer erlauben"
+    "always_allow_webrtc": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebRTC immer erlauben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Allow WebRTC"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Allow WebRTC"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti sempre WebRTC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti sempre WebRTC"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Allow WebRTC"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Allow WebRTC"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours autoriser WebRTC"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours autoriser WebRTC"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti sempre WebRTC"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti sempre WebRTC"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Allow WebRTC"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Allow WebRTC"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WebRTC altijd toestaan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebRTC altijd toestaan"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Allow WebRTC"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Allow WebRTC"
           }
         }
       }
     },
-    "always_send_credentials" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anmeldedaten immer senden"
+    "always_send_credentials": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmeldedaten immer senden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always send credentials"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always send credentials"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siempre enviar credenciales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siempre enviar credenciales"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always send credentials"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always send credentials"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours envoyer les identifiants"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours envoyer les identifiants"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invia sempre le credenziali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia sempre le credenziali"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alltid send innloggingsinformasjon"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alltid send innloggingsinformasjon"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altijd inloggegevens versturen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altijd inloggegevens versturen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always send credentials"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always send credentials"
           }
         }
       }
     },
-    "Animation" : {
-      "comment" : "A section header for the animation settings in the screen saver view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animation"
+    "Animation": {
+      "comment": "A section header for the animation settings in the screen saver view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animation"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animation"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animation"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "App Version" : {
-      "comment" : "The label and value for the application version in the \"About\" settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Version"
+    "App Version": {
+      "comment": "The label and value for the application version in the \"About\" settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "app_version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Version"
+    "app_version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de la aplicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de la aplicación"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Version"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Version"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version de l'application"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de l'application"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione App"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione App"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programversjon"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programversjon"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Versie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Versie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Version"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Version"
           }
         }
       }
     },
-    "Appearance" : {
-      "comment" : "The header for the \"Appearance\" section in the screen saver settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anzeige"
+    "Appearance": {
+      "comment": "The header for the \"Appearance\" section in the screen saver settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeige"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appearance"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aspecto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspecto"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apparence"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparence"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aspetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspetto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weergave"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weergave"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "application_settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anwendungseinstellungen"
+    "application_settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwendungseinstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración de la aplicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de la aplicación"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application Settings"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application Settings"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres de l'application"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres de l'application"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni Applicazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni Applicazione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programinnstillinger"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programinnstillinger"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applicatie Instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicatie Instellingen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application Settings"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application Settings"
           }
         }
       }
     },
-    "Back" : {
-      "comment" : "A button label that goes back to the previous screen.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurück"
+    "Back": {
+      "comment": "A button label that goes back to the previous screen.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurück"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indietro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indietro"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorige"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorige"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "bonjour_discovery_disclaimer" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour-Entdeckung kann vielleicht nicht alle Server finden. Zusätzliche Server könnten im Netzwerk verfügbar sein."
+    "bonjour_discovery_disclaimer": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour-Entdeckung kann vielleicht nicht alle Server finden. Zusätzliche Server könnten im Netzwerk verfügbar sein."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour discovery may not find all servers. Additional servers may be available on your network."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour discovery may not find all servers. Additional servers may be available on your network."
           }
         }
       }
     },
-    "Brightness" : {
-      "comment" : "A section header for brightness settings.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helligkeit"
+    "Brightness": {
+      "comment": "A section header for brightness settings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helligkeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brightness"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brightness"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brillo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brillo"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luminosité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luminosité"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luminosità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luminosità"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helderheid"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helderheid"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Brightness: %.2f" : {
-      "comment" : "A label displaying the brightness value in the checkout view.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brightness: %.2f"
+    "Brightness: %.2f": {
+      "comment": "A label displaying the brightness value in the checkout view.",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brightness: %.2f"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brightness: %.2f"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brightness: %.2f"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "cache_cleared" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache gelöscht"
+    "cache_cleared": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache gelöscht"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache Cleared"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Cleared"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caché limpiada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caché limpiada"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache Cleared"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Cleared"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache effacé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache effacé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache svuotata"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache svuotata"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache Cleared"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Cleared"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache gewist"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache gewist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache Cleared"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache Cleared"
           }
         }
       }
     },
-    "cancel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+    "cancel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbryt"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleer"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "Cancel" : {
-      "comment" : "A button to cancel renaming the home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+    "Cancel": {
+      "comment": "A button to cancel renaming the home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleer"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Cancellation occurred" : {
-      "comment" : "Message displayed when a connection test is cancelled.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbruch aufgetreten"
+    "Cancellation occurred": {
+      "comment": "Message displayed when a connection test is cancelled.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbruch aufgetreten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancellation occurred"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancellation occurred"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Candlelight" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kerzenlicht"
+    "Candlelight": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kerzenlicht"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Candlelight"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Candlelight"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Cannot connect to the server. Is it online?" : {
-      "comment" : "Error message indicating that the device cannot connect to the server.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung zum Server kann nicht hergestellt werden. Ist er online?"
+    "Cannot connect to the server. Is it online?": {
+      "comment": "Error message indicating that the device cannot connect to the server.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung zum Server kann nicht hergestellt werden. Ist er online?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot connect to the server. Is it online?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot connect to the server. Is it online?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Cannot find the server. Is the URL correct?" : {
-      "comment" : "Error message when the URL cannot be resolved to a host.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Server kann nicht gefunden werden. Ist die URL korrekt?"
+    "Cannot find the server. Is the URL correct?": {
+      "comment": "Error message when the URL cannot be resolved to a host.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Server kann nicht gefunden werden. Ist die URL korrekt?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot find the server. Is the URL correct?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot find the server. Is the URL correct?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "certficate_exists" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zertifikat existiert bereits im Schlüsselbund."
+    "certficate_exists": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zertifikat existiert bereits im Schlüsselbund."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificate already exists in the keychain."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificate already exists in the keychain."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El certificado ya existe en el llavero."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El certificado ya existe en el llavero."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificate already exists in the keychain."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificate already exists in the keychain."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le certificat existe déjà dans le trousseau."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le certificat existe déjà dans le trousseau."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il certificato esiste già nel portachiavi."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il certificato esiste già nel portachiavi."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sertifikatet finnes allerede i nøkkelkjeden."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sertifikatet finnes allerede i nøkkelkjeden."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificaat bestaat al in de sleutelhanger."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificaat bestaat al in de sleutelhanger."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificate already exists in the keychain."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificate already exists in the keychain."
           }
         }
       }
     },
-    "certificate_import_password" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passwort wird für den Import benötigt."
+    "certificate_import_password": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passwort wird für den Import benötigt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password required for import."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password required for import."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requiere contraseña para importar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere contraseña para importar."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password required for import."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password required for import."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mot de passe requis pour l'importation."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mot de passe requis pour l'importation."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password richiesta per l'importazione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password richiesta per l'importazione."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passord kreves for import."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passord kreves for import."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wachtwoord vereist voor import."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wachtwoord vereist voor import."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password required for import."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password required for import."
           }
         }
       }
     },
-    "certificate_import_text" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clientzertifikat in den Schlüsselbund importieren?"
+    "certificate_import_text": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clientzertifikat in den Schlüsselbund importieren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import client certificate into the keychain?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import client certificate into the keychain?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Importar certificado de cliente al llavero?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Importar certificado de cliente al llavero?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import client certificate into the keychain?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import client certificate into the keychain?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer le certificat client dans la trousseau ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer le certificat client dans la trousseau ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importare il certificato client nel portachiavi?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importare il certificato client nel portachiavi?"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer klientsertifikat til nøkkelringen?"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer klientsertifikat til nøkkelringen?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client-certificaat in de sleutelhanger importeren?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client-certificaat in de sleutelhanger importeren?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import client certificate into the keychain?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import client certificate into the keychain?"
           }
         }
       }
     },
-    "certificate_import_title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client-Zertifikatimport"
+    "certificate_import_title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client-Zertifikatimport"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificate Import"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificate Import"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar certificado de cliente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar certificado de cliente"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificate Import"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificate Import"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importation du certificat client"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importation du certificat client"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importazione Certificato Client"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importazione Certificato Client"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import av Klientsertifikat"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import av Klientsertifikat"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cliëntcertificaat Importeren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cliëntcertificaat Importeren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificate Import"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificate Import"
           }
         }
       }
     },
-    "Check & Clear Image Cache" : {
-      "comment" : "A button that triggers a check and clear action for the image cache.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder-Cache checken & löschen"
+    "Check & Clear Image Cache": {
+      "comment": "A button that triggers a check and clear action for the image cache.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilder-Cache checken & löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check & Clear Image Cache"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check & Clear Image Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Choose color" : {
-      "comment" : "A label for the color picker button.",
-      "isCommentAutoGenerated" : true
+    "Choose color": {
+      "comment": "A label for the color picker button.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe wählen"
+          }
+        }
+      }
     },
-    "Clear" : {
-      "comment" : "The title of a button that clears the website cache.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+    "Clear": {
+      "comment": "The title of a button that clears the website cache.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effacer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancella"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wis"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wis"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Clear Web Cache" : {
-      "comment" : "A button that clears the web cache.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Cache löschen"
+    "Clear Web Cache": {
+      "comment": "A button that clears the web cache.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Cache löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Web Cache"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Web Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "clear_image_cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder-Cache löschen"
+    "clear_image_cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilder-Cache löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Image Cache"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Image Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpiar caché de imágenes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar caché de imágenes"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Image Cache"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Image Cache"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache des images"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vider le cache des images"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulisci Cache Immagini"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulisci Cache Immagini"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tøm Hurtigbuffer for Bilder"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tøm Hurtigbuffer for Bilder"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leeg de afbeeldingencache"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeg de afbeeldingencache"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Image Cache"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Image Cache"
           }
         }
       }
     },
-    "clear_web_cache" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web-Cache löschen"
+    "clear_web_cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web-Cache löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Web Cache"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Web Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpiar caché web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar caché web"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Web Cache"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Web Cache"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider le cache Web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vider le cache Web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Svuota memoria cache Web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svuota memoria cache Web"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Web Cache"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Web Cache"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wis webcache"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wis webcache"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Web Cache"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Web Cache"
           }
         }
       }
     },
-    "Client Certificates" : {
-      "comment" : "A link to manage client certificates.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client-Zertifikate"
+    "Client Certificates": {
+      "comment": "A link to manage client certificates.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client-Zertifikate"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "client_certificates" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client-Zertifikate"
+    "client_certificates": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client-Zertifikate"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificados de cliente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificados de cliente"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificates"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificates"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificats du client"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificats du client"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificati Client"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certificati Client"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klientsertifikater"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klientsertifikater"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cliëntcertificaat"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cliëntcertificaat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Client Certificates"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Certificates"
           }
         }
       }
     },
-    "Clock Size: %lld %%" : {
-      "comment" : "A label describing the percentage of the screen that is used for the clock face.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhrgröße: %lld %%"
+    "Clock Size: %lld %%": {
+      "comment": "A label describing the percentage of the screen that is used for the clock face.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhrgröße: %lld %%"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clock Size: %lld %%"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clock Size: %lld %%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "closed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "geschlossen"
+    "closed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "geschlossen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "closed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "cerrado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cerrado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "closed"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "closed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "fermé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fermé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "chiuso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chiuso"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lukket"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lukket"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "gesloten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gesloten"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "closed"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "closed"
           }
         }
       }
     },
-    "Closed" : {
-      "comment" : "Displayed name for the closed contact state.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geschlossen"
+    "Closed": {
+      "comment": "Displayed name for the closed contact state.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschlossen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suljettu"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suljettu"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fermé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiuso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiuso"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lukket"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lukket"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesloten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesloten"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Color" : {
-      "comment" : "The title of the color picker in the widget.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbe"
+    "Color": {
+      "comment": "The title of the color picker in the widget.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Color"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Color"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couleur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Colore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kleur"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kleur"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Color Item" : {
-      "comment" : "Display name for a color item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farb-Item"
+    "Color Item": {
+      "comment": "Display name for a color item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farb-Item"
           }
         }
       }
     },
-    "Color wheel" : {
-      "comment" : "A description of a color wheel.",
-      "isCommentAutoGenerated" : true
+    "Color wheel": {
+      "comment": "A description of a color wheel.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbrad"
+          }
+        }
+      }
     },
-    "Command failed: %@" : {
-      "comment" : "Error message when sending a command to an item fails. Placeholder is the error description.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehlsfehler: %@"
+    "Command failed: %@": {
+      "comment": "Error message when sending a command to an item fails. Placeholder is the error description.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlsfehler: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command failed: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command failed: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Command failures: %lld" : {
-      "comment" : "A label describing the number of failed commands. The argument is the number of failed commands.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehlsfehler: %lld"
+    "Command failures: %lld": {
+      "comment": "A label describing the number of failed commands. The argument is the number of failed commands.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehlsfehler: %lld"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command failures: %lld"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command failures: %lld"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Command Item %@" : {
-      "comment" : "A label for the command item setting in the application settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehl-Item %@"
+    "Command Item %@": {
+      "comment": "A label for the command item setting in the application settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehl-Item %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command Item %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Item %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "connecting" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
+    "connecting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion en cours"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion en cours"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler til"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kobler til"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
           }
         }
       }
     },
-    "Connecting" : {
-      "comment" : "A label displayed while waiting for a connection to the OpenHAB server.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
+    "Connecting": {
+      "comment": "A label displayed while waiting for a connection to the OpenHAB server.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connetto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connetto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "connecting_discovered" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit entdeckter URL verbinden"
+    "connecting_discovered": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit entdeckter URL verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to discovered URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to discovered URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectando a URL descubierta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando a URL descubierta"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to discovered URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to discovered URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion à l'URL découverte"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion à l'URL découverte"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione all'URL trovato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione all'URL trovato"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler til oppdaget URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kobler til oppdaget URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden naar gevonden URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden naar gevonden URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to discovered URL"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to discovered URL"
           }
         }
       }
     },
-    "connecting_local" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit lokaler URL verbinden"
+    "connecting_local": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit lokaler URL verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to local URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to local URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectando a la URL local"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando a la URL local"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to local URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to local URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion à l'adresse locale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion à l'adresse locale"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione a URL locale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione a URL locale"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler til lokal URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kobler til lokal URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden naar lokale URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden naar lokale URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to local URL"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to local URL"
           }
         }
       }
     },
-    "connecting_remote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit Remote-URL verbinden"
+    "connecting_remote": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit Remote-URL verbinden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to remote URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to remote URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectando a la URL remota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando a la URL remota"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to remote URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to remote URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion à l'URL distante"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion à l'URL distante"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione a URL remoto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione a URL remoto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to remote URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to remote URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbinden met externe URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden met externe URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecting to remote URL"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to remote URL"
           }
         }
       }
     },
-    "Connection successful" : {
-      "comment" : "Message displayed when a network connection test is successful.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindung erfolgreich"
+    "Connection successful": {
+      "comment": "Message displayed when a network connection test is successful.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung erfolgreich"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection successful"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection successful"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Contact Item" : {
-      "comment" : "Display name for a contact item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontakt-Item"
+    "Contact Item": {
+      "comment": "Display name for a contact item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontakt-Item"
           }
         }
       }
     },
-    "Contact State" : {
-      "comment" : "Type display name for the ContactState enum used in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontakt-Status"
+    "Contact State": {
+      "comment": "Type display name for the ContactState enum used in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontakt-Status"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact State"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Cool Daylight" : {
-      "comment" : "A description for a color temperature between 6500 and 8000 Kelvin.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaltes Tageslicht"
+    "Cool Daylight": {
+      "comment": "A description for a color temperature between 6500 and 8000 Kelvin.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaltes Tageslicht"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cool Daylight"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cool Daylight"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Cool White" : {
-      "comment" : "A color temperature range that maps to \"Cool White\".",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaltweiß"
+    "Cool White": {
+      "comment": "A color temperature range that maps to \"Cool White\".",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaltweiß"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cool White"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cool White"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Copy" : {
-      "comment" : "Label for a button that copies the text of a text row to the clipboard.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieren"
+    "Copy": {
+      "comment": "Label for a button that copies the text of a text row to the clipboard.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieer"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "copy_label" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item-Bezeichnung kopieren"
+    "copy_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item-Bezeichnung kopieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy item label"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy item label"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar etiqueta del ítem"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar etiqueta del ítem"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy item label"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy item label"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier le label de l'item"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le label de l'item"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia etichetta Item"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia etichetta Item"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopier Item-etikett"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier Item-etikett"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item label kopiëren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item label kopiëren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy item label"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy item label"
           }
         }
       }
     },
-    "Crash Reporting" : {
-      "comment" : "A toggle that allows the user to enable or disable crash reporting.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Absturzberichterstattung"
+    "Crash Reporting": {
+      "comment": "A toggle that allows the user to enable or disable crash reporting.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Absturzberichterstattung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash Reporting"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash Reporting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "crash_detected" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Absturz festgestellt"
+    "crash_detected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Absturz festgestellt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash detected"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash detected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error detectado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error detectado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash detected"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash detected"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash détecté"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash détecté"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash rilevato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash rilevato"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Krasj oppdaget"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krasj oppdaget"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash gedetecteerd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash gedetecteerd"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash detected"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash detected"
           }
         }
       }
     },
-    "crash_reporting" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Absturzberichterstattung"
+    "crash_reporting": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Absturzberichterstattung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash Reporting"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash Reporting"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informe de errores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informe de errores"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash Reporting"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash Reporting"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rapports d'erreurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapports d'erreurs"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Segnalazioni di crash"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segnalazioni di crash"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Krasjrapportering"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krasjrapportering"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foutenrapportering"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foutenrapportering"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crash Reporting"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash Reporting"
           }
         }
       }
     },
-    "crash_reporting_info" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durch die Aktivierung der Absturzberichterstattung stimmst du zu, dass Informationen zu deinem Gerät und der Nutzung der App erfasst und mit Crashlytics (einem Unternehmen von Google) geteilt werden. Weitere Informationen findest du in unserer Datenschutzerklärung."
+    "crash_reporting_info": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durch die Aktivierung der Absturzberichterstattung stimmst du zu, dass Informationen zu deinem Gerät und der Nutzung der App erfasst und mit Crashlytics (einem Unternehmen von Google) geteilt werden. Weitere Informationen findest du in unserer Datenschutzerklärung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Al activar los informes de fallos, usted acepta que la información de uso y del dispositivo se recopilará y compartirá con Crashlytics (una empresa de Google). Para obtener más información, consulte nuestra política de privacidad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al activar los informes de fallos, usted acepta que la información de uso y del dispositivo se recopilará y compartirá con Crashlytics (una empresa de Google). Para obtener más información, consulte nuestra política de privacidad."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En activant le rapport de d'erreurs, vous acceptez que les informations relatives à l'appareil et à son utilisation soient collectées et partagées avec Crashlytics (une entreprise Google). Pour plus d'informations, consultez notre politique de confidentialité."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En activant le rapport de d'erreurs, vous acceptez que les informations relatives à l'appareil et à son utilisation soient collectées et partagées avec Crashlytics (une entreprise Google). Pour plus d'informations, consultez notre politique de confidentialité."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attivando la segnalazione di crash si accetta che le informazioni sul dispositivo e sull'utilizzo saranno raccolte e condivise con Crashlytics (un'azienda di Google). Per ulteriori informazioni consultare la nostra informativa sulla privacy."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivando la segnalazione di crash si accetta che le informazioni sul dispositivo e sull'utilizzo saranno raccolte e condivise con Crashlytics (un'azienda di Google). Per ulteriori informazioni consultare la nostra informativa sulla privacy."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ved å aktivere krasjrapportering samtykker du i at enhet og bruksinformasjon samles inn og deles med Crashlytics (et Google-firma). For mer informasjon se våre retningslinjer for personvern."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ved å aktivere krasjrapportering samtykker du i at enhet og bruksinformasjon samles inn og deles med Crashlytics (et Google-firma). For mer informasjon se våre retningslinjer for personvern."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Door het activeren van crash-rapportage gaat u akkoord dat apparaat- en gebruiksinformatie zal worden verzameld en gedeeld met Crashlytics (een Google-bedrijf). Voor meer informatie bekijk ons privacybeleid."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Door het activeren van crash-rapportage gaat u akkoord dat apparaat- en gebruiksinformatie zal worden verzameld en gedeeld met Crashlytics (een Google-bedrijf). Voor meer informatie bekijk ons privacybeleid."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "By activating crash reporting you agree that device and usage information will be collected and shared with Crashlytics (a Google company). For further information view our privacy policy."
           }
         }
       }
     },
-    "Create" : {
-      "comment" : "The text on a button that creates a new home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen"
+    "Create": {
+      "comment": "The text on a button that creates a new home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maak aan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak aan"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Date and Time" : {
-      "comment" : "Parameter title for date and time in the Set DateTime Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum und Uhrzeit"
+    "Date and Time": {
+      "comment": "Parameter title for date and time in the Set DateTime Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum und Uhrzeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date and Time"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date and Time"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "DateTime Item" : {
-      "comment" : "Display name for a DateTimeItemEntity.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DateTime-Item"
+    "DateTime Item": {
+      "comment": "Display name for a DateTimeItemEntity.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DateTime-Item"
           }
         }
       }
     },
-    "Daylight" : {
-      "comment" : "A descriptive label for a color temperature range.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tageslicht"
+    "Daylight": {
+      "comment": "A descriptive label for a color temperature range.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tageslicht"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Daylight"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daylight"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "debug" : {
-      "comment" : "Section header text in the Debug Settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+    "debug": {
+      "comment": "Section header text in the Debug Settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         }
       }
     },
-    "Debug" : {
-      "comment" : "Tab label for the Debug tab in the watch app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+    "Debug": {
+      "comment": "Tab label for the Debug tab in the watch app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debug"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         }
       }
     },
-    "Decrease %@" : {
-      "comment" : "Accessibility labels and hints for the increase and decrease buttons.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ verringern"
+    "Decrease %@": {
+      "comment": "Accessibility labels and hints for the increase and decrease buttons.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ verringern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Decrease %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Default Path" : {
-      "comment" : "A label displayed above the text field for the default path of the main UI.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standardpfad"
+    "Default Path": {
+      "comment": "A label displayed above the text field for the default path of the main UI.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardpfad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default Path"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Path"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Delete" : {
-      "comment" : "The text on the \"Delete\" button in the alert that appears when you long-press a home in the list.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+    "Delete": {
+      "comment": "The text on the \"Delete\" button in the alert that appears when you long-press a home in the list.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Delete home '%@'?" : {
-      "comment" : "An alert that appears when the user swipes to delete a home. The argument is the name of the home that is about to be deleted.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuhause „%@“ löschen?"
+    "Delete home '%@'?": {
+      "comment": "An alert that appears when the user swipes to delete a home. The argument is the name of the home that is about to be deleted.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuhause „%@“ löschen?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete home '%@'?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete home '%@'?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Demo Mode" : {
-      "comment" : "A toggle that enables or disables demo mode.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demomodus"
+    "Demo Mode": {
+      "comment": "A toggle that enables or disables demo mode.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demomodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demo Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demo Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "demo_mode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demomodus"
+    "demo_mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demomodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demo mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demo mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de demostración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de demostración"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demo mode"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demo mode"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode démo"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode démo"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità demo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità demo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demomodus"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demomodus"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demomodus"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demomodus"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demo mode"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demo mode"
           }
         }
       }
     },
-    "Deny" : {
-      "comment" : "A button label that denies access to a website.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ablehnen"
+    "Deny": {
+      "comment": "A button label that denies access to a website.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablehnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deny"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deny"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Denegar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denegar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refuser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refuser"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non consentire"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non consentire"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiger"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiger"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Dim Level: %lld %%" : {
-      "comment" : "A label displaying the current dim level of the screen saver. The value is shown as a percentage.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmwert: %lld %%"
+    "Dim Level: %lld %%": {
+      "comment": "A label displaying the current dim level of the screen saver. The value is shown as a percentage.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimmwert: %lld %%"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dim Level: %lld %%"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dim Level: %lld %%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Dimmer/Roller Item" : {
-      "comment" : "Display name for a dimmer or roller item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmer/Roller-Item"
+    "Dimmer/Roller Item": {
+      "comment": "Display name for a dimmer or roller item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimmer/Roller-Item"
           }
         }
       }
     },
-    "Disable Idle Timeout" : {
-      "comment" : "A toggle that allows the user to disable the idle timeout feature.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruhezustand-Timeout deaktivieren"
+    "Disable Idle Timeout": {
+      "comment": "A toggle that allows the user to disable the idle timeout feature.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruhezustand-Timeout deaktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Idle Timeout"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Idle Timeout"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "disable_idle_timeout" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirm-Timeout deaktivieren"
+    "disable_idle_timeout": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirm-Timeout deaktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Idle Timeout"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Idle Timeout"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar tiempo de espera de inactividad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar tiempo de espera de inactividad"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Idle Timeout"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Idle Timeout"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactiver le délai d'inactivité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactiver le délai d'inactivité"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disabilita Timeout Inattività"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabilita Timeout Inattività"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deaktiver Tidsavbrudd for Inaktivitet"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiver Tidsavbrudd for Inaktivitet"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schermtimeout uitschakelen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schermtimeout uitschakelen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Idle Timeout"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Idle Timeout"
           }
         }
       }
     },
-    "discovered_servers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gefundene Server"
+    "discovered_servers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefundene Server"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovered Servers"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Servers"
           }
         }
       }
     },
-    "discovering_oh" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OpenHAB entdecken"
+    "discovering_oh": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenHAB entdecken"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovering openHAB"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovering openHAB"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descubriendo openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descubriendo openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovering openHAB"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovering openHAB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Découvrir openHAB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Découvrir openHAB"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cercando openHAB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cercando openHAB"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oppdager openHAB"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppdager openHAB"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bezig met zoeken naar openHAB"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bezig met zoeken naar openHAB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovering openHAB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovering openHAB"
           }
         }
       }
     },
-    "discovering_servers" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Server werden entdeckt …"
+    "discovering_servers": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Server werden entdeckt …"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discovering openHAB servers…"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovering openHAB servers…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherche des serveurs openHAB…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche des serveurs openHAB…"
           }
         }
       }
     },
-    "dismiss" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwerfen"
+    "dismiss": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwerfen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignora"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvis"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvis"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afwijzen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afwijzen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dismiss"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
           }
         }
       }
     },
-    "Done" : {
-      "comment" : "A button that dismisses a sheet.",
-      "isCommentAutoGenerated" : true
+    "Done": {
+      "comment": "A button that dismisses a sheet.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        }
+      }
     },
-    "Drag to change hue and saturation" : {
-      "comment" : "A hint that describes how to interact with a color wheel.",
-      "isCommentAutoGenerated" : true
+    "Drag to change hue and saturation": {
+      "comment": "A hint that describes how to interact with a color wheel.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehen, um Farbton und Sättigung zu ändern"
+          }
+        }
+      }
     },
-    "empty" : {
-      "comment" : "local or remote URL: empty",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "leer"
+    "empty": {
+      "comment": "local or remote URL: empty",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "leer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "empty"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "empty"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vacío"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vacío"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vide"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vide"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vuoto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vuoto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "leeg"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "leeg"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "empty_sitemap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB lieferte eine leere Sitemap-Liste"
+    "empty_sitemap": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB lieferte eine leere Sitemap-Liste"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB returned empty sitemap list"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB returned empty sitemap list"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lista de mapas web de openHAB vacía"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lista de mapas web de openHAB vacía"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB returned empty sitemap list"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB returned empty sitemap list"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB a renvoyé une liste vide de sitemaps"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB a renvoyé une liste vide de sitemaps"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB ha ritornato una lista vuota di sitemap"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB ha ritornato una lista vuota di sitemap"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB returnerte en tom Sitemap-liste"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB returnerte en tom Sitemap-liste"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB heeft een lege Sitemap geladen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB heeft een lege Sitemap geladen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB returned empty sitemap list"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB returned empty sitemap list"
           }
         }
       }
     },
-    "empty.action" : {
-      "comment" : "empty action",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leere Aktion"
+    "empty.action": {
+      "comment": "empty action",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leere Aktion"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty action"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty action"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "empty.itemname" : {
-      "comment" : "empty item name",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leerer Item-Name"
+    "empty.itemname": {
+      "comment": "empty item name",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leerer Item-Name"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty Item name"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty Item name"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "empty.itemorhome" : {
-      "comment" : "Empty Item or empty Home",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leeres Item oder leeres Zuhause"
+    "empty.itemorhome": {
+      "comment": "Empty Item or empty Home",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeres Item oder leeres Zuhause"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty Item or empty Home"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty Item or empty Home"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "empty.value" : {
-      "comment" : "Empty, with value name behind",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leerer Wert von"
+    "empty.value": {
+      "comment": "Empty, with value name behind",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leerer Wert von"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaciar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vide"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vide"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leeg"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeg"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enable Dimming" : {
-      "comment" : "A toggle that enables or disables automatic brightness dimming.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmen aktivieren"
+    "Enable Dimming": {
+      "comment": "A toggle that enables or disables automatic brightness dimming.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimmen aktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Dimming"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Dimming"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enable Screen Saver" : {
-      "comment" : "A toggle switch that enables or disables the screen saver feature.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirmschoner aktivieren"
+    "Enable Screen Saver": {
+      "comment": "A toggle switch that enables or disables the screen saver feature.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmschoner aktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Screen Saver"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Screen Saver"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter a name for the new home" : {
-      "comment" : "A prompt that appears when creating a new home, asking for a name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name für das neue Zuhause eingeben"
+    "Enter a name for the new home": {
+      "comment": "A prompt that appears when creating a new home, asking for a name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name für das neue Zuhause eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter a name for the new home"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a name for the new home"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter a new name for the home '%@'" : {
-      "comment" : "Alerts for renaming or deleting a home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuer Name für das Zuhause „%@“ eingeben"
+    "Enter a new name for the home '%@'": {
+      "comment": "Alerts for renaming or deleting a home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Name für das Zuhause „%@“ eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter a new name for the home '%@'"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new name for the home '%@'"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter new value" : {
-      "comment" : "The title of an alert that appears when the user taps the \"Add Time\" button in the example.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuen Wert eingeben"
+    "Enter new value": {
+      "comment": "The title of an alert that appears when the user taps the \"Add Time\" button in the example.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Wert eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter new value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter new value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter password for server" : {
-      "comment" : "A prompt instructing the user to enter a password for the server. Try to keep shortish.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server-Passwort eingeben"
+    "Enter password for server": {
+      "comment": "A prompt instructing the user to enter a password for the server. Try to keep shortish.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server-Passwort eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter password for server"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter password for server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduce la contraseña del servidor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce la contraseña del servidor"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anna palvelimen salasana"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anna palvelimen salasana"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrez le mot de passe du serveur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrez le mot de passe du serveur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inserisci la password del server"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci la password del server"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriv inn passord for server"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn passord for server"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voer wachtwoord voor server in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voer wachtwoord voor server in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите пароль для сервера"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите пароль для сервера"
           }
         }
       }
     },
-    "Enter text" : {
-      "comment" : "A placeholder text for a text input field.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text eingeben"
+    "Enter text": {
+      "comment": "A placeholder text for a text input field.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter text"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter text"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter URL of remote server" : {
-      "comment" : "A message displayed when the URL field in the connection settings is empty.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL des entfernten Servers eingeben"
+    "Enter URL of remote server": {
+      "comment": "A message displayed when the URL field in the connection settings is empty.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL des entfernten Servers eingeben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter URL of remote server"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter URL of remote server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Enter username for server, if required" : {
-      "comment" : "A message displayed below the username field, instructing the user to enter a username if one is required by the server. Try to keep shortish.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server-Benutzername eingeben, falls erforderlich"
+    "Enter username for server, if required": {
+      "comment": "A message displayed below the username field, instructing the user to enter a username if one is required by the server. Try to keep shortish.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server-Benutzername eingeben, falls erforderlich"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter username for server, if required"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter username for server, if required"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduce el nombre de usuario del servidor, si es necesario"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce el nombre de usuario del servidor, si es necesario"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anna palvelimen käyttäjänimi tarvittaessa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anna palvelimen käyttäjänimi tarvittaessa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrez le nom d'utilisateur du serveur, si requis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrez le nom d'utilisateur du serveur, si requis"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inserisci il nome utente del server, se richiesto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci il nome utente del server, se richiesto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriv inn brukernavn for server, om nødvendig"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn brukernavn for server, om nødvendig"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voer gebruikersnaam voor server in, indien vereist"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voer gebruikersnaam voor server in, indien vereist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите имя пользователя для сервера, если требуется"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите имя пользователя для сервера, если требуется"
           }
         }
       }
     },
-    "Error" : {
-      "comment" : "The title of an alert that appears when an error occurs.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler"
+    "Error": {
+      "comment": "The title of an alert that appears when an error occurs.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fout"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fout"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Fade Duration: %@ s" : {
-      "comment" : "A slider that lets the user adjust the duration of the fade-in animation when the screen saver is activated. The argument is the string “%.1f”.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fade-Dauer: %@ s"
+    "Fade Duration: %@ s": {
+      "comment": "A slider that lets the user adjust the duration of the fade-in animation when the screen saver is activated. The argument is the string “%.1f”.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fade-Dauer: %@ s"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fade Duration: %@ s"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fade Duration: %@ s"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Fast Forward" : {
-      "comment" : "Display name for the fast forward action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schneller Vorlauf"
+    "Fast Forward": {
+      "comment": "Display name for the fast forward action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schneller Vorlauf"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fast Forward"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast Forward"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Font" : {
-      "comment" : "A label for the font picker in the screen saver settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schrift"
+    "Font": {
+      "comment": "A label for the font picker in the screen saver settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schrift"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de letra"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de letra"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Police"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lettertype"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettertype"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Font Size" : {
-      "comment" : "A section header that indicates the font size settings.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schriftgröße"
+    "Font Size": {
+      "comment": "A section header that indicates the font size settings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schriftgröße"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Font Size"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Size"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamaño de letra"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño de letra"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taille de la police"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille de la police"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimensioni font"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensioni font"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lettergrootte"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettergrootte"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Foo" : {
-      "comment" : "A label for a text field where the user can input \"Foo\".",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+    "Foo": {
+      "comment": "A label for a text field where the user can input \"Foo\".",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foo"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foo"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "For Shortcuts to work across multiple devices, each home must have the same name on every device." : {
-      "comment" : "Instruction shown in Manage Homes explaining that home names must match across devices for Shortcuts to work.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Damit Kurzbefehle geräteübergreifend funktionieren, muss jedes Zuhause auf jedem Gerät denselben Namen haben."
+    "For Shortcuts to work across multiple devices, each home must have the same name on every device.": {
+      "comment": "Instruction shown in Manage Homes explaining that home names must match across devices for Shortcuts to work.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Damit Kurzbefehle geräteübergreifend funktionieren, muss jedes Zuhause auf jedem Gerät denselben Namen haben."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For Shortcuts to work across multiple devices, each home must have the same name on every device."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For Shortcuts to work across multiple devices, each home must have the same name on every device."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para que los atajos funcionen en varios dispositivos, cada hogar debe tener el mismo nombre en cada dispositivo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para que los atajos funcionen en varios dispositivos, cada hogar debe tener el mismo nombre en cada dispositivo."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jotta pikakuvakkeet toimisivat useilla laitteilla, jokaisella kodilla täytyy olla sama nimi joka laitteella."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jotta pikakuvakkeet toimisivat useilla laitteilla, jokaisella kodilla täytyy olla sama nimi joka laitteella."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour que les raccourcis fonctionnent sur plusieurs appareils, chaque maison doit avoir le même nom sur chaque appareil."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour que les raccourcis fonctionnent sur plusieurs appareils, chaque maison doit avoir le même nom sur chaque appareil."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per far funzionare i comandi rapidi su più dispositivi, ogni casa deve avere lo stesso nome su ogni dispositivo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per far funzionare i comandi rapidi su più dispositivi, ogni casa deve avere lo stesso nome su ogni dispositivo."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For at snarveier skal fungere på tvers av enheter, må hvert hjem ha samme navn på hver enhet."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For at snarveier skal fungere på tvers av enheter, må hvert hjem ha samme navn på hver enhet."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Om snelkoppelingen op meerdere apparaten te laten werken, moet elk thuis dezelfde naam hebben op elk apparaat."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Om snelkoppelingen op meerdere apparaten te laten werken, moet elk thuis dezelfde naam hebben op elk apparaat."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чтобы быстрые команды работали на нескольких устройствах, у каждого дома должно быть одинаковое название на каждом устройстве."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтобы быстрые команды работали на нескольких устройствах, у каждого дома должно быть одинаковое название на каждом устройстве."
           }
         }
       }
     },
-    "Get ${itemEntity} State" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "${itemEntity}-Status erhalten"
+    "Get ${itemEntity} State": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${itemEntity}-Status erhalten"
           }
         }
       }
     },
-    "Get Item State" : {
-      "comment" : "Title of the Get Item State app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status eines Items erhalten"
+    "Get Item State": {
+      "comment": "Title of the Get Item State app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status eines Items erhalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get Item State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Item State"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener estado del ítem"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener estado del ítem"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Récupérer l'état de l'item"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récupérer l'état de l'item"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leggi lo stato dell'Item"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggi lo stato dell'Item"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Få Item-tilstand"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Få Item-tilstand"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haal item state op"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haal item state op"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "habpanel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+    "habpanel": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HABPanel"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HABPanel"
           }
         }
       }
     },
-    "Hide Status Bar" : {
-      "comment" : "A toggle that allows the user to hide the status bar in the app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statusleiste ausblenden"
+    "Hide Status Bar": {
+      "comment": "A toggle that allows the user to hide the status bar in the app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statusleiste ausblenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide Status Bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Status Bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Home" : {
-      "comment" : "The name of the \"Home\" menu item.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuhause"
+    "Home": {
+      "comment": "The name of the \"Home\" menu item.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuhause"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Home"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Casa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domicile"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domicile"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Casa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casa"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thuis"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thuis"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Hue: %.2f" : {
-      "comment" : "A label displaying the hue value of the currently selected color. The value is formatted to two decimal places.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbton: %.2f"
+    "Hue: %.2f": {
+      "comment": "A label displaying the hue value of the currently selected color. The value is formatted to two decimal places.",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbton: %.2f"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hue: %.2f"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hue: %.2f"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Icon Type" : {
-      "comment" : "A label describing the option to change the icon type.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon-Typ"
+    "Icon Type": {
+      "comment": "A label describing the option to change the icon type.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon-Typ"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon Type"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon Type"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "icon_type" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon-Typ"
+    "icon_type": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon-Typ"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon Type"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon Type"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de icono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de icono"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon Type"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon Type"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type d'icône"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type d'icône"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo di icona"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo di icona"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ikontype"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikontype"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icoontype"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icoontype"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icon Type"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon Type"
           }
         }
       }
     },
-    "Idle Interval: %lld s" : {
-      "comment" : "A stepper that allows the user to set the number of seconds after which the screen saver will activate if no movement is detected. The value shown is the current idle interval in seconds.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruhezustand-Intervall: %lld s"
+    "Idle Interval: %lld s": {
+      "comment": "A stepper that allows the user to set the number of seconds after which the screen saver will activate if no movement is detected. The value shown is the current idle interval in seconds.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruhezustand-Intervall: %lld s"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idle Interval: %lld s"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idle Interval: %lld s"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Ignore SSL certificates" : {
-      "comment" : "A toggle that lets the user ignore SSL certificate warnings.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-Zertifikate ignorieren"
+    "Ignore SSL certificates": {
+      "comment": "A toggle that lets the user ignore SSL certificate warnings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-Zertifikate ignorieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore SSL certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore SSL certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "ignore_ssl_certificates" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-Zertifikate ignorieren"
+    "ignore_ssl_certificates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-Zertifikate ignorieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore SSL Certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore SSL Certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar certificados SSL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar certificados SSL"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore SSL Certificates"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore SSL Certificates"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer les certificats SSL"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer les certificats SSL"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignora certificati SSL"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignora certificati SSL"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer SSL-sertifikater"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer SSL-sertifikater"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Negeer SSL-certificaten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Negeer SSL-certificaten"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Игнорировать SSL-сертификаты"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорировать SSL-сертификаты"
           }
         }
       }
     },
-    "Image Cache" : {
-      "comment" : "The title of an alert that shows the result of checking and clearing the image cache.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder-Cache"
+    "Image Cache": {
+      "comment": "The title of an alert that shows the result of checking and clearing the image cache.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilder-Cache"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image Cache"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image Cache"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Import" : {
-      "comment" : "\"Import\" button title.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importieren"
+    "Import": {
+      "comment": "\"Import\" button title.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importeer"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importeer"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Increase %@" : {
-      "comment" : "A button that increases the value of a setpoint. The argument is the name of the setpoint.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ erhöhen"
+    "Increase %@": {
+      "comment": "A button that increases the value of a setpoint. The argument is the name of the setpoint.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ erhöhen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Increase %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+    "info": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Información"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Infos"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Infos"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informasjon"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informasjon"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Info"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
           }
         }
       }
     },
-    "Invalid value %lld for %@ (0-100)" : {
-      "comment" : "Error message when a dimmer or roller shutter value is out of range. First placeholder is the invalid value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiger Wert %lld für %@ (0-100)"
+    "Invalid value %lld for %@ (0-100)": {
+      "comment": "Error message when a dimmer or roller shutter value is out of range. First placeholder is the invalid value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Wert %lld für %@ (0-100)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid value %lld for %@ (0-100)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid value %lld for %@ (0-100)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valor no válido %lld para %@ (0-100)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valor no válido %lld para %@ (0-100)"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valeur %lld invalide pour %@ (0-100)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valeur %lld invalide pour %@ (0-100)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valore non valido %lld per %@ (0-100)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valore non valido %lld per %@ (0-100)"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ugyldig verdi %lld for %@ (0-100)"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugyldig verdi %lld for %@ (0-100)"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ongeldige waarde %lld voor %@ (0-100)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongeldige waarde %lld voor %@ (0-100)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Invalid value: %@ for %@ must be HSB (0-360,0-100,0-100)" : {
-      "comment" : "Error message when a color value is not valid HSB. First placeholder is the invalid value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiger Wert: %@ für %@ muss HSB sein (0-360,0-100,0-100)"
+    "Invalid value: %@ for %@ must be HSB (0-360,0-100,0-100)": {
+      "comment": "Error message when a color value is not valid HSB. First placeholder is the invalid value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Wert: %@ für %@ muss HSB sein (0-360,0-100,0-100)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid value: %@ for %@ must be HSB (0-360,0-100,0-100)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid value: %@ for %@ must be HSB (0-360,0-100,0-100)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valor no válido: %@ para %@ debe ser HSB (0-360,0-100,0-100)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valor no válido: %@ para %@ debe ser HSB (0-360,0-100,0-100)"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valeur invalide : %@ pour %@ doit être HSB (0-360,0-100,0-100)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valeur invalide : %@ pour %@ doit être HSB (0-360,0-100,0-100)"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valore non valido: %@ per %@ deve essere HSB (0-360,0-100,0-100)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valore non valido: %@ per %@ deve essere HSB (0-360,0-100,0-100)"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ugyldig verdi: %@ for %@ må være HSB (0-360,0-100,0-100)"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugyldig verdi: %@ for %@ må være HSB (0-360,0-100,0-100)"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ongeldige waarde: %@ voor %@ moet HSB zijn (0-360,0-100,0-100)"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongeldige waarde: %@ voor %@ moet HSB zijn (0-360,0-100,0-100)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "invalid_connection_configuration" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültige Verbindungskonfiguration."
+    "invalid_connection_configuration": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Verbindungskonfiguration."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid connection configuration."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid connection configuration."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración de conexión no válida."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de conexión no válida."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Virheellinen yhteysasetukset."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virheellinen yhteysasetukset."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration de connexion invalide."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration de connexion invalide."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurazione della connessione non valida."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione della connessione non valida."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ugyldig tilkoblingskonfigurasjon."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugyldig tilkoblingskonfigurasjon."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ongeldige verbindingsconfiguratie."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongeldige verbindingsconfiguratie."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Недопустимая конфигурация подключения."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недопустимая конфигурация подключения."
           }
         }
       }
     },
-    "Item" : {
-      "comment" : "Parameter title for an openHAB item in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+    "Item": {
+      "comment": "Parameter title for an openHAB item in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ítem"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ítem"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Item '%@' is not in home '%@'" : {
-      "comment" : "Error message when the selected item does not belong to the selected home. First placeholder is the item name, second is the home name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Item „%@“ befindet sich nicht im Zuhause „%@“"
+    "Item '%@' is not in home '%@'": {
+      "comment": "Error message when the selected item does not belong to the selected home. First placeholder is the item name, second is the home name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Item „%@“ befindet sich nicht im Zuhause „%@“"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Item '%@' is not in home '%@'"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Item '%@' is not in home '%@'"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Item '%@' not found" : {
-      "comment" : "Error message when an item is not found. The argument is the name of the item.",
-      "isCommentAutoGenerated" : true
+    "Item '%@' not found": {
+      "comment": "Error message when an item is not found. The argument is the name of the item.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Element '%@' nicht gefunden"
+          }
+        }
+      }
     },
-    "Items" : {
-      "comment" : "The title of the view that lists available items.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Items"
+    "Items": {
+      "comment": "The title of the view that lists available items.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Items"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Items"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Items"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ítems"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ítems"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Éléments"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Éléments"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elementi"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onderdelen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onderdelen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Label" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
+    "Label": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etiqueta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Étiquette"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étiquette"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etichetta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etichetta"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Latitude" : {
-      "comment" : "Parameter title for latitude in the Set Location Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breitengrad"
+    "Latitude": {
+      "comment": "Parameter title for latitude in the Set Location Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breitengrad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latitude"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latitude"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Latitude must be between -90 and 90" : {
-      "comment" : "Error message when a latitude value is out of the valid range.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breitengrad muss zwischen -90 and 90 sein"
+    "Latitude must be between -90 and 90": {
+      "comment": "Error message when a latitude value is out of the valid range.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breitengrad muss zwischen -90 and 90 sein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latitude must be between -90 and 90"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latitude must be between -90 and 90"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "legal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechtliches"
+    "legal": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechtliches"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Légal"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Légal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legale"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Juridisk"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Juridisk"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Juridisch"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Juridisch"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal"
           }
         }
       }
     },
-    "Legal" : {
-      "comment" : "A link to the app's legal information.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechtliches"
+    "Legal": {
+      "comment": "A link to the app's legal information.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechtliches"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aviso legal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso legal"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mentions légales"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mentions légales"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note legali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note legali"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Juridische informatie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Juridische informatie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Loading Items…" : {
-      "comment" : "A message displayed while waiting to load items.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Items werden geladen …"
+    "Loading Items…": {
+      "comment": "A message displayed while waiting to load items.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Items werden geladen …"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading Items…"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Items…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Loading sitemap…" : {
-      "comment" : "A placeholder text indicating that the sitemap is being loaded.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap wird geladen …"
+    "Loading sitemap…": {
+      "comment": "A placeholder text indicating that the sitemap is being loaded.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap wird geladen …"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading sitemap…"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading sitemap…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Loading…" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird geladen …"
+    "Loading…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen …"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading…"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando…"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladataan …"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladataan …"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chargement…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caricamento …"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento …"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laster …"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laster …"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laden…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laden…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузка …"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка …"
           }
         }
       }
     },
-    "Local Network access may be required." : {
-      "comment" : "A warning message that appears when the user's local network access is required to connect to a server.",
-      "isCommentAutoGenerated" : true
+    "Local Network access may be required.": {
+      "comment": "A warning message that appears when the user's local network access is required to connect to a server.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möglicherweise ist der Zugriff auf das lokale Netzwerk erforderlich."
+          }
+        }
+      }
     },
-    "Local Network Access Required" : {
-      "comment" : "A title for an alert that warns the user that local network access is required to connect to a local openHAB server.",
-      "isCommentAutoGenerated" : true
+    "Local Network Access Required": {
+      "comment": "A title for an alert that warns the user that local network access is required to connect to a local openHAB server.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff auf lokales Netzwerk erforderlich"
+          }
+        }
+      }
     },
-    "Local server" : {
-      "comment" : "Title of the section in the connection settings view that pertains to the local OpenHAB server.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokaler Server"
+    "Local server": {
+      "comment": "Title of the section in the connection settings view that pertains to the local OpenHAB server.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Server"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local server"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "local_url" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale URL"
+    "local_url": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL local"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL local"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL locale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL locale"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL locale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL locale"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokal URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Локальный URL-адрес"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Локальный URL-адрес"
           }
         }
       }
     },
-    "Location" : {
-      "comment" : "Name of a marker displayed on a map view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standort"
+    "Location": {
+      "comment": "Name of a marker displayed on a map view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standort"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Location"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Location"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicación"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Posizione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posizione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locatie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locatie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Location Item" : {
-      "comment" : "Display name for a location item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standort-Item"
+    "Location Item": {
+      "comment": "Display name for a location item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standort-Item"
           }
         }
       }
     },
-    "Logs" : {
-      "comment" : "A link in the debug settings that navigates to the logs viewer.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protokolle"
+    "Logs": {
+      "comment": "A link in the debug settings that navigates to the logs viewer.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logs"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Historiques"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historiques"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logbestanden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logbestanden"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Longitude" : {
-      "comment" : "Parameter title for longitude in the Set Location Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Längengrad"
+    "Longitude": {
+      "comment": "Parameter title for longitude in the Set Location Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Längengrad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Longitude"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Longitude"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Longitude must be between -180 and 180" : {
-      "comment" : "Error message when a longitude value is out of the valid range.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Längengrad muss zwischen -180 and 180 sein"
+    "Longitude must be between -180 and 180": {
+      "comment": "Error message when a longitude value is out of the valid range.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Längengrad muss zwischen -180 and 180 sein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Longitude must be between -180 and 180"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Longitude must be between -180 and 180"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Lowers by %@" : {
-      "comment" : "A hint that describes how much the value can be decreased by.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um %@ senken"
+    "Lowers by %@": {
+      "comment": "A hint that describes how much the value can be decreased by.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um %@ senken"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lowers by %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lowers by %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Main" : {
-      "comment" : "The header text for the \"Main\" section in the drawer view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main"
+    "Main": {
+      "comment": "The header text for the \"Main\" section in the drawer view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Principal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Principal"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Principal"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Principal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Principale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Principale"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoofd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoofd"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "mainui_settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main UI-Einstellungen"
+    "mainui_settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main UI-Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main UI Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main UI Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes de la interfaz de usuario principal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de la interfaz de usuario principal"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main UI Settings"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main UI Settings"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres Main UI"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres Main UI"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni Main UI"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni Main UI"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstillinger for Main UI"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger for Main UI"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main UI Instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main UI Instellingen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Main UI Settings"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main UI Settings"
           }
         }
       }
     },
-    "Manage Homes" : {
-      "comment" : "The title of a view that allows users to manage their homes.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuhause verwalten"
+    "Manage Homes": {
+      "comment": "The title of a view that allows users to manage their homes.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuhause verwalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manage Homes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Homes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "message_not_decoded" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nachricht konnte nicht dekodiert werden"
+    "message_not_decoded": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nachricht konnte nicht dekodiert werden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message could not be decoded"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message could not be decoded"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se ha podido decodificar el mensaje"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se ha podido decodificar el mensaje"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message could not be decoded"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message could not be decoded"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le message n'a pas pu être décodé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le message n'a pas pu être décodé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il messaggio non può essere decodificato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il messaggio non può essere decodificato"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Melding kunne ikke dekodes"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melding kunne ikke dekodes"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bericht kon niet gedecodeerd worden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bericht kon niet gedecodeerd worden"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message could not be decoded"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message could not be decoded"
           }
         }
       }
     },
-    "Movement Interval: %lld s" : {
-      "comment" : "A stepper that allows the user to set the interval in seconds between when the screen saver will activate and when it will deactivate after a user is detected moving.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bewegungsintervall: %lld s"
+    "Movement Interval: %lld s": {
+      "comment": "A stepper that allows the user to set the interval in seconds between when the screen saver will activate and when it will deactivate after a user is detected moving.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bewegungsintervall: %lld s"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Movement Interval: %lld s"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movement Interval: %lld s"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name"
+    "Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Naam"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naam"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Name for new home" : {
-      "comment" : "A placeholder label for a text field in an alert used to enter the name of a new home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name für neues Zuhause"
+    "Name for new home": {
+      "comment": "A placeholder label for a text field in an alert used to enter the name of a new home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name für neues Zuhause"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name for new home"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name for new home"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "network_not_available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerk ist nicht verfügbar."
+    "network_not_available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk ist nicht verfügbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network is not available."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network is not available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Red no disponible."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red no disponible."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network is not available."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network is not available."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune connexion réseau disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune connexion réseau disponible."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rete non disponibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rete non disponibile."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettverk er ikke tilgjengelig."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettverk er ikke tilgjengelig."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netwerk is niet beschikbaar."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netwerk is niet beschikbaar."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network is not available."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network is not available."
           }
         }
       }
     },
-    "New name" : {
-      "comment" : "A label for a text field where the user can enter a new name for a home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuer Name"
+    "New name": {
+      "comment": "A label for a text field where the user can enter a new name for a home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Name"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New name"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New name"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Next" : {
-      "comment" : "Display name for the next action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nächstes"
+    "Next": {
+      "comment": "Display name for the next action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächstes"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "No accepted server certificates" : {
-      "comment" : "A message displayed when there are no accepted server certificates.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine akzeptierten Server-Zertifikate"
+    "No accepted server certificates": {
+      "comment": "A message displayed when there are no accepted server certificates.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine akzeptierten Server-Zertifikate"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No accepted server certificates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No accepted server certificates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "No Image URL" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Bild-URL"
+    "No Image URL": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Bild-URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Image URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Image URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "No sitemaps available" : {
-      "comment" : "A message indicating that there are no sitemaps available to choose from in the \"Sitemap For Apple Watch\" picker.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Sitemaps verfügbar"
+    "No sitemaps available": {
+      "comment": "A message indicating that there are no sitemaps available to choose from in the \"Sitemap For Apple Watch\" picker.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Sitemaps verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No sitemaps available"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No sitemaps available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "No Video URL" : {
-      "comment" : "A message displayed when a video URL is not provided for a video row.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Video-URL"
+    "No Video URL": {
+      "comment": "A message displayed when a video URL is not provided for a video row.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Video-URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Video URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Video URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "No widgets available." : {
-      "comment" : "A message displayed when a user has no widgets configured.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Widgets verfügbar."
+    "No widgets available.": {
+      "comment": "A message displayed when a user has no widgets configured.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Widgets verfügbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No widgets available."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No widgets available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "no_active_connection" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine aktive Verbindung vorhanden. Bitte Einstellungen prüfen"
+    "no_active_connection": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine aktive Verbindung vorhanden. Bitte Einstellungen prüfen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No active connection available. Please check your settings."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active connection available. Please check your settings."
           }
         }
       }
     },
-    "no_connection_will_reconnect" : {
-      "comment" : "Title of a popup message displayed when the OpenHAB client is not connected to the server and will automatically try to reconnect.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Verbindung, erneuter Verbindungsversuch"
+    "no_connection_will_reconnect": {
+      "comment": "Title of a popup message displayed when the OpenHAB client is not connected to the server and will automatically try to reconnect.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Verbindung, erneuter Verbindungsversuch"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "no_connection_will_reconnect"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no_connection_will_reconnect"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "no_servers_found" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+    "no_servers_found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun serveur trouvé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun serveur trouvé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No servers found"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers found"
           }
         }
       }
     },
-    "notification" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigung"
+    "notification": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notification"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificación"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notification"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notification"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifica"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varsel"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsel"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificatie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificatie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notification"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification"
           }
         }
       }
     },
-    "notifications" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen"
+    "notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifiche"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varsler"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsler"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaties"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaties"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         }
       }
     },
-    "Notifications" : {
-      "comment" : "The title of the notifications view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen"
+    "Notifications": {
+      "comment": "The title of the notifications view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifiche"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifiche"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaties"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaties"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Number Item" : {
-      "comment" : "Display name for a number item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numerisches-Item"
+    "Number Item": {
+      "comment": "Display name for a number item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numerisches-Item"
           }
         }
       }
     },
-    "off" : {
-      "comment" : "Label for the \"off\" state of a contact.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "aus"
+    "off": {
+      "comment": "Label for the \"off\" state of a contact.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "off"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "off"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "desactivada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desactivada"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "désactivé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "désactivé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non attivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "non attivo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "uit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uit"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Off" : {
-      "comment" : "The text \"Off\" displayed in the accessibility value of the toggle.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aus"
+    "Off": {
+      "comment": "The text \"Off\" displayed in the accessibility value of the toggle.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Off"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uit"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Offline" : {
-      "comment" : "A label indicating that the device is currently offline.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline"
+    "Offline": {
+      "comment": "A label indicating that the device is currently offline.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin conexión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin conexión"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déconnecté"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecté"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non in linea"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non in linea"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "oh_secret" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB-Secret"
+    "oh_secret": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB-Secret"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Secret"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Secret"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "código secreto de openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "código secreto de openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Secret"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Secret"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phrase secrète openHAB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phrase secrète openHAB"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Secret"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Secret"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Hemmelighet"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Hemmelighet"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB geheim"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB geheim"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Secret"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Secret"
           }
         }
       }
     },
-    "oh_uuid" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB-UUID"
+    "oh_uuid": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB-UUID"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB UUID"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB UUID"
           }
         }
       }
     },
-    "oh_version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB-Version"
+    "oh_version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB-Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Version"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Version"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Version"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Version"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione openHAB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione openHAB"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB versjon"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB versjon"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Versie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Versie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Version"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Version"
           }
         }
       }
     },
-    "OK" : {
-      "comment" : "The text for an OK button.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "OK": {
+      "comment": "The text for an OK button.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "on" : {
-      "comment" : "\"on\" in capitalized form.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "an"
+    "on": {
+      "comment": "\"on\" in capitalized form.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "an"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "on"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "on"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "activada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "activada"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "activé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "activé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "attivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "attivo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "aan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aan"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "On" : {
-      "comment" : "A label indicating that a switch is on.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An"
+    "On": {
+      "comment": "A label indicating that a switch is on.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "On"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attivo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aan"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aan"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Once" : {
-      "comment" : "Button to allow the app to connect to the server only once, even if the certificate is invalid.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einmal"
+    "Once": {
+      "comment": "Button to allow the app to connect to the server only once, even if the certificate is invalid.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einmal"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Once"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "open" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "offen"
+    "open": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "offen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "open"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "abierto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abierto"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "open"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ouvert"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ouvert"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "aperto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aperto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "åpen"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "åpen"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "open"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "open"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open"
           }
         }
       }
     },
-    "Open" : {
-      "comment" : "Displayed name for the 'Open' contact state.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geöffnet"
+    "Open": {
+      "comment": "Displayed name for the 'Open' contact state.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geöffnet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abierto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abierto"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auki"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auki"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvert"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvert"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aperto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åpen"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpen"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Open Settings" : {
-      "comment" : "A button that opens the user's system settings.",
-      "isCommentAutoGenerated" : true
+    "Open Settings": {
+      "comment": "A button that opens the user's system settings.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
+          }
+        }
+      }
     },
-    "openHAB Cloud Service" : {
-      "comment" : "A toggle that allows the user to enable or disable notifications from the openHAB Cloud Service.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Cloud-Dienst"
+    "openHAB Cloud Service": {
+      "comment": "A toggle that allows the user to enable or disable notifications from the openHAB Cloud Service.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Cloud-Dienst"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Cloud Service"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Cloud Service"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "openhab_connection" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Verbindung"
+    "openhab_connection": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Verbindung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Connection"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Connection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "conexión openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conexión openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Connection"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Connection"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion openHAB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion openHAB"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connessione openHAB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione openHAB"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Tilkobling"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Tilkobling"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB Verbinding"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "openHAB Verbinding"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "подключение к OpenHAB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "подключение к OpenHAB"
           }
         }
       }
     },
-    "password" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passwort"
+    "password": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passwort"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contraseña"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraseña"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mot de passe"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mot de passe"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passord"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passord"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wachtwoord"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wachtwoord"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         }
       }
     },
-    "Password" : {
-      "comment" : "A label displayed above a text field for entering a password.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passwort"
+    "Password": {
+      "comment": "A label displayed above a text field for entering a password.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passwort"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contraseña"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraseña"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salasana"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salasana"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mot de passe"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mot de passe"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Password"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passord"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passord"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wachtwoord"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wachtwoord"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пароль"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пароль"
           }
         }
       }
     },
-    "Pause" : {
-      "comment" : "Display name for the pause action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+    "Pause": {
+      "comment": "Display name for the pause action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Pick a Color" : {
-      "comment" : "A title for the color picker interface.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbe auswählen"
+    "Pick a Color": {
+      "comment": "A title for the color picker interface.",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pick a Color"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick a Color"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Play" : {
-      "comment" : "Display name for the play action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abspielen"
+    "Play": {
+      "comment": "Display name for the play action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abspielen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Player Action" : {
-      "comment" : "Type display name for the PlayerAction enum used in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Player-Aktion"
+    "Player Action": {
+      "comment": "Type display name for the PlayerAction enum used in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player-Aktion"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Player Action"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player Action"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Player Item" : {
-      "comment" : "Display name for a player item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Player-Item"
+    "Player Item": {
+      "comment": "Display name for a player item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player-Item"
           }
         }
       }
     },
-    "PNG" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+    "PNG": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PNG"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG"
           }
         }
       }
     },
-    "Preferences" : {
-      "comment" : "Label for the preferences tab in the watch app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+    "Preferences": {
+      "comment": "Label for the preferences tab in the watch app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferences"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferences"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferencias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferencias"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préférences"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préférences"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferenze"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferenze"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voorkeuren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voorkeuren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Preview state" : {
-      "comment" : "The accessibility label for the picker that allows the user to select and preview a different state of an interactive state token.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorschauzustand"
+    "Preview state": {
+      "comment": "The accessibility label for the picker that allows the user to select and preview a different state of an interactive state token.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschauzustand"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preview state"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview state"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Previous" : {
-      "comment" : "Display name for the previous action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorheriges"
+    "Previous": {
+      "comment": "Display name for the previous action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorheriges"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "privacy_policy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutzerklärung"
+    "privacy_policy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutzerklärung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Política de privacidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de privacidad"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Politique de Confidentialité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politique de Confidentialité"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Politica sulla privacy"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politica sulla privacy"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personvernregler"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personvernregler"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacybeleid"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacybeleid"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         }
       }
     },
-    "Queued commands: %lld" : {
-      "comment" : "A label indicating that there are one or more commands in the queue. The placeholder inside the label is replaced with the actual number of queued commands.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wartende Befehle: %lld"
+    "Queued commands: %lld": {
+      "comment": "A label indicating that there are one or more commands in the queue. The placeholder inside the label is replaced with the actual number of queued commands.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartende Befehle: %lld"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queued commands: %lld"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queued commands: %lld"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Raises by %@" : {
-      "comment" : "A hint that appears when a user hovers over the \"Increase\" button in the setpoint row. The argument is the step size for the current setpoint.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um %@ erhöhen"
+    "Raises by %@": {
+      "comment": "A hint that appears when a user hovers over the \"Increase\" button in the setpoint row. The argument is the step size for the current setpoint.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um %@ erhöhen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raises by %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raises by %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "real_time_sliders" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echtzeitschieberegler"
+    "real_time_sliders": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeitschieberegler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Real-time Sliders"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Real-time Sliders"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deslizadores en tiempo real"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslizadores en tiempo real"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Real-time Sliders"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Real-time Sliders"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Curseurs en temps réel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Curseurs en temps réel"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cursori In Tempo Reale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursori In Tempo Reale"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sanntids Skyveknapper"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanntids Skyveknapper"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Realtime schuifregelaars"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realtime schuifregelaars"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Real-time Sliders"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Real-time Sliders"
           }
         }
       }
     },
-    "Real-time Sliders" : {
-      "comment" : "A toggle that enables or disables the real-time slider feature.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echtzeitschieberegler"
+    "Real-time Sliders": {
+      "comment": "A toggle that enables or disables the real-time slider feature.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeitschieberegler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Real-time Sliders"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Real-time Sliders"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Relative Date: %lld %%" : {
-      "comment" : "A label describing the relative size of the date text compared to the clock text.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relatives Datum: %lld %%"
+    "Relative Date: %lld %%": {
+      "comment": "A label describing the relative size of the date text compared to the clock text.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatives Datum: %lld %%"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relative Date: %lld %%"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative Date: %lld %%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Remote server" : {
-      "comment" : "Header text for the remote server section in the connection settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fernzugriff-Server"
+    "Remote server": {
+      "comment": "Header text for the remote server section in the connection settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fernzugriff-Server"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote server"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote server"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "remote_url" : {
-      "comment" : "Space constraint string which has only about half the screen width on Apple Watch. Best to try and keep it no longer than the English string.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fern-URL"
+    "remote_url": {
+      "comment": "Space constraint string which has only about half the screen width on Apple Watch. Best to try and keep it no longer than the English string.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fern-URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL remota"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL remota"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote URL"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote URL"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL distante"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL distante"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL remoto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL remoto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekstern URL"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekstern URL"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Externe URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Externe URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удаленный URL-адрес"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удаленный URL-адрес"
           }
         }
       }
     },
-    "remote_url_not_configured" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL für Fernzugriff ist nicht konfiguriert."
+    "remote_url_not_configured": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL für Fernzugriff ist nicht konfiguriert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote URL is not configured."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote URL is not configured."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La URL remota no está configurada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La URL remota no está configurada."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote URL is not configured."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote URL is not configured."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'URL distante n'est pas configurée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'URL distante n'est pas configurée."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'URL remoto non è configurato."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'URL remoto non è configurato."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekstern URL er ikke konfigurert."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekstern URL er ikke konfigurert."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Externe URL is niet geconfigureerd."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Externe URL is niet geconfigureerd."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remote URL is not configured."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote URL is not configured."
           }
         }
       }
     },
-    "Rename" : {
-      "comment" : "A button that renames a home.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umbenennen"
+    "Rename": {
+      "comment": "A button that renames a home.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbenennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wijzig naam"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wijzig naam"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Restore Brightness: %lld %%" : {
-      "comment" : "A label under the slider that shows the current brightness level and allows the user to adjust it. The value shown is the brightness level as a percentage.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helligkeit wiederherstellen: %lld %%"
+    "Restore Brightness: %lld %%": {
+      "comment": "A label under the slider that shows the current brightness level and allows the user to adjust it. The value shown is the brightness level as a percentage.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helligkeit wiederherstellen: %lld %%"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore Brightness: %lld %%"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Brightness: %lld %%"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Restore Previous Brightness on Wake" : {
-      "comment" : "A toggle that allows the user to restore the brightness level to its previous value when the device wakes up.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorherige Helligkeit beim Aufwecken wiederherstellen"
+    "Restore Previous Brightness on Wake": {
+      "comment": "A toggle that allows the user to restore the brightness level to its previous value when the device wakes up.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorherige Helligkeit beim Aufwecken wiederherstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore Previous Brightness on Wake"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Previous Brightness on Wake"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Retrieve the current state of an item" : {
-      "comment" : "Description of the Get Item State app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktuellen Status eines Items abrufen"
+    "Retrieve the current state of an item": {
+      "comment": "Description of the Get Item State app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuellen Status eines Items abrufen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retrieve the current state of an item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retrieve the current state of an item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recuperar el estado actual de un elemento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperar el estado actual de un elemento"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Récupérer l'état actuel d'un item"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récupérer l'état actuel d'un item"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recupera lo stato attuale di un Item"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recupera lo stato attuale di un Item"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hent nåværende tilstand for et Item"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hent nåværende tilstand for et Item"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haal de huidige status van een item op"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haal de huidige status van een item op"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "retry" : {
-      "comment" : "retry connection",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneut versuchen"
+    "retry": {
+      "comment": "retry connection",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut versuchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reintentar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réessayer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riprova"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prøv på nytt"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prøv på nytt"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opnieuw"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opnieuw"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         }
       }
     },
-    "Rewind" : {
-      "comment" : "Display name for the rewind action in the PlayerAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurückspulen"
+    "Rewind": {
+      "comment": "Display name for the rewind action in the PlayerAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurückspulen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rewind"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rewind"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "running_demo_mode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läuft im Demomodus. Überprüfe die Einstellungen, um den Demomodus zu deaktivieren."
+    "running_demo_mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft im Demomodus. Überprüfe die Einstellungen, um den Demomodus zu deaktivieren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running in demo mode. Check settings to disable demo mode."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running in demo mode. Check settings to disable demo mode."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funccionando en modo demostración. Comprueba la configuración para desactivarlo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funccionando en modo demostración. Comprueba la configuración para desactivarlo."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running in demo mode. Check settings to disable demo mode."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running in demo mode. Check settings to disable demo mode."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécution en mode démo. Vérifiez les paramètres pour désactiver le mode démo."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécution en mode démo. Vérifiez les paramètres pour désactiver le mode démo."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esecuzione in modalità demo. Controlla le impostazioni per disabilitare la modalità demo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esecuzione in modalità demo. Controlla le impostazioni per disabilitare la modalità demo."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kjører i demomodus. Sjekk innstillingene for å deaktivere demomodus."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kjører i demomodus. Sjekk innstillingene for å deaktivere demomodus."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uitvoeren in demo-modus. Controleer instellingen om demomodus uit te schakelen."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uitvoeren in demo-modus. Controleer instellingen om demomodus uit te schakelen."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running in demo mode. Check settings to disable demo mode."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running in demo mode. Check settings to disable demo mode."
           }
         }
       }
     },
-    "Saturation: %.2f" : {
-      "comment" : "A label displaying the saturation value in the color picker view.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sättigung: %.2f"
+    "Saturation: %.2f": {
+      "comment": "A label displaying the saturation value in the color picker view.",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sättigung: %.2f"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saturation: %.2f"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saturation: %.2f"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Save" : {
-      "comment" : "The text for a button that saves current settings.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sichern"
+    "Save": {
+      "comment": "The text for a button that saves current settings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bewaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bewaar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Screen Saver" : {
-      "comment" : "The title of the screen.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirmschoner"
+    "Screen Saver": {
+      "comment": "The title of the screen.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmschoner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Screen Saver"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Saver"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvapantallas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvapantallas"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Économiseur d’écran"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Économiseur d’écran"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvaschermo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvaschermo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schermbeveiliging"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schermbeveiliging"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Screen Saver Settings" : {
-      "comment" : "A link to the settings related to the screen saver.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirmschoner-Einstellungen"
+    "Screen Saver Settings": {
+      "comment": "A link to the settings related to the screen saver.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmschoner-Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Screen Saver Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Saver Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Search" : {
-      "comment" : "A text field for searching through a list of items.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchen"
+    "Search": {
+      "comment": "A text field for searching through a list of items.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoek"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoek"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Search for an item" : {
-      "comment" : "Dialog text prompting the user to search for an openHAB item in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Item suchen"
+    "Search for an item": {
+      "comment": "Dialog text prompting the user to search for an openHAB item in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Item suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search for an item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search for an item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "search_items" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suche openHAB Items"
+    "search_items": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suche openHAB Items"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search openHAB items"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search openHAB items"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar ítems en openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar ítems en openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search openHAB items"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search openHAB items"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des items openHAB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des items openHAB"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca Item openHAB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerca Item openHAB"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søk i openHAB Items"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Søk i openHAB Items"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoek openHAB items"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoek openHAB items"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search openHAB items"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search openHAB items"
           }
         }
       }
     },
-    "Select a home for '%@'" : {
-      "comment" : "A message to be displayed in a dialog box when the user needs to select a home. The argument is the name of the item that needs a home.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuhause für '%@' auswählen"
+    "Select a home for '%@'": {
+      "comment": "A message to be displayed in a dialog box when the user needs to select a home. The argument is the name of the item that needs a home.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuhause für '%@' auswählen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar una casa para '%@'"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar una casa para '%@'"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valitse koti kohteelle '%@'"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valitse koti kohteelle '%@'"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner un domicile pour '%@'"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner un domicile pour '%@'"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona una casa per '%@'"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona una casa per '%@'"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg et hjem for '%@'"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velg et hjem for '%@'"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecteer een thuis voor '%@'"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecteer een thuis voor '%@'"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите дом для '%@'"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите дом для '%@'"
           }
         }
       }
     },
-    "Select color" : {
-      "comment" : "A button that, when pressed, opens a view allowing the user to select a color.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbe wählen"
+    "Select color": {
+      "comment": "A button that, when pressed, opens a view allowing the user to select a color.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe wählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select color"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select color"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "select_sitemap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap auswählen"
+    "select_sitemap": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Sitemap"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Sitemap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar mapa web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar mapa web"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Sitemap"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Sitemap"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner le Sitemap"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner le Sitemap"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona Sitemap"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona Sitemap"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg Sitemap"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velg Sitemap"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecteer Sitemap"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecteer Sitemap"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать Sitemap"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать Sitemap"
           }
         }
       }
     },
-    "Send ${action} to ${itemEntity}" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "${action} an ${itemEntity} senden"
+    "Send ${action} to ${itemEntity}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${action} an ${itemEntity} senden"
           }
         }
       }
     },
-    "Send a player command such as play, pause, next, or previous" : {
-      "comment" : "Description of the Set Player Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einen Player-Befehl senden, z. B. Abspielen, Pause, Weiter oder Zurück"
+    "Send a player command such as play, pause, next, or previous": {
+      "comment": "Description of the Set Player Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Player-Befehl senden, z. B. Abspielen, Pause, Weiter oder Zurück"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send a player command such as play, pause, next, or previous"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send a player command such as play, pause, next, or previous"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sending commands: %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehle werden gesendet: %lld"
+    "Sending commands: %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehle werden gesendet: %lld"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sending commands: %lld"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending commands: %lld"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent %@ to %@" : {
-      "comment" : "The result text displayed in the dialog. The argument is the action, and the second argument is the item label.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ an %2$@ gesendet"
+    "Sent %@ to %@": {
+      "comment": "The result text displayed in the dialog. The argument is the action, and the second argument is the item label.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ an %2$@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent %1$@ to %2$@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent %1$@ to %2$@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado %1$@ a %2$@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado %1$@ a %2$@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ envoyé à %2$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ envoyé à %2$@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ inviato a %2$@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ inviato a %2$@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ sendt til %2$@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ sendt til %2$@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ verzonden naar %2$@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ verzonden naar %2$@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent location %lf, %lf to %@" : {
-      "comment" : "Dialog shown after setting a location value. First two placeholders are latitude and longitude, third is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lf, %lf wurde an Standort %@ gesendet"
+    "Sent location %lf, %lf to %@": {
+      "comment": "Dialog shown after setting a location value. First two placeholders are latitude and longitude, third is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lf, %lf wurde an Standort %@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent location %lf, %lf to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent location %lf, %lf to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent the color value of %@ to %@" : {
-      "comment" : "Dialog shown after setting a color value. First placeholder is the color value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Farbwert %@ wurde an %@ gesendet"
+    "Sent the color value of %@ to %@": {
+      "comment": "Dialog shown after setting a color value. First placeholder is the color value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Farbwert %@ wurde an %@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent the color value of %@ to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent the color value of %@ to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado el valor de color de %@ a %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado el valor de color de %@ a %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyé la valeur de couleur de %@ à %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyé la valeur de couleur de %@ à %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inviato il valore di colore di %@ a %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inviato il valore di colore di %@ a %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sendte fargeverdien %@ til %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sendte fargeverdien %@ til %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De kleurwaarde van %@ is verzonden naar %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De kleurwaarde van %@ is verzonden naar %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent the date %@ to %@" : {
-      "comment" : "Dialog shown after setting a date/time value. First placeholder is the date string, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum %@ auf %@ setzen"
+    "Sent the date %@ to %@": {
+      "comment": "Dialog shown after setting a date/time value. First placeholder is the date string, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum %@ auf %@ setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent the date %@ to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent the date %@ to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent the number %lf to %@" : {
-      "comment" : "Dialog shown after setting a number control value. First placeholder is the decimal value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Zahl %lf wurde an %@ gesendet"
+    "Sent the number %lf to %@": {
+      "comment": "Dialog shown after setting a number control value. First placeholder is the decimal value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zahl %lf wurde an %@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent the number %lf to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent the number %lf to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir el número %lf a %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir el número %lf a %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyé le numéro %lf à %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyé le numéro %lf à %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inviato il numero %lf a %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inviato il numero %lf a %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send den numeriske verdien %lf til %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send den numeriske verdien %lf til %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De waarde %lf is verzonden naar %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De waarde %lf is verzonden naar %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent the string %@ to %@" : {
-      "comment" : "Dialog shown after setting a string control value. First placeholder is the string value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der String %@ wurde an %@ gesendet"
+    "Sent the string %@ to %@": {
+      "comment": "Dialog shown after setting a string control value. First placeholder is the string value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der String %@ wurde an %@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent the string %@ to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent the string %@ to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviada la cadena %@ a %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviada la cadena %@ a %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoi de la chaîne %@ à %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoi de la chaîne %@ à %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inviata la stringa %@ a %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inviata la stringa %@ a %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send strengverdien %@ til %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send strengverdien %@ til %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De waarde %@ is verzonden naar %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De waarde %@ is verzonden naar %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sent the value of %lld to %@" : {
-      "comment" : "Dialog shown after setting a dimmer or roller shutter value. First placeholder is the integer value, second is the item name.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Wert %lld wurde an %@ gesendet"
+    "Sent the value of %lld to %@": {
+      "comment": "Dialog shown after setting a dimmer or roller shutter value. First placeholder is the integer value, second is the item name.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Wert %lld wurde an %@ gesendet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent the value of %lld to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent the value of %lld to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado el valor de %lld a %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado el valor de %lld a %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyé la valeur %lld à %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyé la valeur %lld à %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inviato il valore %lld a %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inviato il valore %lld a %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sendte verdien %lld til %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sendte verdien %lld til %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De waarde %lld is verzonden naar %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De waarde %lld is verzonden naar %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set ${itemEntity} to ${latitude}, ${longitude}" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standort ${itemEntity} auf ${latitude}, ${longitude} setzen"
+    "Set ${itemEntity} to ${latitude}, ${longitude}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standort ${itemEntity} auf ${latitude}, ${longitude} setzen"
           }
         }
       }
     },
-    "Set ${itemEntity} to ${value}" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "${itemEntity} auf ${value} setzen"
+    "Set ${itemEntity} to ${value}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${itemEntity} auf ${value} setzen"
           }
         }
       }
     },
-    "Set ${itemEntity} to ${value} (HSB)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "${itemEntity} auf ${value} (HSB) setzen"
+    "Set ${itemEntity} to ${value} (HSB)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${itemEntity} auf ${value} (HSB) setzen"
           }
         }
       }
     },
-    "Set Active Home" : {
-      "comment" : "Title of the intent to set the active home.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktives Zuhause setzen"
+    "Set Active Home": {
+      "comment": "Title of the intent to set the active home.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktives Zuhause setzen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer casa activa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer casa activa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta aktiivinen koti"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aseta aktiivinen koti"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir le domicile actif"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir le domicile actif"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta casa attiva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta casa attiva"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi aktivt hjem"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi aktivt hjem"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actief thuis instellen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actief thuis instellen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить активный дом"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить активный дом"
           }
         }
       }
     },
-    "Set active home to ${home}" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktives Zuhause auf ${home} setzen"
+    "Set active home to ${home}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktives Zuhause auf ${home} setzen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer casa activa como ${home}"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer casa activa como ${home}"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta aktiiviseksi kodiksi ${home}"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aseta aktiiviseksi kodiksi ${home}"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir ${home} comme domicile actif"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir ${home} comme domicile actif"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta ${home} come casa attiva"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta ${home} come casa attiva"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi ${home} som aktivt hjem"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi ${home} som aktivt hjem"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "${home} instellen als actief thuis"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${home} instellen als actief thuis"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить ${home} как активный дом"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить ${home} как активный дом"
           }
         }
       }
     },
-    "Set Color Control Value" : {
-      "comment" : "Title of the Set Color Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbwert festlegen"
+    "Set Color Control Value": {
+      "comment": "Title of the Set Color Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbwert festlegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Color Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Color Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Define el valor de control de color"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Define el valor de control de color"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur de contrôle de couleur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur de contrôle de couleur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta Valore Controllo Colore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta Valore Controllo Colore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi Fargekontrollverdi"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi Fargekontrollverdi"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kleurwaarde instellen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kleurwaarde instellen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Contact State Value" : {
-      "comment" : "Title of the Set Contact State Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert eines Kontakt=Status festlegen"
+    "Set Contact State Value": {
+      "comment": "Title of the Set Contact State Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert eines Kontakt=Status festlegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Contact State Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Contact State Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el valor del estado del pulsador"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el valor del estado del pulsador"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur de l'état du contacteur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur de l'état du contacteur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta lo Stato del Contatto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta lo Stato del Contatto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett Tilstand for Bryter"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett Tilstand for Bryter"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel contact status waarde in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel contact status waarde in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set DateTime Control Value" : {
-      "comment" : "Title of the Set DateTime Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert eines DateTime-Kontrollelements setzen "
+    "Set DateTime Control Value": {
+      "comment": "Title of the Set DateTime Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert eines DateTime-Kontrollelements setzen "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set DateTime Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set DateTime Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Dimmer or Roller Shutter Value" : {
-      "comment" : "Title of the Set Dimmer or Roller Shutter Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert eines Dimmers oder Rollladens festlegen"
+    "Set Dimmer or Roller Shutter Value": {
+      "comment": "Title of the Set Dimmer or Roller Shutter Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert eines Dimmers oder Rollladens festlegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Dimmer or Roller Shutter Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Dimmer or Roller Shutter Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir el valor del regulador o persiana"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir el valor del regulador o persiana"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Régler la valeur du Dimmer ou du Volet Roulant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Régler la valeur du Dimmer ou du Volet Roulant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il valore di Dimmer o Tapparella"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il valore di Dimmer o Tapparella"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi Verdi for Dimmer eller Rullegardin"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi Verdi for Dimmer eller Rullegardin"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel Dimmer of Rolluik waarde in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel Dimmer of Rolluik waarde in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Location Control Value" : {
-      "comment" : "Title of the Set Location Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standort-Kontrollwert setzen"
+    "Set Location Control Value": {
+      "comment": "Title of the Set Location Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standort-Kontrollwert setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Location Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Location Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Number Control Value" : {
-      "comment" : "Title of the Set Number Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert eines numerischen Kontrollelements setzen"
+    "Set Number Control Value": {
+      "comment": "Title of the Set Number Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert eines numerischen Kontrollelements setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Number Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Number Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer valor de control de número"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer valor de control de número"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur de contrôle du numéro"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur de contrôle du numéro"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta Valore del Numero di Controllo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta Valore del Numero di Controllo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett Verdi for Numerisk Kontroll"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett Verdi for Numerisk Kontroll"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zet Nummer Control Waarde"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zet Nummer Control Waarde"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Player Control Value" : {
-      "comment" : "Title of the Set Player Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Player-Kontrollelement setzen"
+    "Set Player Control Value": {
+      "comment": "Title of the Set Player Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player-Kontrollelement setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Player Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Player Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set String Control Value" : {
-      "comment" : "Title of the Set String Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "String-Kontrollwert setzen"
+    "Set String Control Value": {
+      "comment": "Title of the Set String Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "String-Kontrollwert setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set String Control Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set String Control Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el valor de control de cadena"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el valor de control de cadena"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur de contrôle de chaîne"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur de contrôle de chaîne"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta Valore della Stringa di Controllo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta Valore della Stringa di Controllo"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett Strengkontroll-Verdi"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett Strengkontroll-Verdi"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zet String Control Waarde in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zet String Control Waarde in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set Switch State" : {
-      "comment" : "Title of the Set Switch State app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schalterzustand setzen"
+    "Set Switch State": {
+      "comment": "Title of the Set Switch State app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schalterzustand setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set Switch State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Switch State"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir el estado del interruptor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir el estado del interruptor"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir l'état du Switch"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir l'état du Switch"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta stato Interruttore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta stato Interruttore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi Brytertilstand"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi Brytertilstand"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel schakelstatus in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel schakelstatus in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the color of a color control item" : {
-      "comment" : "Description of the Set Color Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbe eines Kontrollelements festlegen"
+    "Set the color of a color control item": {
+      "comment": "Description of the Set Color Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe eines Kontrollelements festlegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the color of a color control item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the color of a color control item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir el color de un ítem de control de color"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir el color de un ítem de control de color"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la couleur d'un élément de contrôle de couleur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la couleur d'un élément de contrôle de couleur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il colore di un Item di controllo colore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il colore di un Item di controllo colore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi fargen til et fargekontroll-Item"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi fargen til et fargekontroll-Item"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel de kleur van een kleurbesturingsitem in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel de kleur van een kleurbesturingsitem in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the date and time of a DateTime control item" : {
-      "comment" : "Description of the Set DateTime Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum und Uhrzeit eines DateTime-Kontrollelements setzen"
+    "Set the date and time of a DateTime control item": {
+      "comment": "Description of the Set DateTime Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum und Uhrzeit eines DateTime-Kontrollelements setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the date and time of a DateTime control item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the date and time of a DateTime control item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the decimal value of a number control item" : {
-      "comment" : "Description of the Set Number Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dezimalwert eines numerischen Kontrollelements setzen"
+    "Set the decimal value of a number control item": {
+      "comment": "Description of the Set Number Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dezimalwert eines numerischen Kontrollelements setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the decimal value of a number control item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the decimal value of a number control item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el valor decimal de un ítem de control numérico"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el valor decimal de un ítem de control numérico"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur décimale d'un item de contrôle de nombre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur décimale d'un item de contrôle de nombre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il valore decimale di un Item di controllo numerico"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il valore decimale di un Item di controllo numerico"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett desimalverdien til en numerisk kontroll-Item"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett desimalverdien til en numerisk kontroll-Item"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel de decimale waarde van een nummer control item in"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stel de decimale waarde van een nummer control item in"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the integer value of a dimmer or roller shutter" : {
-      "comment" : "Description of the Set Dimmer or Roller Shutter Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Festlegen des Wertes eines Dimmers oder Rollladens"
+    "Set the integer value of a dimmer or roller shutter": {
+      "comment": "Description of the Set Dimmer or Roller Shutter Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Festlegen des Wertes eines Dimmers oder Rollladens"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the integer value of a dimmer or roller shutter"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the integer value of a dimmer or roller shutter"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Define el valor entero de un regulador o persiana"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Define el valor entero de un regulador o persiana"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la valeur entière d'un dimmer ou d'un volet roulant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la valeur entière d'un dimmer ou d'un volet roulant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il valore intero di un dimmer o una tapparella"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il valore intero di un dimmer o una tapparella"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett heltallsverdien til en dimmer eller rullegardin"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett heltallsverdien til en dimmer eller rullegardin"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zet de integerwaarde van een dimmer of rolluik"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zet de integerwaarde van een dimmer of rolluik"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the latitude and longitude of a location control item" : {
-      "comment" : "Description of the Set Location Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breitengrad und Längengrad eines Standort-Kontrollelements setzen"
+    "Set the latitude and longitude of a location control item": {
+      "comment": "Description of the Set Location Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breitengrad und Längengrad eines Standort-Kontrollelements setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the latitude and longitude of a location control item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the latitude and longitude of a location control item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the state of ${itemEntity} to ${state}" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Den Status von ${itemEntity} auf ${state} setzen"
+    "Set the state of ${itemEntity} to ${state}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den Status von ${itemEntity} auf ${state} setzen"
           }
         }
       }
     },
-    "Set the state of a contact open or closed" : {
-      "comment" : "Description of the Set Contact State Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status eines Kontakts auf offen oder geschlossen setzen"
+    "Set the state of a contact open or closed": {
+      "comment": "Description of the Set Contact State Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status eines Kontakts auf offen oder geschlossen setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the state of a contact open or closed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the state of a contact open or closed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el estado de un interruptor encendido o apagado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer el estado de un interruptor encendido o apagado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir l'état d'un contacteur ouvert ou fermé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir l'état d'un contacteur ouvert ou fermé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta lo stato di un contatto aperto o chiuso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta lo stato di un contatto aperto o chiuso"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett tilstanden til en bryter til åpen eller lukket"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sett tilstanden til en bryter til åpen eller lukket"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zet de status van een contact open of gesloten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zet de status van een contact open of gesloten"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the state of a switch on or off, or toggle its state" : {
-      "comment" : "Description of the Set Switch State app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch-Status auf An, Aus oder Umschalten setzen"
+    "Set the state of a switch on or off, or toggle its state": {
+      "comment": "Description of the Set Switch State app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch-Status auf An, Aus oder Umschalten setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the state of a switch on or off, or toggle its state"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the state of a switch on or off, or toggle its state"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set the string of a string control item" : {
-      "comment" : "Description of the Set String Control Value app intent.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeichenkette eines String-Kontrollelements setzen"
+    "Set the string of a string control item": {
+      "comment": "Description of the Set String Control Value app intent.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichenkette eines String-Kontrollelements setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the string of a string control item"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the string of a string control item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer la cadena de un ítem controlador de cadena"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer la cadena de un ítem controlador de cadena"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la chaîne d'un item de contrôle de chaîne"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la chaîne d'un item de contrôle de chaîne"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta il valore di una item di controllo di tipo stringa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta il valore di una item di controllo di tipo stringa"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi teksten til et teksterkontroll-Item"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi teksten til et teksterkontroll-Item"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De tekenreeks van een string controle item instellen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De tekenreeks van een string controle item instellen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Set value" : {
-      "comment" : "A button that sets the value of a text input.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert setzen"
+    "Set value": {
+      "comment": "A button that sets the value of a text input.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert setzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+    "settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramétrage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramétrage"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstillinger"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instellingen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         }
       }
     },
-    "settings_not_received" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen noch nicht vom iPhone empfangen."
+    "settings_not_received": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen noch nicht vom iPhone empfangen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings not yet received from iPhone."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings not yet received from iPhone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración aún no recibida del iPhone."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración aún no recibida del iPhone."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Settings not yet received from phone."
+        "fi": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Settings not yet received from phone."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres pas encore reçus de l'iPhone."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres pas encore reçus de l'iPhone."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni non ancora ricevute da iPhone."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni non ancora ricevute da iPhone."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstillinger som ennå ikke er mottatt fra iPhone."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger som ennå ikke er mottatt fra iPhone."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instellingen nog niet ontvangen van iPhone."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instellingen nog niet ontvangen van iPhone."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Settings not yet received from phone."
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Settings not yet received from phone."
           }
         }
       }
     },
-    "Show Date" : {
-      "comment" : "A toggle that enables or disables the display of the date in the screen saver.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum anzeigen"
+    "Show Date": {
+      "comment": "A toggle that enables or disables the display of the date in the screen saver.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Date"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Date"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Show Search Field" : {
-      "comment" : "A toggle that enables or disables the search field in the app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchfeld anzeigen"
+    "Show Search Field": {
+      "comment": "A toggle that enables or disables the search field in the app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchfeld anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Show Seconds" : {
-      "comment" : "A toggle that lets the user enable or disable the display of seconds in the screen saver.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sekunden anzeigen"
+    "Show Seconds": {
+      "comment": "A toggle that lets the user enable or disable the display of seconds in the screen saver.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekunden anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Seconds"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Seconds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Show Time" : {
-      "comment" : "A toggle that enables or disables the display of the time.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeit anzeigen"
+    "Show Time": {
+      "comment": "A toggle that enables or disables the display of the time.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeit anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Time"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Time"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "show_search_field" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchfeld anzeigen"
+    "show_search_field": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchfeld anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Search Field"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Search Field"
           }
         }
       }
     },
-    "sitemap" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+    "sitemap": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mapa web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa web"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         }
       }
     },
-    "Sitemap" : {
-      "comment" : "Label for the tab item representing the sitemap view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+    "Sitemap": {
+      "comment": "Label for the tab item representing the sitemap view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sitemap Diagnostics Logging" : {
-      "comment" : "A toggle that enables or disables logging of sitemap diagnostics.",
-      "isCommentAutoGenerated" : true
+    "Sitemap Diagnostics Logging": {
+      "comment": "A toggle that enables or disables logging of sitemap diagnostics.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap-Diagnoseprotokollierung"
+          }
+        }
+      }
     },
-    "Sitemap for Apple Watch" : {
-      "comment" : "A label for selecting a sitemap to be used with an Apple Watch app.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Watch Sitemap"
+    "Sitemap for Apple Watch": {
+      "comment": "A label for selecting a sitemap to be used with an Apple Watch app.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Watch Sitemap"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap for Apple Watch"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap for Apple Watch"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "sitemap_settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap-Einstellungen"
+    "sitemap_settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap-Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes del esquema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes del esquema"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap Settings"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap Settings"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres Sitemap"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres Sitemap"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni Sitemap"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni Sitemap"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstillinger for Sitemap"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innstillinger for Sitemap"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap instellingen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemap Settings"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemap Settings"
           }
         }
       }
     },
-    "Sitemaps" : {
-      "comment" : "A section header that lists the user's available sitemaps.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemaps"
+    "Sitemaps": {
+      "comment": "A section header that lists the user's available sitemaps.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemaps"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemaps"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemaps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Size: %llu MB" : {
-      "comment" : "A message showing the size of the image cache. The argument is the size of the image cache in MB.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Größe: %llu MB"
+    "Size: %llu MB": {
+      "comment": "A message showing the size of the image cache. The argument is the size of the image cache in MB.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Größe: %llu MB"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Size: %llu MB"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size: %llu MB"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Soft White" : {
-      "comment" : "A color temperature description.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiches Weiß"
+    "Soft White": {
+      "comment": "A color temperature description.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiches Weiß"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soft White"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soft White"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Sort sitemaps by" : {
-      "comment" : "A label describing the option to sort sitemaps.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemaps sortieren nach"
+    "Sort sitemaps by": {
+      "comment": "A label describing the option to sort sitemaps.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemaps sortieren nach"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sort sitemaps by"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort sitemaps by"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "sortSitemapsBy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemaps sortieren nach"
+    "sortSitemapsBy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemaps sortieren nach"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sort sitemaps by"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort sitemaps by"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordenar mapas del sitio por"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenar mapas del sitio por"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitemapien järjestys"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitemapien järjestys"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trier les sitemaps par"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trier les sitemaps par"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordina le Sitemaps per"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordina le Sitemaps per"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorter SiteMaps etter"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorter SiteMaps etter"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorteer sitemaps op"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorteer sitemaps op"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sort sitemaps by"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort sitemaps by"
           }
         }
       }
     },
-    "SSL error. The connection couldn’t be established securely." : {
-      "comment" : "Error message displayed when a connection to the OpenHAB server fails due to a SSL error.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-Fehler. Die Verbindung konnte nicht sicher hergestellt werden."
+    "SSL error. The connection couldn’t be established securely.": {
+      "comment": "Error message displayed when a connection to the OpenHAB server fails due to a SSL error.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-Fehler. Die Verbindung konnte nicht sicher hergestellt werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL error. The connection couldn’t be established securely."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL error. The connection couldn’t be established securely."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "ssl_certificate_error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-Zertifikatfehler"
+    "ssl_certificate_error": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-Zertifikatfehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de certificado SSL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de certificado SSL"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Error"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur de certificat SSL"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de certificat SSL"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore certificato SSL"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore certificato SSL"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feil med SSL sertifikat"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feil med SSL sertifikat"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-certificaat fout"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-certificaat fout"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Error"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Error"
           }
         }
       }
     },
-    "ssl_certificate_invalid" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das von %1$@ für %2$@ vorgestellte SSL-Zertifikat ist ungültig. Möchtest du fortfahren?"
+    "ssl_certificate_invalid": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das von %1$@ für %2$@ vorgestellte SSL-Zertifikat ist ungültig. Möchtest du fortfahren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El certificado SSL presentado por %1$@ para %2$@ no es válido. ¿Desea continuar?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El certificado SSL presentado por %1$@ para %2$@ no es válido. ¿Desea continuar?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ n'est pas valide. Voulez-vous continuer ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le certificat SSL présenté par %1$@ pour %2$@ n'est pas valide. Voulez-vous continuer ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il certificato SSL presentato da %1$@ per %2$@ non è valido. Vuoi procedere?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il certificato SSL presentato da %1$@ per %2$@ non è valido. Vuoi procedere?"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-sertifikat presentert av %1$@ for %2$@ er ugyldig. Vil du fortsette?"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-sertifikat presentert av %1$@ for %2$@ er ugyldig. Vil du fortsette?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-certificaat gepresenteerd door %1$@ voor %2$@ is ongeldig. Wilt u toch doorgaan?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-certificaat gepresenteerd door %1$@ voor %2$@ is ongeldig. Wilt u toch doorgaan?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ is invalid. Do you want to proceed?"
           }
         }
       }
     },
-    "ssl_certificate_no_match" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das von %1$@ für %2$@ vorgestellte SSL-Zertifikat stimmt nicht mit dem Datensatz überein. Möchtest du fortfahren?"
+    "ssl_certificate_no_match": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das von %1$@ für %2$@ vorgestellte SSL-Zertifikat stimmt nicht mit dem Datensatz überein. Möchtest du fortfahren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El certificado SSL presentado por %1$@ para %2$@ no coincide con el registro. ¿Desea continuar?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El certificado SSL presentado por %1$@ para %2$@ no coincide con el registro. ¿Desea continuar?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ ne correspond pas à l'enregistrement. Voulez-vous continuer ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le certificat SSL présenté par %1$@ pour %2$@ ne correspond pas à l'enregistrement. Voulez-vous continuer ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il certificato SSL presentato da %1$@ per %2$@ non corrisponde al record. Vuoi procedere?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il certificato SSL presentato da %1$@ per %2$@ non corrisponde al record. Vuoi procedere?"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-sertifikat presentert av %1$@ for %2$@ samsvarer ikke med det som er lagret fra før av. Vil du fortsette?"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-sertifikat presentert av %1$@ for %2$@ samsvarer ikke med det som er lagret fra før av. Vil du fortsette?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-certificaat gepresenteerd door %1$@ voor %2$@ komt niet overeen met het record. Wilt u toch doorgaan?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-certificaat gepresenteerd door %1$@ voor %2$@ komt niet overeen met het record. Wilt u toch doorgaan?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate presented by %1$@ for %2$@ doesn't match the record. Do you want to proceed?"
           }
         }
       }
     },
-    "ssl_certificate_warning" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-Zertifikatwarnung"
+    "ssl_certificate_warning": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-Zertifikatwarnung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Warning"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Warning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aviso de certificado SSL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso de certificado SSL"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Warning"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Warning"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avertissement de certificat SSL"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement de certificat SSL"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avviso Certificato SSL"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avviso Certificato SSL"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advarsel for SSL sertifikat"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel for SSL sertifikat"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-certificaat waarschuwing"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL-certificaat waarschuwing"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL Certificate Warning"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSL Certificate Warning"
           }
         }
       }
     },
-    "State" : {
-      "comment" : "A label for a picker that lets the user select a state.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zustand"
+    "State": {
+      "comment": "A label for a picker that lets the user select a state.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zustand"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "State"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provincia"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provincia"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "État"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "String Item" : {
-      "comment" : "Display name for a string item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "String-Item"
+    "String Item": {
+      "comment": "Display name for a string item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "String-Item"
           }
         }
       }
     },
-    "SVG" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+    "SVG": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SVG"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SVG"
           }
         }
       }
     },
-    "Switch Action" : {
-      "comment" : "Type display name for the SwitchAction enum used in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch-Aktion"
+    "Switch Action": {
+      "comment": "Type display name for the SwitchAction enum used in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch-Aktion"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch Action"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch Action"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Switch Item" : {
-      "comment" : "Display name for a switch item type.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch-Item"
+    "Switch Item": {
+      "comment": "Display name for a switch item type.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch-Item"
           }
         }
       }
     },
-    "Switch the active home in the openHAB app" : {
-      "comment" : "Description of the intent to set the active home.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktives Zuhause in der openHAB-App wechseln"
+    "Switch the active home in the openHAB app": {
+      "comment": "Description of the intent to set the active home.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktives Zuhause in der openHAB-App wechseln"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar la casa activa en la app openHAB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar la casa activa en la app openHAB"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaihda aktiivinen koti openHAB-sovelluksessa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda aktiivinen koti openHAB-sovelluksessa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changer le domicile actif dans l'application openHAB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer le domicile actif dans l'application openHAB"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia la casa attiva nell'app openHAB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia la casa attiva nell'app openHAB"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bytt aktivt hjem i openHAB-appen"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bytt aktivt hjem i openHAB-appen"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actief thuis wijzigen in de openHAB-app"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actief thuis wijzigen in de openHAB-app"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сменить активный дом в приложении openHAB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сменить активный дом в приложении openHAB"
           }
         }
       }
     },
-    "sync_prefs" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronisationseinstellung"
+    "sync_prefs": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisationseinstellung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync preferences"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync preferences"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferencias de sincronización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferencias de sincronización"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync preferences"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync preferences"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchroniser les préférences"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchroniser les préférences"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizza preferenze"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizza preferenze"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync-innstillinger"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync-innstillinger"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronisatie voorkeuren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisatie voorkeuren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync preferences"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync preferences"
           }
         }
       }
     },
-    "System" : {
-      "comment" : "A section header in the drawer view that links to the system settings.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+    "System": {
+      "comment": "A section header in the drawer view that links to the system settings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Système"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systeem"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeem"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Test Connection" : {
-      "comment" : "A button label that triggers a test connection action.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testverbindung"
+    "Test Connection": {
+      "comment": "A button label that triggers a test connection action.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testverbindung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test Connection"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test Connection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Test Screen Saver" : {
-      "comment" : "A button that can be used to test the functionality of the screen saver.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirmschoner testen"
+    "Test Screen Saver": {
+      "comment": "A button that can be used to test the functionality of the screen saver.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmschoner testen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test Screen Saver"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test Screen Saver"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "The connection timed out. Try again later." : {
-      "comment" : "Error message displayed when a network request times out.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Verbindung ist abgelaufen. Später noch einmal versuchen."
+    "The connection timed out. Try again later.": {
+      "comment": "Error message displayed when a network request times out.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Verbindung ist abgelaufen. Später noch einmal versuchen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The connection timed out. Try again later."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The connection timed out. Try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "The state of %@ is %@" : {
-      "comment" : "Dialog shown when retrieving an item state. First placeholder is the item name, second is its state.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Status von %@ ist %@"
+    "The state of %@ is %@": {
+      "comment": "Dialog shown when retrieving an item state. First placeholder is the item name, second is its state.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Status von %@ ist %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The state of %@ is %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The state of %@ is %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El estado de %@ es %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado de %@ es %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'état de %@ est %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'état de %@ est %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo stato di %@ è %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stato di %@ è %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilstanden til %@ er %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilstanden til %@ er %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De staat van %@ is %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De staat van %@ is %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "The state of %@ was set to %@" : {
-      "comment" : "Dialog shown after setting a contact state. First placeholder is the item name, second is the new state.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Status von %@ wurde auf %@ gesetzt"
+    "The state of %@ was set to %@": {
+      "comment": "Dialog shown after setting a contact state. First placeholder is the item name, second is the new state.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Status von %@ wurde auf %@ gesetzt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The state of %@ was set to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The state of %@ was set to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El estado de %@ se ha establecido en %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado de %@ se ha establecido en %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'état de %@ a été réglé sur %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'état de %@ a été réglé sur %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lo stato di %@ è stato impostato su %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stato di %@ è stato impostato su %@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilstanden til %@ ble satt til %@"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilstanden til %@ ble satt til %@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De status van %@ is ingesteld op %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De status van %@ is ingesteld op %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080 or http://[::1]:8080 for IPv6)." : {
-      "comment" : "Error message displayed when the URL is invalid.",
-      "isCommentAutoGenerated" : true
+    "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080 or http://[::1]:8080 for IPv6).": {
+      "comment": "Error message displayed when the URL is invalid.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die URL ist ungültig. Bitte überprüfen Sie das Format (z.B. http://192.168.2.1:8080 oder http://[::1]:8080 für IPv6)."
+          }
+        }
+      }
     },
-    "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080)." : {
-      "comment" : "Error message displayed when the URL is invalid.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die URL ist ungültig. Bitte prüfe das Format (z. B. http://192.168.2.1:8080)."
+    "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080).": {
+      "comment": "Error message displayed when the URL is invalid.",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die URL ist ungültig. Bitte prüfe das Format (z. B. http://192.168.2.1:8080)."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080)."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The URL is invalid. Please check the format (e.g., http://192.168.2.1:8080)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Tiles" : {
-      "comment" : "A section header that lists the user's tiles.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kacheln"
+    "Tiles": {
+      "comment": "A section header that lists the user's tiles.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kacheln"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiles"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiles"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Timing" : {
-      "comment" : "The header for the timing section in the screen saver settings view.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing"
+    "Timing": {
+      "comment": "The header for the timing section in the screen saver settings view.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "To connect to your local openHAB server, please allow Local Network access when prompted. If you previously denied it, enable it in Settings → Privacy & Security → Local Network." : {
-      "comment" : "A message displayed in the alert when the user tries to connect to a local openHAB server.",
-      "isCommentAutoGenerated" : true
+    "To connect to your local openHAB server, please allow Local Network access when prompted. If you previously denied it, enable it in Settings → Privacy & Security → Local Network.": {
+      "comment": "A message displayed in the alert when the user tries to connect to a local openHAB server.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um eine Verbindung zu Ihrem lokalen openHAB-Server herzustellen, erlauben Sie bitte den Zugriff auf das lokale Netzwerk, wenn Sie dazu aufgefordert werden. Wenn Sie es zuvor abgelehnt haben, aktivieren Sie es unter Einstellungen → Datenschutz & Sicherheit → Lokales Netzwerk."
+          }
+        }
+      }
     },
-    "toggle" : {
-      "comment" : "Action to toggle a switch between on and off states",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "umschalten"
+    "toggle": {
+      "comment": "Action to toggle a switch between on and off states",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "umschalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "toggle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "toggle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "alternar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alternar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vaihda"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vaihda"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "basculer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "basculer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "alternare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alternare"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "veksle"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "veksle"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "omschakelen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "omschakelen"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Toggle" : {
-      "comment" : "Display name for the toggle action in the SwitchAction enum.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschalten"
+    "Toggle": {
+      "comment": "Display name for the toggle action in the SwitchAction enum.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umschalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toggle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "unable_to_add_certificate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zertifikat konnte nicht zum Schlüsselbund hinzugefügt werden: %@."
+    "unable_to_add_certificate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zertifikat konnte nicht zum Schlüsselbund hinzugefügt werden: %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to add certificate to the keychain: %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to add certificate to the keychain: %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede agregar el certificado al llavero %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede agregar el certificado al llavero %@."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to add certificate to the keychain: %@."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to add certificate to the keychain: %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'ajouter le certificat au trousseau : %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'ajouter le certificat au trousseau : %@."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile aggiungere il certificato al portachiavi: %@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile aggiungere il certificato al portachiavi: %@."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan ikke legge sertifikatet til i nøkkelkjeden: %@."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan ikke legge sertifikatet til i nøkkelkjeden: %@."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan certificaat niet toevoegen aan de sleutelhanger: %@."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan certificaat niet toevoegen aan de sleutelhanger: %@."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to add certificate to the keychain: %@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to add certificate to the keychain: %@."
           }
         }
       }
     },
-    "unable_to_decode_certificate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zertifikat kann nicht dekodiert werden: %@."
+    "unable_to_decode_certificate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zertifikat kann nicht dekodiert werden: %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to decode certificate: %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to decode certificate: %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede descifrar el certificado: %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede descifrar el certificado: %@."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to decode certificate: %@."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to decode certificate: %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de décoder le certificat : %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de décoder le certificat : %@."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile decodificare il certificato: %@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile decodificare il certificato: %@."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan ikke dekode sertifikat: %@."
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan ikke dekode sertifikat: %@."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan certificaat niet decoderen: %@."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan certificaat niet decoderen: %@."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to decode certificate: %@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to decode certificate: %@."
           }
         }
       }
     },
-    "Unexpected error: %@" : {
-      "comment" : "A user-visible description of a `DecodingError` that might occur when testing a network connection.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unerwarteter Fehler: %@"
+    "Unexpected error: %@": {
+      "comment": "A user-visible description of a `DecodingError` that might occur when testing a network connection.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unerwarteter Fehler: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unexpected error: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unexpected error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "unknown" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unbekannt"
+    "unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unbekannt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unknown"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknown"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "desconocido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "desconocido"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unknown"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknown"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "inconnu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inconnu"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sconosciuto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sconosciuto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ukjent"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ukjent"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onbekend"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onbekend"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unknown"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknown"
           }
         }
       }
     },
-    "Unknown home" : {
-      "comment" : "Error message displayed when a home is selected but the home ID is not found in the list of stored homes.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekanntes Zuhause"
+    "Unknown home": {
+      "comment": "Error message displayed when a home is selected but the home ID is not found in the list of stored homes.",
+      "isCommentAutoGenerated": true,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekanntes Zuhause"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Casa desconocida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casa desconocida"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tuntematon koti"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntematon koti"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domicile inconnu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domicile inconnu"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Casa sconosciuta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casa sconosciuta"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukjent hjem"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukjent hjem"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onbekend thuis"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onbekend thuis"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Неизвестный дом"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестный дом"
           }
         }
       }
     },
-    "unknownHome" : {
-      "comment" : "unknown home",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekanntes Zuhause"
+    "unknownHome": {
+      "comment": "unknown home",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekanntes Zuhause"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unknownHome"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknownHome"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "unknownState" : {
-      "comment" : "unknown item state",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannter Zustand"
+    "unknownState": {
+      "comment": "unknown item state",
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannter Zustand"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "unknownState"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "unknownState"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Updating…" : {
-      "comment" : "A text that appears while a user is waiting for the sitemap to update.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisierung …"
+    "Updating…": {
+      "comment": "A text that appears while a user is waiting for the sitemap to update.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierung …"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updating…"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizando…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando…"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise à jour…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour…"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiorno …"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorno …"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bijwerken…"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bijwerken…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "URL" : {
-      "comment" : "A text field for entering the URL of the remote server.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+    "URL": {
+      "comment": "A text field for entering the URL of the remote server.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "uselastpath_settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuletzt besuchten Pfad verwenden?"
+    "uselastpath_settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt besuchten Pfad verwenden?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use last visited path?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use last visited path?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Usar la última ruta visitada?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Usar la última ruta visitada?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käytä edellistä polkua?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytä edellistä polkua?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser le chemin de la dernière visite ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser le chemin de la dernière visite ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usare L'Ultimo Percorso Visitato?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usare L'Ultimo Percorso Visitato?"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bruk sist brukte bane?"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bruk sist brukte bane?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laatst bezochte pad gebruiken?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laatst bezochte pad gebruiken?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use last visited path?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use last visited path?"
           }
         }
       }
     },
-    "username" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzername"
+    "username": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzername"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre de usario"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de usario"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identifiant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifiant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utente"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brukernavn"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brukernavn"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gebruikersnaam"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruikersnaam"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
         }
       }
     },
-    "Username" : {
-      "comment" : "A label displayed above the text field for the username.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzername"
+    "Username": {
+      "comment": "A label displayed above the text field for the username.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzername"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Username"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Username"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre de usuario"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de usuario"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom d’utilisateur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom d’utilisateur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome utente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome utente"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gebruikersnaam"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gebruikersnaam"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Value" : {
-      "comment" : "Parameter title for a value in app intents.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wert"
+    "Value": {
+      "comment": "Parameter title for a value in app intents.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Value"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Value"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valor"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valeur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valeur"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verdi"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verdi"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waarde"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waarde"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "version" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+    "version": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versjon"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versjon"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versie"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         }
       }
     },
-    "Very Cool" : {
-      "comment" : "A description for a very cool color temperature.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sehr kalt"
+    "Very Cool": {
+      "comment": "A description for a very cool color temperature.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sehr kalt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Very Cool"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Very Cool"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Very Warm" : {
-      "comment" : "A color temperature range description.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sehr warm"
+    "Very Warm": {
+      "comment": "A color temperature range description.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sehr warm"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Very Warm"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Very Warm"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "Warm White" : {
-      "comment" : "A color temperature range description.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warmweiß"
+    "Warm White": {
+      "comment": "A color temperature range description.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warmweiß"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warm White"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warm White"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "warning" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warnung"
+    "warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warning"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aviso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varoitus"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varoitus"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attention"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attention"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attenzione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attenzione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advarsel"
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advarsel"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waarschuwing"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waarschuwing"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warning"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
           }
         }
       }
     },
-    "Warning: Renaming the home might cause external integrations like shortcuts to fail until reconfigured." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warnung: Das Umbenennen des Zuhauses kann dazu führen, dass externe Integrationen wie Kurzbefehle bis zur Neukonfiguration fehlschlagen."
+    "Warning: Renaming the home might cause external integrations like shortcuts to fail until reconfigured.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung: Das Umbenennen des Zuhauses kann dazu führen, dass externe Integrationen wie Kurzbefehle bis zur Neukonfiguration fehlschlagen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warning: Renaming the home might cause external integrations like shortcuts to fail until reconfigured."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning: Renaming the home might cause external integrations like shortcuts to fail until reconfigured."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     },
-    "You appear to be offline. Check your internet connection." : {
-      "comment" : "Error message displayed when the user is offline.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du scheinst offline zu sein. Überprüfe deine Internetverbindung."
+    "You appear to be offline. Check your internet connection.": {
+      "comment": "Error message displayed when the user is offline.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du scheinst offline zu sein. Überprüfe deine Internetverbindung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You appear to be offline. Check your internet connection."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You appear to be offline. Check your internet connection."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ""
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": ""
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }


### PR DESCRIPTION
## Summary

Adds missing German (`de`) translations for 13 keys that had no `de` entry in `Localizable.xcstrings`:

| Key | Translation |
|-----|-------------|
| `__item_state_passthrough__` | `%@` (format passthrough, unchanged) |
| `%lld %%` | `%lld %%` (format string, unchanged) |
| `Choose color` | Farbe wählen |
| `Color wheel` | Farbrad |
| `Done` | Fertig |
| `Drag to change hue and saturation` | Ziehen, um Farbton und Sättigung zu ändern |
| `Item '%@' not found` | Element '%@' nicht gefunden |
| `Local Network access may be required.` | Möglicherweise ist der Zugriff auf das lokale Netzwerk erforderlich. |
| `Local Network Access Required` | Zugriff auf lokales Netzwerk erforderlich |
| `Open Settings` | Einstellungen öffnen |
| `Sitemap Diagnostics Logging` | Sitemap-Diagnoseprotokollierung |
| `The URL is invalid. Please check the format…` | Die URL ist ungültig. Bitte überprüfen Sie das Format… |
| `To connect to your local openHAB server…` | Um eine Verbindung zu Ihrem lokalen openHAB-Server herzustellen… |

## Test plan

- [ ] Run the app with device language set to German
- [ ] Verify color picker UI shows "Farbrad", "Farbe wählen", "Fertig"
- [ ] Trigger a local network access prompt — alert should appear in German
- [ ] Trigger an invalid URL error — message should appear in German