### PR TITLE
fix: remove UIImageView polling timer from MJPEG video stream

### DIFF
--- a/openHAB/UI/SimpleMJPEGPlayer.swift
+++ b/openHAB/UI/SimpleMJPEGPlayer.swift
@@ -19,24 +19,10 @@ final class SimpleMJPEGPlayer {
     private var streamTask: URLSessionDataTask?
     private var httpClient: HTTPClient?
     private var delegate: SimpleMJPEGStreamDelegate?
-    private var imageView: UIImageView
 
+    var onFrame: (@MainActor (UIImage) -> Void)?
     var onFirstFrame: ((CGFloat) -> Void)?
     var onError: ((any Error) -> Void)?
-
-    init(imageView: UIImageView) {
-        self.imageView = imageView
-    }
-
-    func updateImageView(_ newImageView: UIImageView, onFirstFrame: ((CGFloat) -> Void)? = nil, onError: ((any Error) -> Void)? = nil) {
-        imageView = newImageView
-        if let onFirstFrame {
-            self.onFirstFrame = onFirstFrame
-        }
-        if let onError {
-            self.onError = onError
-        }
-    }
 
     func play(url: URL) {
         stop()
@@ -50,11 +36,9 @@ final class SimpleMJPEGPlayer {
             connectionConfiguration: config,
             onFrame: { [weak self] image, isFirst in
                 guard let self else { return }
-                imageView.image = image
-
+                onFrame?(image)
                 if isFirst {
-                    let aspectRatio = image.size.width / image.size.height
-                    onFirstFrame?(aspectRatio)
+                    onFirstFrame?(image.size.width / image.size.height)
                 }
             },
             onError: { [weak self] error in
@@ -77,7 +61,15 @@ final class SimpleMJPEGPlayer {
         streamTask = nil
         httpClient = nil
         delegate = nil
-        // Don't clear the image view when stopping - this allows sharing between cells
-        // The VideoStreamManager will handle proper cleanup
+    }
+
+    func updateCallbacks(
+        onFrame: (@MainActor (UIImage) -> Void)?,
+        onFirstFrame: ((CGFloat) -> Void)?,
+        onError: ((any Error) -> Void)?
+    ) {
+        if let onFrame { self.onFrame = onFrame }
+        if let onFirstFrame { self.onFirstFrame = onFirstFrame }
+        if let onError { self.onError = onError }
     }
 }

--- a/openHAB/UI/SwiftUI/Rows/VideoRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/VideoRowView.swift
@@ -38,7 +38,6 @@ private struct VideoRowContent: View {
     @State private var aspectRatio: CGFloat = 16.0 / 9.0
     @State private var isLoading = false
     @State private var currentStreamUrl: URL?
-    @State private var imageObservationTimer: Timer?
     @State private var playerObserver: NSKeyValueObservation?
 
     private let logger = Logger(subsystem: "org.openhab", category: "VideoRowView")
@@ -65,7 +64,6 @@ private struct VideoRowContent: View {
             if let videoURL {
                 ZStack {
                     if isMJPEG {
-                        // MJPEG display using UIImageView
                         if let mjpegImage {
                             Image(uiImage: mjpegImage)
                                 .resizable()
@@ -151,49 +149,21 @@ private struct VideoRowContent: View {
 
     @MainActor
     private func setupMJPEG(url: URL) {
-        // Create a dummy UIImageView for the SimpleMJPEGPlayer
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-
         mjpegPlayer = VideoStreamManager.shared.getOrCreateStream(
             for: url,
-            imageView: imageView,
-            onFirstFrame: { newAspectRatio in
-                Task { @MainActor in
-                    aspectRatio = newAspectRatio
-                    isLoading = false
-                }
+            onFrame: { image in
+                mjpegImage = image
+                if isLoading { isLoading = false }
             },
-            onError: { error in
-                Task { @MainActor in
-                    logger.debug("MJPEG stream error: \(error.localizedDescription)")
-                    isLoading = false
-                }
+            onFirstFrame: { newAspectRatio in
+                aspectRatio = newAspectRatio
+                isLoading = false
+            },
+            onError: { [logger] error in
+                logger.debug("MJPEG stream error: \(error.localizedDescription)")
+                isLoading = false
             }
         )
-
-        // Observe image changes on the UIImageView
-        startImageObservation(imageView: imageView)
-    }
-
-    @MainActor
-    private func startImageObservation(imageView: UIImageView) {
-        imageObservationTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { _ in
-            DispatchQueue.main.async {
-                if mjpegPlayer == nil {
-                    imageObservationTimer?.invalidate()
-                    imageObservationTimer = nil
-                    return
-                }
-
-                if let image = imageView.image {
-                    mjpegImage = image
-                    if isLoading {
-                        isLoading = false
-                    }
-                }
-            }
-        }
     }
 
     private func setupHLS(url: URL) {
@@ -223,10 +193,6 @@ private struct VideoRowContent: View {
     }
 
     private func cleanup() {
-        // Clean up timer
-        imageObservationTimer?.invalidate()
-        imageObservationTimer = nil
-
         // Clean up HLS observer
         playerObserver = nil
 

--- a/openHAB/UI/Widgets/VideoStreamManager.swift
+++ b/openHAB/UI/Widgets/VideoStreamManager.swift
@@ -23,27 +23,30 @@ final class VideoStreamManager {
 
     private init() {}
 
-    func getOrCreateStream(for url: URL, imageView: UIImageView, onFirstFrame: ((CGFloat) -> Void)?, onError: ((any Error) -> Void)?) -> SimpleMJPEGPlayer {
+    func getOrCreateStream(
+        for url: URL,
+        onFrame: @escaping @MainActor (UIImage) -> Void,
+        onFirstFrame: ((CGFloat) -> Void)?,
+        onError: ((any Error) -> Void)?
+    ) -> SimpleMJPEGPlayer {
         let key = url.absoluteString
 
         if let existingPlayer = activeStreams[key] {
-            // Update the image view target for existing stream
-            existingPlayer.updateImageView(imageView, onFirstFrame: onFirstFrame, onError: onError)
+            existingPlayer.updateCallbacks(onFrame: onFrame, onFirstFrame: onFirstFrame, onError: onError)
             streamReferenceCounts[key] = (streamReferenceCounts[key] ?? 0) + 1
             // swiftformat:disable:next redundantSelf
             Logger.widgets.debug("Reusing existing stream for URL: \(key), refs: \(self.streamReferenceCounts[key] ?? 0)")
             return existingPlayer
         }
 
-        // Create new stream
-        let player = SimpleMJPEGPlayer(imageView: imageView)
+        let player = SimpleMJPEGPlayer()
+        player.onFrame = onFrame
         player.onFirstFrame = onFirstFrame
         player.onError = onError
 
         activeStreams[key] = player
         streamReferenceCounts[key] = 1
 
-        // Start playing the stream
         player.play(url: url)
 
         Logger.widgets.debug("Created new stream for URL: \(key)")
@@ -64,7 +67,6 @@ final class VideoStreamManager {
         Logger.widgets.debug("Released stream reference for URL: \(key), remaining refs: \(newCount)")
 
         if newCount <= 0 {
-            // No more references, clean up the stream
             if let player = activeStreams[key] {
                 player.stop()
                 Logger.widgets.debug("Stopped and removed stream for URL: \(key)")


### PR DESCRIPTION
## Summary

- Removes the dummy `UIImageView` + 30fps `Timer` polling pattern from `VideoRowView` that was delivering MJPEG frames via `UIImageView.image`
- `SimpleMJPEGPlayer` now exposes an `@MainActor onFrame: (UIImage) -> Void` callback instead of holding a `UIImageView`
- `VideoStreamManager.getOrCreateStream` takes an `onFrame` closure instead of a `UIImageView`
- `VideoRowView` passes the closure directly, removing `imageObservationTimer`, `startImageObservation(imageView:)`, and all associated `DispatchQueue.main.async` bridging

This also fixes the `__NSThreadPerformPerform` crash seen in Crashlytics (3.3.2), where `performSelector` was delivered to a deallocated `UIImageView` after the view had been torn down.

## Test plan

- [ ] Open a sitemap page with an MJPEG video widget — stream should display and update
- [ ] Navigate away and back — stream should stop and restart cleanly
- [ ] Verify no timer-related log noise or memory leaks