### PR TITLE
Fix Home re-tap reload and screensaver idle reset

### DIFF
--- a/openHAB/ActivityTrackingApplication.swift
+++ b/openHAB/ActivityTrackingApplication.swift
@@ -1,0 +1,27 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import UIKit
+
+/// Resets the screensaver idle timer on every touch. Wired in via the
+/// `NSPrincipalClass` key in Info.plist.
+final class ActivityTrackingApplication: UIApplication {
+    override func sendEvent(_ event: UIEvent) {
+        super.sendEvent(event)
+
+        guard event.type == .touches,
+              let touches = event.allTouches,
+              touches.contains(where: { $0.phase == .began || $0.phase == .moved || $0.phase == .ended })
+        else { return }
+
+        ScreenSaverManager.shared.noteUserActivity()
+    }
+}

--- a/openHAB/Supporting Files/openHAB-Info.plist
+++ b/openHAB/Supporting Files/openHAB-Info.plist
@@ -77,6 +77,8 @@
 	<string>openHAB needs access to your local network to connect with the openHAB server.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>openHAB needs access to your microphone.</string>
+	<key>NSPrincipalClass</key>
+	<string>$(PRODUCT_MODULE_NAME).ActivityTrackingApplication</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>OpenHABGetItemStateIntent</string>

--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -511,7 +511,8 @@ class OpenHABRootViewController: UIViewController {
             }
             SideMenuManager.default.rightMenuNavigationController?.dismiss(animated: true) { [weak self] in
                 guard let self else { return }
-                if needsSwitch, !webViewController.hasLoadedPage {
+                // Re-tapping Home while already on it reloads.
+                if !needsSwitch || !webViewController.hasLoadedPage {
                     webViewController.reloadView()
                 }
                 transitionCoverView.isHidden = true

--- a/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
+++ b/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
@@ -38,6 +38,8 @@ final class ScreenSaverManager: NSObject {
 
     private var previousBrightness: CGFloat?
 
+    private var lastActivity: Date?
+
     override private init() {
         super.init()
         NotificationCenter.default.addObserver(self, selector: #selector(handleDisableNotification), name: .disableScreenSaver, object: nil)
@@ -48,7 +50,6 @@ final class ScreenSaverManager: NSObject {
     func startMonitoring(window: UIWindow, configuration: ScreenSaverConfiguration = ScreenSaverConfiguration()) {
         self.configuration = configuration
         self.window = window
-        attachGestureRecognizers(to: window)
         resetIdleTimer()
     }
 
@@ -63,21 +64,22 @@ final class ScreenSaverManager: NSObject {
         }
     }
 
-    private func attachGestureRecognizers(to window: UIWindow) {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(userInteracted))
-        tap.cancelsTouchesInView = false
-        tap.delaysTouchesEnded = false
-        tap.delegate = self
-        window.addGestureRecognizer(tap)
+    /// Resets the idle timer on user touches, forwarded from `ActivityTrackingApplication`.
+    func noteUserActivity() {
+        guard configuration.isEnabled else { return }
 
-        let pan = UIPanGestureRecognizer(target: self, action: #selector(userInteracted))
-        pan.cancelsTouchesInView = false
-        pan.delegate = self
-        window.addGestureRecognizer(pan)
-    }
+        if overlayWindow != nil {
+            dismissSaverIfNeeded()
+            resetIdleTimer()
+            lastActivity = Date()
+            return
+        }
 
-    @objc private func userInteracted() {
-        dismissSaverIfNeeded()
+        // Throttle: continuous gestures fire many touches per second.
+        if let last = lastActivity, Date().timeIntervalSince(last) < 1.0 {
+            return
+        }
+        lastActivity = Date()
         resetIdleTimer()
     }
 
@@ -210,10 +212,4 @@ extension Notification.Name {
     static let disableScreenSaver = Notification.Name("disableScreenSaver")
     static let wakeScreenSaver = Notification.Name("wakeScreenSaver")
     static let activateScreenSaver = Notification.Name("activateScreenSaver")
-}
-
-extension ScreenSaverManager: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        true
-    }
 }


### PR DESCRIPTION
Two small regressions i noticed recently, the reload home button stoped working and also the screensaver was not being reset consistently when interacting with the app.