### PR TITLE
fix: position webview below navigation bar to prevent BasicUI back button from being hidden

### DIFF
--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -6,10 +6,10 @@ devices([
     "iPad Pro 13-inch (M5)"     # 13-inch — required
 ])
 
-#languages([
-#    "en-US",
-#    "de-DE"
-#])
+languages([
+    "en-US",
+    "de-DE"
+])
 
 launch_arguments([
   "-demomode true -iconType 0"

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -538,7 +538,7 @@ class OpenHABWebViewController: OpenHABViewController {
         }
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)


### PR DESCRIPTION
## Summary

- Anchors the `WKWebView` to `view.safeAreaLayoutGuide.topAnchor` instead of `view.topAnchor` in `attachWebViewToLayout`
- Fixes #1272: navigating from a `goFullscreen` page (MainUI) to a BasicUI sub-page left the web view extending behind the visible navigation bar, hiding BasicUI's own navigation header and making the back button unreachable
- The safe area constraint self-corrects via AutoLayout whenever navigation bar visibility changes, so the web content always starts below the bar regardless of the `goFullscreen` state