### PR TITLE
Allow for two lines label and value for iOS Lock Screen Accessories

### DIFF
--- a/openHABWidget/SensorWidgetEntryView.swift
+++ b/openHABWidget/SensorWidgetEntryView.swift
@@ -332,8 +332,9 @@ struct SensorAccessoryCircularView: View {
                     Text(formattedState(for: slot.item))
                         .font(.caption2)
                         .fontWeight(.bold)
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .minimumScaleFactor(0.5)
+                        .multilineTextAlignment(.center)
                 }
             } else {
                 Image(systemSymbol: .gear)
@@ -353,7 +354,7 @@ struct SensorAccessoryRectangularView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(label)
                     .font(.headline)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .minimumScaleFactor(0.7)
                 if item.state != nil {
                     Text(formattedState(for: item))

--- a/openHABWidget/SwitchWidgetEntryView.swift
+++ b/openHABWidget/SwitchWidgetEntryView.swift
@@ -427,7 +427,7 @@ struct SwitchAccessoryRectangularView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(label)
                         .font(.headline)
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .minimumScaleFactor(0.7)
                     if let stateText = slot.item.state {
                         Text(stateText)


### PR DESCRIPTION
Allow for two lines longer label and value for iOS Lock Screen Circular and Rectangle Accessories

<img width="93" height="82" alt="Screenshot 2026-07-03 at 23 45 10" src="https://github.com/user-attachments/assets/4485cab9-2a0b-4a9b-a1e2-e5b4ed631b84" />
<img width="151" height="71" alt="Screenshot 2026-07-04 at 00 55 47" src="https://github.com/user-attachments/assets/7fe1c1e3-426a-433d-a8cd-98e3bb0e11b1" />
<img width="132" height="68" alt="Screenshot 2026-07-04 at 00 54 00" src="https://github.com/user-attachments/assets/cec6392b-411a-4109-a140-544c17f9d11b" />
