### PR TITLE
fix: avoid NWPathMonitor makeAsyncStream() recursive lock crash on iOS 17

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/NWPathMonitoring.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NWPathMonitoring.swift
@@ -22,15 +22,14 @@ final class RealPathMonitor: NWPathMonitoring, Sendable {
     }
 
     func startMonitoring(handler: @escaping (Bool) async -> Void) async {
-        if #available(iOS 17, watchOS 10, *) {
-            for await path in monitor {
-                Logger.nwPathMonitoring.debug("Path monitor update: \(path.debugDescription)")
-                await handler(path.status == .satisfied || path.status == .requiresConnection)
-            }
-        } else {
-            for await path in monitor.paths() {
-                await handler(path.status == .satisfied || path.status == .requiresConnection)
-            }
+        // Use the manual paths() wrapper on all OS versions.
+        // NWPathMonitor's native iOS 17 AsyncSequence conformance (makeAsyncStream()) has a
+        // re-entrancy bug: startLocked() holds the monitor's os_unfair_lock and calls
+        // AsyncStream.Continuation.finish(), whose onTermination callback tries to re-acquire
+        // the same lock → os_unfair_lock_recursive_abort (crash seen on iOS 17.7.11).
+        for await path in monitor.paths() {
+            Logger.nwPathMonitoring.debug("Path monitor update: \(path.debugDescription)")
+            await handler(path.status == .satisfied || path.status == .requiresConnection)
         }
     }
 
@@ -48,11 +47,8 @@ public protocol NWPathMonitoring: AnyObject, Sendable {
     func cancel()
 }
 
-// MARK: Extension for version iOS <17
+// MARK: - NWPathMonitor AsyncStream wrapper
 
-/// this line breaks availability checking, since watchos 10 is minimum for the app
-/// @available(watchOS, obsoleted: 10.0)
-@available(iOS, obsoleted: 17.0)
 extension NWPathMonitor {
     func paths() -> AsyncStream<NWPath> {
         AsyncStream { continuation in


### PR DESCRIPTION
## Summary

- `NWPathMonitor`'s native iOS 17 `AsyncSequence` conformance (`makeAsyncStream()`) has a re-entrancy bug: `startLocked()` holds the monitor's internal `os_unfair_lock` and calls `AsyncStream.Continuation.finish()`, whose `onTermination` callback tries to re-acquire the same lock → `_os_unfair_lock_recursive_abort` → crash
- Observed in Crashlytics: version 3.2.77 (286), iPad 6th generation, iOS 17.7.11
- Fix: use the manual `paths()` wrapper on all OS versions — it wires up `pathUpdateHandler` + `start(queue:)` directly, bypassing `makeAsyncStream()` entirely
- Also removes the now-unnecessary `@available(iOS, obsoleted: 17.0)` restriction on the `paths()` extension

## Test plan

- [ ] Build and run on a device or simulator running iOS 17
- [ ] Verify path monitor still fires connectivity updates (connect/disconnect from network)
- [ ] Verify no regression on iOS 18+