### PR TITLE
fix: use edgesForExtendedLayout to properly anchor webview below navigation bar

### DIFF
--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -113,6 +113,7 @@ class OpenHABRootViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Logger.viewController.info("OpenHABRootViewController viewDidLoad")
+        edgesForExtendedLayout = []
         setupSideMenu()
         addConnectionStatusIndication()
 
@@ -899,32 +900,20 @@ class OpenHABRootViewController: UIViewController {
 
     func showSideMenu() {
         Logger.viewController.info("OpenHABRootViewController showSideMenu")
-        if let menu = SideMenuManager.default.rightMenuNavigationController {
-            // don't try and push an already visible menu less you crash the app
-            dismiss(animated: false) {
-                var topMostViewController: UIViewController? =
-                    UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.last { $0.isKeyWindow }?.rootViewController
+        guard let menu = SideMenuManager.default.rightMenuNavigationController else { return }
+        guard menu.presentingViewController == nil else { return }
 
-                while let presentedViewController = topMostViewController?.presentedViewController {
-                    topMostViewController = presentedViewController
-                }
-
-                guard let presenter = topMostViewController else {
-                    // swiftformat:disable:next redundantSelf
-                    Logger.viewController.error("No valid view controller found to present side menu")
-                    return
-                }
-
-                // Avoid trying to present the menu on itself
-                if presenter == menu {
-                    // swiftformat:disable:next redundantSelf
-                    Logger.viewController.error("Cannot present side menu on itself")
-                    return
-                }
-
-                presenter.present(menu, animated: true)
-            }
+        var presenter: UIViewController = self
+        while let presentedViewController = presenter.presentedViewController {
+            presenter = presentedViewController
         }
+
+        guard presenter !== menu else {
+            Logger.viewController.error("Cannot present side menu on itself")
+            return
+        }
+
+        presenter.present(menu, animated: true)
     }
 
     private func addView(viewController: UIViewController) {

--- a/openHAB/UI/OpenHABWebViewController.swift
+++ b/openHAB/UI/OpenHABWebViewController.swift
@@ -122,6 +122,7 @@ class OpenHABWebViewController: OpenHABViewController {
 
         loadingOverlay.backgroundColor = .systemBackground
         loadingOverlay.isHidden = true
+        loadingOverlay.isUserInteractionEnabled = false
         loadingOverlay.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(loadingOverlay)
         NSLayoutConstraint.activate([
@@ -134,6 +135,7 @@ class OpenHABWebViewController: OpenHABViewController {
         activityIndicator = UIActivityIndicatorView()
         activityIndicator.center = view.center
         activityIndicator.hidesWhenStopped = true
+        activityIndicator.isUserInteractionEnabled = false
         activityIndicator.style = UIActivityIndicatorView.Style.large
 
         view.addSubview(activityIndicator)
@@ -538,7 +540,7 @@ class OpenHABWebViewController: OpenHABViewController {
         }
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.topAnchor.constraint(equalTo: view.topAnchor),
             webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)


### PR DESCRIPTION
## Summary

Follow-up to #1275 with a more explicit approach to the same fix:

- Sets `edgesForExtendedLayout = []` on `OpenHABRootViewController` so the view frame starts below the navigation bar rather than extending behind it — making `view.topAnchor` in the child `OpenHABWebViewController` naturally land at the nav-bar bottom without needing the safe area layout guide
- Disables user interaction on `loadingOverlay` and `activityIndicator` so they cannot block touches on the navigation bar back button during page loads
- Simplifies `showSideMenu` presentation logic: replaces the `dismiss`-then-find-top-presenter pattern with a direct walk up the presented-VC chain from `self`