### PR TITLE
fix: animate GIFs in the Image sitemap widget

### DIFF
--- a/CommonUI/Sources/CommonUI/KFImageExtension.swift
+++ b/CommonUI/Sources/CommonUI/KFImageExtension.swift
@@ -12,10 +12,10 @@
 import Kingfisher
 import OpenHABCore
 
-public extension KFImage {
+public extension KFImageProtocol {
     /// Applies the openHAB Basic Auth request modifier when a connection is available.
     /// When `connection` is nil no modifier is attached and the image loads unauthenticated.
-    func withOpenHABCredentials(for connection: ConnectionInfo?) -> KFImage {
+    func withOpenHABCredentials(for connection: ConnectionInfo?) -> Self {
         guard let connection else { return self }
         return requestModifier(OpenHABAccessTokenAdapter(connectionConfiguration: connection.configuration))
     }

--- a/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
@@ -165,36 +165,67 @@ private struct ImageRowContent: View {
                 .frame(maxHeight: 300)
                 .clipShape(.rect(cornerRadius: 8))
         case let .link(url):
-            KFImage(url)
-                .withOpenHABCredentials(for: networkTracker.activeConnection)
-                .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
-                .placeholder {
-                    if let state = lastRegularImageState, state.url == url {
-                        Image(uiImage: state.image)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    } else {
-                        Color.gray.opacity(0.1)
-                            .frame(height: 200)
-                            .clipShape(.rect(cornerRadius: 8))
+            if url?.pathExtension.lowercased() == "gif" {
+                KFAnimatedImage(url)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
+                    .configure { $0.contentMode = .scaleAspectFit }
+                    .placeholder {
+                        if let state = lastRegularImageState, state.url == url {
+                            Image(uiImage: state.image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } else {
+                            Color.gray.opacity(0.1)
+                                .frame(height: 200)
+                                .clipShape(.rect(cornerRadius: 8))
+                        }
                     }
-                }
-                .onSuccess { result in
-                    lastRegularImageState = RegularImageState(url: url, image: result.image)
-                }
-                .onFailure { error in
-                    guard !error.isTaskCancelled else { return }
-                    logger.warning("Image fetch failed for \(url?.absoluteString ?? "nil", privacy: .public): \(error.localizedDescription, privacy: .public)")
-                }
-                .fade(duration: 0)
-                .resizable()
-                .cacheMemoryOnly(!shouldCache)
-                .forceRefresh(shouldCache ? false : true)
-                .cacheOriginalImage(!shouldCache ? false : true)
-                .id(shouldCache ? url?.absoluteString : "\(url?.absoluteString ?? "")-\(forceRefreshKey)")
-                .aspectRatio(contentMode: .fit)
-                .frame(maxHeight: 300)
-                .clipShape(.rect(cornerRadius: 8))
+                    .onSuccess { result in
+                        lastRegularImageState = RegularImageState(url: url, image: result.image)
+                    }
+                    .onFailure { error in
+                        guard !error.isTaskCancelled else { return }
+                        logger.warning("Image fetch failed for \(url?.absoluteString ?? "nil", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
+                    .fade(duration: 0)
+                    .cacheMemoryOnly(!shouldCache)
+                    .forceRefresh(shouldCache ? false : true)
+                    .cacheOriginalImage(!shouldCache ? false : true)
+                    .id(shouldCache ? url?.absoluteString : "\(url?.absoluteString ?? "")-\(forceRefreshKey)")
+                    .frame(maxHeight: 300)
+                    .clipShape(.rect(cornerRadius: 8))
+            } else {
+                KFImage(url)
+                    .withOpenHABCredentials(for: networkTracker.activeConnection)
+                    .setProcessor(OpenHABImageProcessor(svgMaxSize: nil))
+                    .placeholder {
+                        if let state = lastRegularImageState, state.url == url {
+                            Image(uiImage: state.image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } else {
+                            Color.gray.opacity(0.1)
+                                .frame(height: 200)
+                                .clipShape(.rect(cornerRadius: 8))
+                        }
+                    }
+                    .onSuccess { result in
+                        lastRegularImageState = RegularImageState(url: url, image: result.image)
+                    }
+                    .onFailure { error in
+                        guard !error.isTaskCancelled else { return }
+                        logger.warning("Image fetch failed for \(url?.absoluteString ?? "nil", privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
+                    .fade(duration: 0)
+                    .resizable()
+                    .cacheMemoryOnly(!shouldCache)
+                    .forceRefresh(shouldCache ? false : true)
+                    .cacheOriginalImage(!shouldCache ? false : true)
+                    .id(shouldCache ? url?.absoluteString : "\(url?.absoluteString ?? "")-\(forceRefreshKey)")
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: 300)
+                    .clipShape(.rect(cornerRadius: 8))
+            }
         case .empty:
             Rectangle()
                 .fill(Color.gray.opacity(0.3))


### PR DESCRIPTION
## Summary

- `KFImage` decodes animated GIFs into a static `UIImage` (first frame only) because the image data passes through `OpenHABImageProcessor`, which always returns a single `UIImage`
- For URLs with a `.gif` extension, switch to `KFAnimatedImage` — it delivers raw data to `AnimatedImageView` which handles frame playback natively
- The existing `KFImage` + `OpenHABImageProcessor` path is preserved for all other image types (SVG support intact)
- Broadened `withOpenHABCredentials` from `extension KFImage` to `extension KFImageProtocol` so it covers `KFAnimatedImage` without duplication

## Test plan

- [ ] Add an `Image` widget to a sitemap pointing at an animated GIF (e.g. `Image url="https://www.dwd.de/DWD/wetter/radar/radfilm_bay_akt.gif"`) and confirm it animates
- [ ] Confirm a static image URL (JPEG/PNG) still loads correctly
- [ ] Confirm an SVG icon URL still renders correctly (SVG path uses `KFImage` + `OpenHABImageProcessor`)
- [ ] Confirm a widget with `refresh` set still refreshes at the correct interval