### PR TITLE
Widget adjustments

### DIFF
--- a/openHABWidget/OpenHABIconOverlay.swift
+++ b/openHABWidget/OpenHABIconOverlay.swift
@@ -16,18 +16,11 @@ import SwiftUI
 // MARK: - Shared Icon Overlay
 
 struct OpenHABIconOverlay: View {
-    let size: CGFloat
-    var leadingPadding: CGFloat = 14
-    var topPadding: CGFloat = 14
-
     var body: some View {
         Image("openHABIcon")
             .resizable()
             .scaledToFit()
-            .frame(width: size, height: size)
-            .opacity(0.5)
-            .padding(.leading, leadingPadding)
-            .padding(.top, topPadding)
+            .opacity(0.1)
     }
 }
 

--- a/openHABWidget/SensorWidgetEntryView.swift
+++ b/openHABWidget/SensorWidgetEntryView.swift
@@ -182,9 +182,10 @@ private struct SensorItemRow: View {
             Text(label)
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+                .lineLimit(2)
+                .layoutPriority(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
             Text(formattedState(for: item))
                 .font(.subheadline)
                 .fontWeight(.semibold)
@@ -202,16 +203,19 @@ struct SensorSmallWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(10)
+
             if let slot = entry.slots.compactMap(\.self).first {
                 let item = slot.item
                 let label = item.label.isEmpty ? item.name : item.label
                 VStack(spacing: 8) {
                     Text(label)
                         .font(.headline)
-                        .lineLimit(1)
+                        .lineLimit(3)
                         .minimumScaleFactor(0.7)
                         .padding(.top, 20)
-
                     Spacer()
 
                     Text(formattedState(for: item))
@@ -230,8 +234,6 @@ struct SensorSmallWidgetView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding()
             }
-
-            OpenHABIconOverlay(size: 16)
         }
     }
 }
@@ -243,6 +245,10 @@ struct SensorMediumWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(10)
+
             let filledSlots = entry.slots.compactMap(\.self)
             if filledSlots.isEmpty {
                 UnconfiguredPlaceholder()
@@ -253,7 +259,7 @@ struct SensorMediumWidgetView: View {
                     ForEach(filledSlots.indices, id: \.self) { index in
                         SensorItemRow(slot: filledSlots[index])
                             .padding(.horizontal)
-                            .padding(.vertical, 10)
+                            .padding(.vertical, 12)
                         if index < filledSlots.count - 1 {
                             Divider()
                                 .padding(.leading)
@@ -261,10 +267,7 @@ struct SensorMediumWidgetView: View {
                     }
                 }
                 .frame(maxHeight: .infinity)
-                .padding(.top, 22)
             }
-
-            OpenHABIconOverlay(size: 18)
         }
     }
 }
@@ -276,6 +279,10 @@ struct SensorLargeWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(14)
+
             let filledSlots = entry.slots.compactMap(\.self)
             if filledSlots.isEmpty {
                 VStack(alignment: .center, spacing: 16) {
@@ -305,10 +312,7 @@ struct SensorLargeWidgetView: View {
                     }
                 }
                 .frame(maxHeight: .infinity)
-                .padding(.top, 22)
             }
-
-            OpenHABIconOverlay(size: 20)
         }
     }
 }

--- a/openHABWidget/SwitchWidgetEntryView.swift
+++ b/openHABWidget/SwitchWidgetEntryView.swift
@@ -194,9 +194,10 @@ private struct SwitchItemRow: View {
             Text(label)
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+                .lineLimit(2)
+                .layoutPriority(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
             if let home {
                 Toggle(isOn: isOn, intent: createToggleIntent(item: item, homeUUID: slot.homeUUID, home: home)) {}
                     .toggleStyle(PowerButtonToggleStyle(diameter: 36, showStateLabel: false))
@@ -236,12 +237,16 @@ struct SwitchSmallWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(10)
+
             if let slot = entry.slots.compactMap(\.self).first {
                 let label = slot.item.label.isEmpty ? slot.item.name : slot.item.label
                 VStack(spacing: 8) {
                     Text(label)
                         .font(.headline)
-                        .lineLimit(1)
+                        .lineLimit(3)
                         .minimumScaleFactor(0.7)
                         .padding(.top, 20)
                     Spacer()
@@ -268,8 +273,6 @@ struct SwitchSmallWidgetView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding()
             }
-
-            OpenHABIconOverlay(size: 16)
         }
     }
 }
@@ -281,6 +284,10 @@ struct SwitchMediumWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(10)
+
             let filledSlots = Array(entry.slots.compactMap(\.self))
             if filledSlots.isEmpty {
                 UnconfiguredPlaceholder()
@@ -299,10 +306,7 @@ struct SwitchMediumWidgetView: View {
                     }
                 }
                 .frame(maxHeight: .infinity)
-                .padding(.top, 22)
             }
-
-            OpenHABIconOverlay(size: 18)
         }
     }
 }
@@ -314,6 +318,10 @@ struct SwitchLargeWidgetView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
+            OpenHABIconOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(14)
+
             let filledSlots = Array(entry.slots.compactMap(\.self))
             if filledSlots.isEmpty {
                 VStack(alignment: .center, spacing: 16) {
@@ -343,10 +351,7 @@ struct SwitchLargeWidgetView: View {
                     }
                 }
                 .frame(maxHeight: .infinity)
-                .padding(.top, 22)
             }
-
-            OpenHABIconOverlay(size: 20)
         }
     }
 }


### PR DESCRIPTION
Widget adjustments, with
• openHAB logo in larg size as watermark in the background
• allow for 2 line labels, especially also for accessibility larger text settings