### PR TITLE
feat: add CarPlay support with sitemap-based favorites scene

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/LoggerExtension.swift
@@ -19,6 +19,8 @@ public extension Logger {
 
     static let appDelegate = Logger(subsystem: subsystem, category: "AppDelegate")
 
+    static let carPlay = Logger(subsystem: subsystem, category: "CarPlay")
+
     static let clientCert = Logger(subsystem: subsystem, category: "ClientCert")
 
     static let connectionFailureTracker = Logger(subsystem: subsystem, category: "ConnectionFailureTracker")

--- a/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Preferences.swift
@@ -103,6 +103,7 @@ public struct HomePreferences: Codable, Equatable {
     public var sitemapForWatchLabel = "watch"
     public var homeName = "Home#1"
     public var sseCommandItem = ""
+    public var sitemapForCarPlay = ""
 
     fileprivate init(id: UUID) {
         self.id = id
@@ -132,6 +133,7 @@ public struct HomePreferences: Codable, Equatable {
         sitemapForWatchLabel = try container.decodeIfPresent(String.self, forKey: .sitemapForWatchLabel) ?? "watch"
         homeName = try container.decodeIfPresent(String.self, forKey: .homeName) ?? "Home#1"
         sseCommandItem = try container.decodeIfPresent(String.self, forKey: .sseCommandItem) ?? ""
+        sitemapForCarPlay = try container.decodeIfPresent(String.self, forKey: .sitemapForCarPlay) ?? ""
     }
 }
 

--- a/openHAB.xcodeproj/project.pbxproj
+++ b/openHAB.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		657144962C30A16700C8A1F3 /* OpenHABCore in Frameworks */ = {isa = PBXBuildFile; productRef = 657144952C30A16700C8A1F3 /* OpenHABCore */; };
 		73F094A3C17641738D6215CD /* SetSwitchItemIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD5E85B2F02C272003215C0 /* SetSwitchItemIntent.swift */; };
 		791AFA47B71D4B6995369F3A /* GetItemStateIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4BF3512F0307A40082479C /* GetItemStateIntent.swift */; };
+		856AA30C33F548E58EA00F6C /* CarPlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F572C79726447B8B9C40B49 /* CarPlay.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		934E592528F16EBA00162004 /* OpenHABCore in Frameworks */ = {isa = PBXBuildFile; productRef = 934E592428F16EBA00162004 /* OpenHABCore */; };
 		934E592728F16EBA00162004 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 934E592628F16EBA00162004 /* Kingfisher */; };
 		937E4471270B36D000A98C26 /* OpenHABCore in Frameworks */ = {isa = PBXBuildFile; productRef = 937E4470270B36D000A98C26 /* OpenHABCore */; };
@@ -229,6 +230,7 @@
 		657144502C1E438700C8A1F3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		657144522C1E438700C8A1F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		657144972C30A3E300C8A1F3 /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
+		6F572C79726447B8B9C40B49 /* CarPlay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CarPlay.framework; path = System/Library/Frameworks/CarPlay.framework; sourceTree = SDKROOT; };
 		933D7F0422E7015000621A03 /* openHABUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = openHABUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		933D7F0622E7015000621A03 /* OpenHABUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenHABUITests.swift; sourceTree = "<group>"; };
 		933D7F0822E7015100621A03 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -515,6 +517,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				856AA30C33F548E58EA00F6C /* CarPlay.framework in Frameworks */,
 				6557AF922C039D140094D0C8 /* FirebaseMessaging in Frameworks */,
 				DFB2622B18830A3600D3244D /* Foundation.framework in Frameworks */,
 				DABB5E332D98972F009A4B8A /* SDWebImageSVGCoder in Frameworks */,
@@ -724,6 +727,7 @@
 			isa = PBXGroup;
 			children = (
 				032C4C3A922FABCBEB20EAA3 /* AppIntents */,
+				6F572C79726447B8B9C40B49 /* CarPlay.framework */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 
 import AVFoundation
+import CarPlay
 import Combine
 import Firebase
 import FirebaseMessaging
@@ -233,7 +234,12 @@ extension Notification.Name {
 
 extension AppDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        switch connectingSceneSession.role {
+        case .carTemplateApplication:
+            UISceneConfiguration(name: "CarPlay Configuration", sessionRole: connectingSceneSession.role)
+        default:
+            UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        }
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {}

--- a/openHAB/CarPlaySceneDelegate.swift
+++ b/openHAB/CarPlaySceneDelegate.swift
@@ -1,0 +1,189 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import CarPlay
+import OpenHABCore
+import os.log
+
+private let carPlayMaxItems = 8
+
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+    private var interfaceController: CPInterfaceController?
+    private var streamTask: Task<Void, Never>?
+    private var preferencesTask: Task<Void, Never>?
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                  didConnect interfaceController: CPInterfaceController) {
+        self.interfaceController = interfaceController
+        interfaceController.setRootTemplate(placeholderTemplate(), animated: false, completion: nil)
+        startStreaming()
+        startObservingPreferences()
+        Logger.carPlay.info("CarPlay scene connected")
+    }
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                  didDisconnectInterfaceController interfaceController: CPInterfaceController) {
+        streamTask?.cancel()
+        streamTask = nil
+        preferencesTask?.cancel()
+        preferencesTask = nil
+        self.interfaceController = nil
+        Logger.carPlay.info("CarPlay scene disconnected")
+    }
+
+    // MARK: - Streaming
+
+    private func startStreaming() {
+        streamTask?.cancel()
+        streamTask = Task { [weak self] in
+            await self?.runStream()
+        }
+    }
+
+    private func startObservingPreferences() {
+        preferencesTask?.cancel()
+        preferencesTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var lastSitemap = Preferences.shared.currentHomePreferences.sitemapForCarPlay
+            for await _ in NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification) {
+                guard !Task.isCancelled else { break }
+                let newSitemap = Preferences.shared.currentHomePreferences.sitemapForCarPlay
+                guard newSitemap != lastSitemap else { continue }
+                lastSitemap = newSitemap
+                startStreaming()
+            }
+        }
+    }
+
+    @MainActor
+    private func runStream() async {
+        guard let connection = await NetworkTracker.shared.waitForActiveConnection() else {
+            Logger.carPlay.warning("CarPlay: no active connection")
+            return
+        }
+        let sitemapName = Preferences.shared.currentHomePreferences.sitemapForCarPlay
+        guard !sitemapName.isEmpty else {
+            Logger.carPlay.info("CarPlay: no sitemap configured")
+            return
+        }
+        do {
+            let service = try OpenAPIService(connectionConfiguration: connection.configuration)
+            for try await event in SitemapPageLoader.stream(sitemapName: sitemapName, service: service) {
+                guard !Task.isCancelled else { break }
+                let page: OpenHABPage? = switch event {
+                case let .initialFetch(page): page
+                case let .longPoll(page, _): page
+                }
+                if let page { updateTemplate(page: page, service: service) }
+            }
+        } catch {
+            Logger.carPlay.error("CarPlay stream error: \(error)")
+        }
+    }
+
+    // MARK: - Template building
+
+    @MainActor
+    private func updateTemplate(page: OpenHABPage, service: OpenAPIService) {
+        let items = page.widgets
+            .filter { $0.visibility && isCarPlayCompatible($0) }
+            .prefix(carPlayMaxItems)
+            .map { makeItem(for: $0, service: service) }
+
+        let section = CPListSection(items: Array(items))
+        let template = CPListTemplate(title: "openHAB", sections: [section])
+        interfaceController?.setRootTemplate(template, animated: false, completion: nil)
+    }
+
+    private func isCarPlayCompatible(_ widget: OpenHABWidget) -> Bool {
+        switch widget.type {
+        case .switchWidget, .text, .button, .selection: true
+        default: false
+        }
+    }
+
+    private func makeItem(for widget: OpenHABWidget, service: OpenAPIService) -> CPListItem {
+        let ds = widget.displayState
+
+        switch widget.type {
+        case .switchWidget where !ds.mappings.isEmpty:
+            let item = CPListItem(text: ds.labelText, detailText: ds.selectedLabel ?? ds.labelValue)
+            item.accessoryType = .disclosureIndicator
+            item.handler = { [weak self] _, done in
+                self?.pushMappingList(title: ds.labelText, mappings: ds.mappings, widget: widget, service: service)
+                done()
+            }
+            return item
+
+        case .switchWidget:
+            let item = CPListItem(text: ds.labelText, detailText: ds.isOn ? "ON" : "OFF")
+            item.handler = { _, done in
+                Task {
+                    guard let name = widget.item?.name else { return }
+                    try? await service.sendItemCommand(itemname: name, command: ds.isOn ? "OFF" : "ON")
+                }
+                done()
+            }
+            return item
+
+        case .button:
+            let item = CPListItem(text: ds.labelText, detailText: ds.labelValue)
+            item.handler = { _, done in
+                Task {
+                    guard let name = widget.item?.name, let command = widget.command else { return }
+                    try? await service.sendItemCommand(itemname: name, command: command)
+                }
+                done()
+            }
+            return item
+
+        case .selection:
+            let item = CPListItem(text: ds.labelText, detailText: ds.selectedLabel ?? ds.labelValue)
+            item.accessoryType = .disclosureIndicator
+            item.handler = { [weak self] _, done in
+                self?.pushMappingList(title: ds.labelText, mappings: ds.mappings, widget: widget, service: service)
+                done()
+            }
+            return item
+
+        default:
+            return CPListItem(text: ds.labelText, detailText: ds.labelValue)
+        }
+    }
+
+    private func pushMappingList(title: String,
+                                 mappings: [OpenHABWidgetMapping],
+                                 widget: OpenHABWidget,
+                                 service: OpenAPIService) {
+        let items = mappings.map { mapping -> CPListItem in
+            let item = CPListItem(text: mapping.label, detailText: nil)
+            item.handler = { [weak self] _, done in
+                Task {
+                    guard let name = widget.item?.name else { return }
+                    try? await service.sendItemCommand(itemname: name, command: mapping.command)
+                }
+                self?.interfaceController?.popTemplate(animated: true, completion: nil)
+                done()
+            }
+            return item
+        }
+        let template = CPListTemplate(title: title, sections: [CPListSection(items: items)])
+        interfaceController?.pushTemplate(template, animated: true, completion: nil)
+    }
+
+    private func placeholderTemplate() -> CPListTemplate {
+        let item = CPListItem(
+            text: String(localized: "carplay_not_configured"),
+            detailText: String(localized: "carplay_not_configured_detail")
+        )
+        return CPListTemplate(title: "openHAB", sections: [CPListSection(items: [item])])
+    }
+}

--- a/openHAB/Supporting Files/Localizable.xcstrings
+++ b/openHAB/Supporting Files/Localizable.xcstrings
@@ -83,8 +83,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -101,8 +101,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -113,8 +113,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " - "
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -136,18 +136,6 @@
             "value" : "%@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -160,19 +148,7 @@
             "value" : "%@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
-        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -197,14 +173,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -221,8 +197,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -233,8 +209,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "/overview/"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -248,18 +224,6 @@
             "value" : "%@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -272,19 +236,7 @@
             "value" : "%@"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
         "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
-          }
-        },
-        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -321,14 +273,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes de %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-asetukset"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -345,8 +297,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-innstillinger"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -357,8 +309,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -380,14 +332,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valor de %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -404,8 +356,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@-verdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -416,8 +368,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Значение %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -439,14 +391,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -463,8 +415,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -475,8 +427,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -498,14 +450,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -522,8 +474,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -534,8 +486,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldK"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -557,14 +509,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reloj de 24 horas"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "24 tunnin kello"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -581,8 +533,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "24-timers klokke"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -593,8 +545,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "24-часовые часы"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -674,14 +626,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificados de servidor aceptados"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hyväksytyt palvelinvarmenteet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -698,8 +650,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Godkjente serversertifikater"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -710,8 +662,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Принятые сертификаты сервера"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -739,8 +691,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toiminto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -769,8 +721,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Действие"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -913,14 +865,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadido: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lisätty: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -937,8 +889,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lagt til: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -949,8 +901,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавлено: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -978,8 +930,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aina"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -996,8 +948,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alltid"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1008,8 +960,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всегда"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1031,14 +983,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir WebRTC siempre"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salli WebRTC aina"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1055,8 +1007,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tillat alltid WebRTC"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1067,8 +1019,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всегда разрешать WebRTC"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1090,14 +1042,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar credenciales siempre"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähetä tunnistetiedot aina"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1114,8 +1066,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send alltid legitimasjon"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1126,8 +1078,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всегда отправлять учётные данные"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1267,14 +1219,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animaatio"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1291,8 +1243,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animasjon"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1303,8 +1255,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анимация"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1326,14 +1278,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de la aplicación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sovelluksen versio"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1350,8 +1302,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-versjon"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1362,8 +1314,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия приложения"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1450,8 +1402,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ulkoasu"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1468,8 +1420,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utseende"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1480,8 +1432,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Внешний вид"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1567,8 +1519,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Takaisin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1585,8 +1537,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilbake"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1597,14 +1549,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Назад"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Begin" : {
-      "comment" : "The action to play music.",
+      "comment" : "User action to start or resume playback.",
       "isCommentAutoGenerated" : true
     },
     "bonjour_discovery_disclaimer" : {
@@ -1688,8 +1640,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kirkkaus"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1706,8 +1658,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lysstyrke"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1718,8 +1670,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Яркость"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1863,8 +1815,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peruuta"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1881,8 +1833,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbryt"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1893,8 +1845,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1916,14 +1868,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se produjo una cancelación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peruutus tapahtui"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1940,8 +1892,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbrudd inntraff"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -1952,8 +1904,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Произошла отмена"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -1974,14 +1926,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luz de vela"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kynttilänvalo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -1998,8 +1950,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stearinlys"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2010,8 +1962,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Свет свечи"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2033,14 +1985,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede conectar al servidor. ¿Está en línea?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhteyden muodostaminen palvelimeen epäonnistui. Onko se verkossa?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2057,8 +2009,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan ikke koble til serveren. Er den online?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2069,8 +2021,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удаётся подключиться к серверу. Он в сети?"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2092,14 +2044,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede encontrar el servidor. ¿Es correcta la URL?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palvelinta ei löydy. Onko URL oikein?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2116,8 +2068,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan ikke finne serveren. Er URL-en riktig?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2128,8 +2080,30 @@
         },
         "ru" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "carplay_not_configured" : {
+      "comment" : "CarPlay root list placeholder shown before a CarPlay favorites page is set up.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удаётся найти сервер. URL верный?"
+            "value" : "No CarPlay favorites configured"
+          }
+        }
+      }
+    },
+    "carplay_not_configured_detail" : {
+      "comment" : "CarPlay root list placeholder detail text shown before a CarPlay favorites page is set up.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set up a CarPlay sitemap page in Settings"
           }
         }
       }
@@ -2368,7 +2342,7 @@
       }
     },
     "Change" : {
-      "comment" : "Display representation for the toggle action.",
+      "comment" : "Display name for the toggle action.",
       "isCommentAutoGenerated" : true
     },
     "Check & Clear Image Cache" : {
@@ -2388,14 +2362,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobar y limpiar caché de imágenes"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarkista ja tyhjennä kuvavälimuisti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2412,8 +2386,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sjekk og tøm bildebuffer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2424,8 +2398,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить и очистить кэш изображений"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2440,18 +2414,6 @@
             "value" : "Farbe wählen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elegir color"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valitse väri"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2464,22 +2426,10 @@
             "value" : "Scegli colore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg farge"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleur kiezen"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать цвет"
           }
         }
       }
@@ -2507,8 +2457,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2525,8 +2475,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tøm"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2537,8 +2487,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2560,14 +2510,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpiar caché web"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä verkkovälimuisti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2584,8 +2534,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tøm nettbuffer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2596,8 +2546,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить веб-кэш"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2737,14 +2687,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certificados de cliente"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asiakasvarmenteet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2761,8 +2711,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klientsertifikater"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2773,8 +2723,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Клиентские сертификаты"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -2854,14 +2804,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamaño del reloj: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kellon koko: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -2878,8 +2828,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klokkestørrelse: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -2890,8 +2840,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Размер часов: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3003,8 +2953,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрыто"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3032,8 +2982,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Väri"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3050,8 +3000,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farge"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3062,8 +3012,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Цвет"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3078,18 +3028,6 @@
             "value" : "Farb-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento de color"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Värielementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3102,22 +3040,10 @@
             "value" : "Elemento colore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fargeelement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleur-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент цвета"
           }
         }
       }
@@ -3132,18 +3058,6 @@
             "value" : "Farbrad"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rueda de colores"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Väriympyrä"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3156,22 +3070,10 @@
             "value" : "Ruota dei colori"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fargehjul"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleurwiel"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Цветовой круг"
           }
         }
       }
@@ -3193,14 +3095,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comando fallido: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komento epäonnistui: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3217,8 +3119,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommando mislyktes: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3229,8 +3131,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команда не выполнена: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3252,14 +3154,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errores de comando: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komentoviat: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3276,8 +3178,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommandofeil: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3288,8 +3190,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбоев команд: %lld"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3311,14 +3213,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento de comando %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komentoelementti %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3335,8 +3237,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommandoelement %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3347,8 +3249,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент команды %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3434,8 +3336,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhdistetään"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3452,8 +3354,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler til"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3464,8 +3366,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подключение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3664,14 +3566,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conexión exitosa"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhteys muodostettu"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3688,8 +3590,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilkobling vellykket"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3700,8 +3602,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Соединение установлено"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3716,18 +3618,6 @@
             "value" : "Kontakt-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento de contacto"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontaktielementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3740,22 +3630,10 @@
             "value" : "Elemento contatto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontaktelement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Contact-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент контакта"
           }
         }
       }
@@ -3777,14 +3655,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de contacto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontaktin tila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3801,8 +3679,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontaktstatus"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3813,8 +3691,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние контакта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3840,14 +3718,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luz diurna fría"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Viileä päivänvalo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3864,8 +3742,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kjølig dagslys"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3876,8 +3754,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Холодный дневной свет"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3899,14 +3777,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blanco frío"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Viileä valkoinen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3923,8 +3801,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kjølig hvit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3935,8 +3813,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Холодный белый"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -3964,8 +3842,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopioi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -3982,8 +3860,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopier"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -3994,8 +3872,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Копировать"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4076,14 +3954,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informe de fallos"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaatumisraportointi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4100,8 +3978,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Krasjirapportering"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4112,8 +3990,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отчёты о сбоях"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4263,7 +4141,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En activant le rapport de d'erreurs, tu acceptes que les informations relatives à l'appareil et à son utilisation soient collectées et partagées avec Crashlytics (une entreprise Google). Pour plus d'informations, consulte notre politique de confidentialité."
+            "value" : "En activant le rapport de d’erreurs, tu acceptes que les informations relatives à l’appareil et à son utilisation soient collectées et partagées avec Crashlytics (une entreprise Google). Pour plus d’informations, consulte notre politique de confidentialité."
           }
         },
         "it" : {
@@ -4315,8 +4193,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4333,8 +4211,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opprett"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4345,8 +4223,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4368,14 +4246,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fecha y hora"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivämäärä ja aika"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4392,8 +4270,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dato og tid"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4404,8 +4282,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дата и время"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4420,18 +4298,6 @@
             "value" : "DateTime-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento DateTime"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DateTime-elementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4444,22 +4310,10 @@
             "value" : "Elemento DateTime"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DateTime-element"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DateTime-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент DateTime"
           }
         }
       }
@@ -4481,14 +4335,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luz diurna"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivänvalo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4505,8 +4359,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dagslys"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4517,8 +4371,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дневной свет"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4658,14 +4512,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disminuir %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pienennä %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4682,8 +4536,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reduser %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4694,8 +4548,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уменьшить %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4717,14 +4571,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta predeterminada"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oletuspolku"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4741,8 +4595,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard sti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4753,8 +4607,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Путь по умолчанию"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4782,8 +4636,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4800,8 +4654,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slett"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4812,8 +4666,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4835,14 +4689,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Eliminar hogar ‘%@’?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poistetaanko koti ‘%@’?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4859,8 +4713,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slette hjem ‘%@’?"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4871,8 +4725,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить дом «%@»?"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -4894,14 +4748,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo demo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esittelytila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -4918,8 +4772,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demomodus"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -4930,8 +4784,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Демо-режим"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5018,8 +4872,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hylkää"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5036,8 +4890,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avslå"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5048,8 +4902,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отклонить"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5071,14 +4925,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivel de atenuación: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Himmennystaso: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5095,8 +4949,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmenivå: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5107,74 +4961,49 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уровень затемнения: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Dimmer or Roller Item" : {
       "comment" : "Display name for a dimmer or roller item type.",
+      "isCommentAutoGenerated" : true
+    },
+    "Dimmer/Roller Item" : {
+      "comment" : "Display name for a dimmer or roller item type.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dimmer- oder Rolladen-Item"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmer or Roller Item"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento regulador o persiana"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Himmennin- tai rullakaihdinelementti"
+            "value" : "Dimmer/Roller-Item"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Élément variateur ou volet"
+            "value" : "Élément gradateur/volet"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elemento dimmer o tapparella"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimmer- eller rullelukkelement"
+            "value" : "Elemento dimmer/tapparella"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dimmer- of rolluik-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент диммера или ролеты"
+            "value" : "Dimmer/Roller-item"
           }
         }
       }
     },
     "Disable" : {
-      "comment" : "Displayed when the user disables a setting.",
+      "comment" : "Display name for the \"Disable\" action.",
       "isCommentAutoGenerated" : true
     },
     "Disable Idle Timeout" : {
@@ -5194,14 +5023,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar tiempo de espera en reposo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista käytöstä lepoajan aikakatkaisu"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5218,8 +5047,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deaktiver tidsavbrudd ved inaktivitet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5230,8 +5059,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отключить тайм-аут простоя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5426,18 +5255,6 @@
             "value" : "Discovering openHAB servers…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descubriendo servidores openHAB…"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etsitään openHAB-palvelimia…"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5450,22 +5267,10 @@
             "value" : "Ricerca server openHAB in corso…"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finner openHAB-servere…"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "openHAB-servers worden ontdekt…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обнаружение серверов openHAB…"
           }
         }
       }
@@ -5538,18 +5343,6 @@
             "value" : "Fertig"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hecho"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valmis"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5562,22 +5355,10 @@
             "value" : "Fine"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ferdig"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gereed"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово"
           }
         }
       }
@@ -5592,18 +5373,6 @@
             "value" : "Ziehen, um Farbton und Sättigung zu ändern"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrastrar para cambiar el tono y la saturación"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vedä muuttaaksesi värisävyä ja kylläisyyttä"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5616,22 +5385,10 @@
             "value" : "Trascina per modificare tonalità e saturazione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dra for å endre fargetone og metning"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sleep om tint en verzadiging te wijzigen"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перетащите для изменения оттенка и насыщенности"
           }
         }
       }
@@ -5659,8 +5416,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "tyhjä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5677,8 +5434,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "tom"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5689,8 +5446,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "пусто"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5775,14 +5532,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar atenuación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota himmennys käyttöön"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5799,8 +5556,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiver dimming"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5811,8 +5568,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включить затемнение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5834,14 +5591,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar salvapantallas"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota näytönsäästäjä käyttöön"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5858,8 +5615,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiver skjermsparer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5870,8 +5627,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включить заставку экрана"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5893,14 +5650,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducir un nombre para el nuevo hogar"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syötä nimi uudelle kodille"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5917,8 +5674,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi et navn for det nye hjemmet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5929,8 +5686,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите имя для нового дома"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -5952,14 +5709,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducir un nuevo nombre para el hogar ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syötä uusi nimi kodille ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -5976,8 +5733,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi et nytt navn for hjemmet ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -5988,8 +5745,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите новое имя для дома «%@»"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6011,14 +5768,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducir nuevo valor"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syötä uusi arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6035,8 +5792,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi ny verdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6047,8 +5804,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите новое значение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6129,14 +5886,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducir texto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syötä teksti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6153,8 +5910,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi tekst"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6165,8 +5922,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите текст"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6188,14 +5945,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introducir URL del servidor remoto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syötä etäpalvelimen URL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6212,8 +5969,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi URL til fjernserver"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6224,8 +5981,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Введите URL удалённого сервера"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6312,8 +6069,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Virhe"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6330,8 +6087,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feil"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6342,8 +6099,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6365,14 +6122,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duración del fundido: %@ s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Häivytyksen kesto: %@ s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6389,8 +6146,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falming varighet: %@ s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6401,8 +6158,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Длительность затухания: %@ с"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6424,14 +6181,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avance rápido"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pikakelaus eteenpäin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6448,8 +6205,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spol frem"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6460,8 +6217,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перемотка вперёд"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6471,7 +6228,7 @@
       "isCommentAutoGenerated" : true
     },
     "Flip" : {
-      "comment" : "Display name for the switch action \"Toggle\".",
+      "comment" : "Display name for the toggle action.",
       "isCommentAutoGenerated" : true
     },
     "Font" : {
@@ -6497,8 +6254,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fontti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6515,8 +6272,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skrift"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6527,8 +6284,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Шрифт"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6556,8 +6313,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonttikoko"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6574,8 +6331,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriftstørrelse"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6586,8 +6343,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Размер шрифта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6609,14 +6366,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6633,8 +6390,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6645,8 +6402,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foo"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6718,18 +6475,6 @@
             "value" : "${itemEntity}-Status erhalten"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener estado de ${itemEntity}"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hae ${itemEntity}-tila"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6742,22 +6487,10 @@
             "value" : "Ottieni lo stato di ${itemEntity}"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hent status for ${itemEntity}"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Status van ${itemEntity} ophalen"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Получить состояние ${itemEntity}"
           }
         }
       }
@@ -6785,8 +6518,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hae elementin tila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6815,8 +6548,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Получить состояние элемента"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6900,14 +6633,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocultar barra de estado"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piilota tilapalkki"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6924,8 +6657,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skjul statuslinje"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6936,8 +6669,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скрыть строку состояния"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -6968,8 +6701,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -6986,8 +6719,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hjem"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -6998,8 +6731,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дом"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7021,14 +6754,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de icono"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuvaketyyppi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7045,8 +6778,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ikonstil"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7057,8 +6790,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тип значка"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7139,14 +6872,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalo de reposo: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lepoväli: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7163,8 +6896,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inaktivitetsintervall: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7175,8 +6908,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Интервал простоя: %lld с"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7198,14 +6931,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar certificados SSL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohita SSL-varmenteet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7222,8 +6955,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer SSL-sertifikater"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7234,8 +6967,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Игнорировать SSL-сертификаты"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7316,14 +7049,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caché de imágenes"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuvavälimuisti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7340,8 +7073,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildebuffer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7352,8 +7085,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кэш изображений"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7381,8 +7114,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tuo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7399,8 +7132,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7411,14 +7144,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Импорт"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Inactive" : {
-      "comment" : "Displayed when the contact is closed.",
+      "comment" : "Displayed title for the contact state when the contact is closed.",
       "isCommentAutoGenerated" : true
     },
     "Increase %@" : {
@@ -7438,14 +7171,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aumentar %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suurenna %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7462,8 +7195,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Øk %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7474,8 +7207,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Увеличить %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7562,8 +7295,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Virheellinen arvo %lld kohteelle %@ (0–100)"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7592,8 +7325,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Недопустимое значение %lld для %@ (0–100)"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7621,8 +7354,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Virheellinen arvo: %@ kohteelle %@ täytyy olla HSB (0–360, 0–100, 0–100)"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7651,8 +7384,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Недопустимое значение: %@ для %@ должно быть HSB (0–360, 0–100, 0–100)"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7739,8 +7472,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7769,8 +7502,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7792,14 +7525,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "El elemento ‘%@’ no está en el hogar ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementti ‘%@’ ei ole kodissa ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7816,8 +7549,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Element ‘%@’ er ikke i hjemmet ‘%@’"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7828,8 +7561,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент «%@» не входит в дом «%@»"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7844,18 +7577,6 @@
             "value" : "Element '%@' nicht gefunden"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento ‘%@’ no encontrado"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementtiä ‘%@’ ei löydy"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7868,22 +7589,10 @@
             "value" : "Elemento '%@' non trovato"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Element ‘%@’ ikke funnet"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Item '%@' niet gevonden"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент «%@» не найден"
           }
         }
       }
@@ -7911,8 +7620,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7929,8 +7638,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elementer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -7941,8 +7650,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элементы"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -7970,8 +7679,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etiketti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -7988,8 +7697,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etikett"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8000,8 +7709,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Метка"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8023,14 +7732,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latitud"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leveysaste"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8047,8 +7756,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breddegrad"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8059,8 +7768,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Широта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8082,14 +7791,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "La latitud debe estar entre -90 y 90"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leveysasteen on oltava välillä −90 ja 90"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8106,8 +7815,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breddegraden må være mellom -90 og 90"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8118,8 +7827,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Широта должна быть от -90 до 90"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8206,8 +7915,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oikeudelliset tiedot"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8224,8 +7933,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Juridisk"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8236,8 +7945,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Юридическая информация"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8259,14 +7968,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando elementos…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladataan elementtejä…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8283,8 +7992,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laster elementer…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8295,8 +8004,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузка элементов…"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8318,14 +8027,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando mapa del sitio…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladataan sivukarttaa…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8342,8 +8051,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laster nettstedskart…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8354,8 +8063,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузка карты сайта…"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8429,18 +8138,6 @@
             "value" : "Möglicherweise ist der Zugriff auf das lokale Netzwerk erforderlich."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es posible que se requiera acceso a la red local."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähiverkon käyttöoikeus voi olla tarpeen."
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8453,22 +8150,10 @@
             "value" : "Potrebbe essere necessario l'accesso alla rete locale."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilgang til lokalt nettverk kan være nødvendig."
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegang tot lokaal netwerk kan vereist zijn."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Может потребоваться доступ к локальной сети."
           }
         }
       }
@@ -8483,18 +8168,6 @@
             "value" : "Zugriff auf lokales Netzwerk erforderlich"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requiere acceso a la red local"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähiverkon käyttöoikeus vaaditaan"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8507,22 +8180,10 @@
             "value" : "Accesso alla rete locale richiesto"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilgang til lokalt nettverk kreves"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegang tot lokaal netwerk vereist"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуется доступ к локальной сети"
           }
         }
       }
@@ -8544,14 +8205,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servidor local"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paikallinen palvelin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8568,8 +8229,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal server"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8580,8 +8241,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Локальный сервер"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8667,8 +8328,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sijainti"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8685,8 +8346,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plassering"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8697,8 +8358,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Местоположение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8713,18 +8374,6 @@
             "value" : "Standort-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento de ubicación"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sijaintielementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8737,22 +8386,10 @@
             "value" : "Elemento posizione"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plasseringselement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Locatie-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент местоположения"
           }
         }
       }
@@ -8780,8 +8417,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8798,8 +8435,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logger"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8810,8 +8447,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Журналы"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8833,14 +8470,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Longitud"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pituusaste"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8857,8 +8494,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lengdegrad"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8869,8 +8506,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Долгота"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8892,14 +8529,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "La longitud debe estar entre -180 y 180"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pituusasteen on oltava välillä −180 ja 180"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8916,8 +8553,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lengdegraden må være mellom -180 og 180"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8928,8 +8565,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Долгота должна быть от -180 до 180"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -8951,14 +8588,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baja %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laskee %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -8975,8 +8612,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senker med %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -8987,8 +8624,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Снижает на %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9016,8 +8653,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pää"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9034,8 +8671,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoved"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9046,8 +8683,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Главная"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9127,14 +8764,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestionar hogares"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hallitse koteja"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9151,8 +8788,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrer hjem"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9163,8 +8800,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Управление домами"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9244,14 +8881,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalo de movimiento: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liikeväli: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9268,8 +8905,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bevegelsesintervall: %lld s"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9280,8 +8917,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Интервал движения: %lld с"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9309,8 +8946,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nimi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9327,8 +8964,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Navn"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9339,8 +8976,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Имя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9362,14 +8999,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre para el nuevo hogar"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nimi uudelle kodille"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9386,8 +9023,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Navn for nytt hjem"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9398,8 +9035,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Имя для нового дома"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9479,14 +9116,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuevo nombre"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uusi nimi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9503,8 +9140,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nytt navn"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9515,8 +9152,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Новое имя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9538,14 +9175,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siguiente"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seuraava"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9562,8 +9199,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neste"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9574,14 +9211,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Следующий"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Next track" : {
-      "comment" : "Synonyms for the \"Next\" player action.",
+      "comment" : "Synonyms for the \"Next\" action.",
       "isCommentAutoGenerated" : true
     },
     "No accepted server certificates" : {
@@ -9601,14 +9238,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay certificados de servidor aceptados"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei hyväksyttyjä palvelinvarmenteita"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9625,8 +9262,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen godkjente serversertifikater"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9637,8 +9274,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет принятых сертификатов сервера"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9659,14 +9296,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin URL de imagen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei kuvan URL-osoitetta"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9683,8 +9320,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen bilde-URL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9695,8 +9332,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет URL изображения"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9718,14 +9355,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay mapas del sitio disponibles"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei sivukarttoja saatavilla"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9742,8 +9379,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen nettstedskart tilgjengelig"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9754,8 +9391,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет доступных карт сайта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9777,14 +9414,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin URL de vídeo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei videon URL-osoitetta"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9801,8 +9438,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen video-URL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9813,8 +9450,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет URL видео"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9836,14 +9473,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay widgets disponibles."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei widgettejä saatavilla."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9860,8 +9497,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen widgeter tilgjengelig."
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9872,8 +9509,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет доступных виджетов."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -9954,14 +9591,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin conexión, reintentando…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei yhteyttä, yritetään uudelleen…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -9978,8 +9615,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen tilkobling, kobler til igjen…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -9990,8 +9627,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет подключения, повторное подключение…"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10053,6 +9690,10 @@
           }
         }
       }
+    },
+    "None" : {
+      "comment" : "A label for the \"Sitemap for CarPlay\" picker.",
+      "isCommentAutoGenerated" : true
     },
     "notification" : {
       "localizations" : {
@@ -10194,8 +9835,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ilmoitukset"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10212,8 +9853,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varsler"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10224,8 +9865,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уведомления"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10240,18 +9881,6 @@
             "value" : "Numerisches-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento numérico"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numeraalielementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10264,22 +9893,70 @@
             "value" : "Elemento numerico"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallselement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Numeriek item"
           }
+        }
+      }
+    },
+    "off" : {
+      "comment" : "Label for the \"off\" state of a contact.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "aus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "off"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "desactivada"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "désactivé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non attivo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uit"
+          }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Числовой элемент"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10307,8 +9984,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pois"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10325,8 +10002,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Av"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10337,8 +10014,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выкл."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10366,8 +10043,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10384,8 +10061,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frakoblet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10396,8 +10073,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не в сети"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10602,8 +10279,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10620,8 +10297,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10632,8 +10309,68 @@
         },
         "ru" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "on" : {
+      "comment" : "\"on\" in capitalized form.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "ОК"
+            "value" : "an"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "on"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "activada"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "activé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "attivo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "aan"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10655,14 +10392,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encendido"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päällä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10679,8 +10416,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "På"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10691,8 +10428,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вкл."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10714,14 +10451,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Una vez"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kerran"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10738,8 +10475,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Én gang"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10750,8 +10487,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Один раз"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10863,8 +10600,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыто"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -10879,18 +10616,6 @@
             "value" : "Einstellungen öffnen"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir ajustes"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa asetukset"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10903,22 +10628,10 @@
             "value" : "Apri Impostazioni"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åpne innstillinger"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen openen"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки"
           }
         }
       }
@@ -10944,14 +10657,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servicio en la nube openHAB"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB-pilvipalvelu"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -10968,8 +10681,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "openHAB-skytjeneste"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -10980,8 +10693,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Облачный сервис openHAB"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11179,14 +10892,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tauko"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11203,8 +10916,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11215,8 +10928,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пауза"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11238,14 +10951,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reproducir"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toista"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11262,8 +10975,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spill av"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11274,8 +10987,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Воспроизвести"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11297,14 +11010,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acción del reproductor"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soittimen toiminto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11321,8 +11034,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spillerhandling"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11333,8 +11046,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Действие плеера"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11349,18 +11062,6 @@
             "value" : "Player-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento reproductor"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soitinelementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11373,22 +11074,10 @@
             "value" : "Elemento player"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spillerelement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Speler-item"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент плеера"
           }
         }
       }
@@ -11475,8 +11164,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asetukset"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11493,8 +11182,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstillinger"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11505,8 +11194,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11528,14 +11217,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de vista previa"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esikatselutila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11552,8 +11241,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forhåndsvisningstilstand"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11564,8 +11253,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние предварительного просмотра"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11587,14 +11276,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anterior"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edellinen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11611,8 +11300,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forrige"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11623,14 +11312,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предыдущий"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Previous track" : {
-      "comment" : "Display name for the previous action.",
+      "comment" : "Synonyms for the previous action.",
       "isCommentAutoGenerated" : true
     },
     "privacy_policy" : {
@@ -11708,14 +11397,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandos en cola: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jonossa olevat komennot: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11732,8 +11421,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommandoer i kø: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11744,8 +11433,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команды в очереди: %lld"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11767,14 +11456,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sube %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nostaa %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11791,8 +11480,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Øker med %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11803,8 +11492,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повышает на %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11885,14 +11574,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controles deslizantes en tiempo real"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reaaliaikaiset liukusäätimet"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11909,8 +11598,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sanntidsskyvere"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11921,8 +11610,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Слайдеры реального времени"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -11944,14 +11633,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fecha relativa: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suhteellinen päivämäärä: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -11968,8 +11657,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relativ dato: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -11980,8 +11669,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Относительная дата: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12003,14 +11692,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servidor remoto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etäpalvelin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12027,8 +11716,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjernserver"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12039,8 +11728,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалённый сервер"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12186,8 +11875,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nimeä uudelleen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12204,8 +11893,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gi nytt navn"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12216,18 +11905,18 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Replay" : {
-      "comment" : "A synonym for the rewind action.",
+      "comment" : "Synonym for the rewind action.",
       "isCommentAutoGenerated" : true
     },
     "Reset" : {
-      "comment" : "Synonyms for the \"Reset\" state of a contact.",
+      "comment" : "Synonyms for the contact state \"Closed\".",
       "isCommentAutoGenerated" : true
     },
     "Restore Brightness: %@" : {
@@ -12247,14 +11936,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar brillo: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palauta kirkkaus: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12271,8 +11960,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gjenopprett lysstyrke: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12283,8 +11972,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановить яркость: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12306,14 +11995,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaurar brillo anterior al despertar"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palauta aiempi kirkkaus herätessä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12330,8 +12019,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gjenopprett tidligere lysstyrke ved vekking"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12342,8 +12031,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановить предыдущую яркость при пробуждении"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12375,8 +12064,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hae elementin nykyinen tila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12405,8 +12094,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Получить текущее состояние элемента"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12487,14 +12176,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rebobinar"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kelaa taaksepäin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12511,8 +12200,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spol tilbake"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12523,14 +12212,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перемотка назад"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Rewind back" : {
-      "comment" : "A synonym for the rewind action.",
+      "comment" : "Synonyms for the rewind action.",
       "isCommentAutoGenerated" : true
     },
     "running_demo_mode" : {
@@ -12615,8 +12304,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tallenna"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12633,8 +12322,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lagre"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12645,8 +12334,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сохранить"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12674,8 +12363,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytönsäästäjä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12692,8 +12381,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skjermsparer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12704,8 +12393,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Заставка экрана"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12727,14 +12416,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes del salvapantallas"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytönsäästäjän asetukset"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12751,8 +12440,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skjermsparer-innstillinger"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12763,8 +12452,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки заставки"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12792,8 +12481,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haku"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12810,8 +12499,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søk"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12822,8 +12511,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поиск"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -12845,14 +12534,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar un elemento"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etsi elementtiä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -12869,8 +12558,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søk etter et element"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -12881,8 +12570,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Найти элемент"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13016,14 +12705,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar color"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valitse väri"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13040,8 +12729,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg farge"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -13052,8 +12741,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать цвет"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13125,18 +12814,6 @@
             "value" : "${action} an ${itemEntity} senden"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar ${action} a ${itemEntity}"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähetä ${action} kohteeseen ${itemEntity}"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13149,22 +12826,10 @@
             "value" : "Invia ${action} a ${itemEntity}"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send ${action} til ${itemEntity}"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "${action} verzenden naar ${itemEntity}"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправить ${action} в ${itemEntity}"
           }
         }
       }
@@ -13186,14 +12851,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviar un comando al reproductor como reproducir, pausar, siguiente o anterior"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähetä soittimelle komento, kuten toista, tauko, seuraava tai edellinen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13210,8 +12875,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send en spillerkommando som spill av, pause, neste eller forrige"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -13222,8 +12887,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправить команду плееру: воспроизвести, пауза, следующий или предыдущий"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13244,14 +12909,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviando comandos: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähetetään komentoja: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13268,8 +12933,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sender kommandoer: %lld"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -13280,8 +12945,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправка команд: %lld"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13310,8 +12975,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ lähetetty kohteeseen %2$@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13340,8 +13005,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ отправлено в %2$@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13363,14 +13028,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicación %lf, %lf enviada a %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sijainti %lf, %lf lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13387,8 +13052,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plassering %lf, %lf sendt til %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -13399,8 +13064,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Местоположение %lf, %lf отправлено в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13428,8 +13093,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Väriarvo %@ lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13458,8 +13123,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Значение цвета %@ отправлено в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13481,14 +13146,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fecha %@ enviada a %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivämäärä %@ lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13505,8 +13170,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dato %@ sendt til %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -13517,8 +13182,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дата %@ отправлена в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13546,8 +13211,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luku %lf lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13576,8 +13241,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Число %lf отправлено в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13605,8 +13270,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Merkkijono %@ lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13635,8 +13300,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Строка %@ отправлена в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13664,8 +13329,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arvo %lld lähetetty kohteeseen %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -13694,8 +13359,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Значение %lld отправлено в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -13706,18 +13371,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standort ${itemEntity} auf ${latitude}, ${longitude} setzen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer ${itemEntity} en ${latitude}, ${longitude}"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta ${itemEntity} arvoon ${latitude}, ${longitude}"
           }
         },
         "fr" : {
@@ -13732,22 +13385,10 @@
             "value" : "Imposta ${itemEntity} su ${latitude}, ${longitude}"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett ${itemEntity} til ${latitude}, ${longitude}"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "${itemEntity} instellen op ${latitude}, ${longitude}"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить ${itemEntity} в ${latitude}, ${longitude}"
           }
         }
       }
@@ -13758,18 +13399,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${itemEntity} auf ${value} setzen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer ${itemEntity} en ${value}"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta ${itemEntity} arvoon ${value}"
           }
         },
         "fr" : {
@@ -13784,22 +13413,10 @@
             "value" : "Imposta ${itemEntity} su ${value}"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett ${itemEntity} til ${value}"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "${itemEntity} instellen op ${value}"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить ${itemEntity} в ${value}"
           }
         }
       }
@@ -13810,18 +13427,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${itemEntity} auf ${value} (HSB) setzen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer ${itemEntity} en ${value} (HSB)"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta ${itemEntity} arvoon ${value} (HSB)"
           }
         },
         "fr" : {
@@ -13836,22 +13441,10 @@
             "value" : "Imposta ${itemEntity} su ${value} (HSB)"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sett ${itemEntity} til ${value} (HSB)"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "${itemEntity} instellen op ${value} (HSB)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить ${itemEntity} в ${value} (HSB)"
           }
         }
       }
@@ -13989,8 +13582,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta värisäätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14019,14 +13612,14 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение элемента управления цветом"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Set Contact State" : {
-      "comment" : "Short title for the shortcut to set the contact state.",
+      "comment" : "Shortcut title for setting the state of a contact.",
       "isCommentAutoGenerated" : true
     },
     "Set Contact State Value" : {
@@ -14052,8 +13645,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta kontaktin tilanarvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14082,8 +13675,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение состояния контакта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14109,14 +13702,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer valor del control DateTime"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta DateTime-säätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14133,8 +13726,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi DateTime-kontrollverdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14145,8 +13738,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение элемента управления DateTime"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14178,8 +13771,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta himmentimen tai rullaverkon arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14208,8 +13801,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение диммера или рольставни"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14231,14 +13824,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer valor del control de ubicación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta sijaintisäätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14255,8 +13848,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi plasseringskontrollverdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14267,8 +13860,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение элемента управления местоположением"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14300,8 +13893,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta numerosäätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14330,8 +13923,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить числовое значение элемента управления"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14353,14 +13946,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer valor del control del reproductor"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta soittimen säätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14377,8 +13970,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi spillerkontrollverdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14389,8 +13982,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение элемента управления плеером"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14418,8 +14011,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta merkkijonosäätimen arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14448,8 +14041,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить строковое значение элемента управления"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14481,8 +14074,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta kytkimen tila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14511,8 +14104,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить состояние переключателя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14544,8 +14137,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta värielementin väri"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14574,8 +14167,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить цвет элемента управления цветом"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14597,14 +14190,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer la fecha y hora de un elemento de control DateTime"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta DateTime-elementin päivämäärä ja aika"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14621,8 +14214,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi dato og tid for et DateTime-kontrollelement"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14633,8 +14226,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить дату и время элемента DateTime"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14662,8 +14255,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta numeroelementin desimaaliarvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14692,8 +14285,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить десятичное значение числового элемента"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14721,8 +14314,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta himmentimen tai rullaverkon kokonaislukuarvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14751,8 +14344,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить целочисленное значение диммера или рольставни"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14774,14 +14367,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer la latitud y longitud de un elemento de control de ubicación"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta sijaintielementin leveys- ja pituusaste"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14798,8 +14391,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi bredde- og lengdegrad for et plasseringskontrollelement"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14810,8 +14403,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить широту и долготу элемента местоположения"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14822,18 +14415,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Den Status von ${itemEntity} auf ${state} setzen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el estado de ${itemEntity} en ${state}"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta ${itemEntity}-tila arvoon ${state}"
           }
         },
         "fr" : {
@@ -14848,22 +14429,10 @@
             "value" : "Imposta lo stato di ${itemEntity} su ${state}"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi status for ${itemEntity} til ${state}"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De status van ${itemEntity} instellen op ${state}"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить состояние ${itemEntity} в ${state}"
           }
         }
       }
@@ -14891,8 +14460,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta kontaktin tilaksi auki tai kiinni"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14921,8 +14490,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить состояние контакта: открыт или закрыт"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -14944,14 +14513,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer el estado de un interruptor en encendido o apagado, o alternar su estado"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta kytkimen tilaksi päällä tai pois tai vaihda sen tilaa"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -14968,8 +14537,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi brytertilstanden til på eller av, eller bytt tilstand"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -14980,8 +14549,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить состояние переключателя вкл. или выкл., или переключить его состояние"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15009,8 +14578,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta merkkijonoelementin merkkijono"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15039,8 +14608,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить строку строкового элемента"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15062,14 +14631,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer valor"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aseta arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15086,8 +14655,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi verdi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15098,8 +14667,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить значение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15185,8 +14754,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asetuksia ei ole vielä vastaanotettu iPhonelta."
+            "state" : "needs_review",
+            "value" : "Settings not yet received from phone."
           }
         },
         "fr" : {
@@ -15215,8 +14784,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки ещё не получены с iPhone."
+            "state" : "needs_review",
+            "value" : "Settings not yet received from phone."
           }
         }
       }
@@ -15238,14 +14807,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar fecha"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä päivämäärä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15262,8 +14831,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis dato"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15274,8 +14843,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать дату"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15297,14 +14866,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar campo de búsqueda"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä hakukenttä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15321,8 +14890,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis søkefelt"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15333,8 +14902,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать поле поиска"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15356,14 +14925,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar segundos"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä sekunnit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15380,8 +14949,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis sekunder"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15392,8 +14961,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать секунды"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15415,14 +14984,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar hora"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä aika"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15439,8 +15008,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis tid"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15451,8 +15020,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать время"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15517,7 +15086,7 @@
       }
     },
     "Shut" : {
-      "comment" : "Displayed title for the \"Shut\" state of a contact.",
+      "comment" : "Displayed title for the contact state \"Shut\".",
       "isCommentAutoGenerated" : true
     },
     "sitemap" : {
@@ -15595,14 +15164,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mapa del sitio"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sivukartta"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15619,8 +15188,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettstedskart"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15631,8 +15200,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Карта сайта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15647,18 +15216,6 @@
             "value" : "Sitemap-Diagnoseprotokollierung"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registro de diagnóstico del mapa del sitio"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sivukartan diagnostiikkaloki"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15671,22 +15228,10 @@
             "value" : "Registrazione diagnostica sitemap"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnoslogging for nettstedskart"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sitemap-diagnoselogboek"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Журналирование диагностики карты сайта"
           }
         }
       }
@@ -15708,14 +15253,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mapa del sitio para Apple Watch"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Watch -sivukartta"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15732,8 +15277,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettstedskart for Apple Watch"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15744,11 +15289,15 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Карта сайта для Apple Watch"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
+    },
+    "Sitemap for CarPlay" : {
+      "comment" : "A label for selecting a sitemap to be used for CarPlay.",
+      "isCommentAutoGenerated" : true
     },
     "sitemap_settings" : {
       "localizations" : {
@@ -15825,14 +15374,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mapas del sitio"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sivukartat"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15849,8 +15398,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettstedskart"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15861,8 +15410,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Карты сайта"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15884,14 +15433,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamaño: %llu MB"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koko: %llu Mt"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15908,8 +15457,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Størrelse: %llu MB"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15920,8 +15469,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Размер: %llu МБ"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -15939,7 +15488,7 @@
       "isCommentAutoGenerated" : true
     },
     "Skip forward" : {
-      "comment" : "A synonym for the \"Next\" action.",
+      "comment" : "Synonyms for the \"Next\" action.",
       "isCommentAutoGenerated" : true
     },
     "Soft White" : {
@@ -15959,14 +15508,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blanco suave"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pehmeä valkoinen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -15983,8 +15532,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Myk hvit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -15995,8 +15544,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мягкий белый"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16018,14 +15567,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordenar mapas del sitio por"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lajittele sivukartat"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16042,8 +15591,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorter nettstedskart etter"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16054,8 +15603,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сортировать карты сайта по"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16140,14 +15689,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error SSL. No se pudo establecer la conexión de forma segura."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-virhe. Yhteyttä ei voitu muodostaa turvallisesti."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16164,8 +15713,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSL-feil. Tilkoblingen kunne ikke opprettes sikkert."
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16176,8 +15725,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка SSL. Не удалось установить безопасное соединение."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16270,7 +15819,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ n'est pas valide. Veux-tu continuer ?"
+            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ n’est pas valide. Veux-tu continuer ?"
           }
         },
         "it" : {
@@ -16328,7 +15877,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ ne correspond pas à l'enregistrement. Veux-tu continuer ?"
+            "value" : "Le certificat SSL présenté par %1$@ pour %2$@ ne correspond pas à l’enregistrement. Veux-tu continuer ?"
           }
         },
         "it" : {
@@ -16442,8 +15991,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tila"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16460,8 +16009,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilstand"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16472,14 +16021,15 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
     },
     "Stop" : {
-
+      "comment" : "Synonyms for the pause action.",
+      "isCommentAutoGenerated" : true
     },
     "String Item" : {
       "comment" : "Display name for a string item type.",
@@ -16489,18 +16039,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "String-Item"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento de texto"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Merkkijonoelementti"
           }
         },
         "fr" : {
@@ -16515,28 +16053,16 @@
             "value" : "Elemento stringa"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekststrengselement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tekst-item"
           }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Строковый элемент"
-          }
         }
       }
     },
     "Suspend" : {
-      "comment" : "Display name for the pause action.",
+      "comment" : "Synonyms for the pause action.",
       "isCommentAutoGenerated" : true
     },
     "SVG" : {
@@ -16619,14 +16145,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acción del interruptor"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kytkimen toiminto"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16643,8 +16169,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bryterhandling"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16655,8 +16181,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Действие переключателя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16676,18 +16202,6 @@
             "value" : "Switch-Item"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elemento interruptor"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kytkinelementti"
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16700,28 +16214,16 @@
             "value" : "Elemento interruttore"
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bryterelement"
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schakelaar-item"
           }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент переключателя"
-          }
         }
       }
     },
     "Switch off" : {
-      "comment" : "Displayed when the user disables a device.",
+      "comment" : "Displayed when the user disables a switch.",
       "isCommentAutoGenerated" : true
     },
     "Switch on" : {
@@ -16868,8 +16370,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Järjestelmä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16886,8 +16388,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16898,8 +16400,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Система"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16921,14 +16423,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probar conexión"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testaa yhteys"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -16945,8 +16447,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test tilkobling"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -16957,8 +16459,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить соединение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -16980,14 +16482,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Probar salvapantallas"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testaa näytönsäästäjä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17004,8 +16506,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Test skjermsparer"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17016,8 +16518,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить заставку"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17039,14 +16541,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "La conexión ha agotado el tiempo de espera. Inténtelo de nuevo más tarde."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhteys aikakatkaistiin. Yritä myöhemmin uudelleen."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17063,8 +16565,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilkoblingen ble tidsavbrutt. Prøv igjen senere."
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17075,8 +16577,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Время соединения истекло. Повторите попытку позже."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17104,8 +16606,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kohteen %@ tila on %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17134,8 +16636,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние %@ равно %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17163,8 +16665,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kohteen %@ tilaksi asetettiin %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17193,8 +16695,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние %@ установлено в %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17209,18 +16711,6 @@
             "value" : "Die URL ist ungültig. Bitte überprüfe das Format (z.B. http://192.168.2.1:8080 oder http://[::1]:8080 für IPv6)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La URL no es válida. Compruebe el formato (p. ej., http://192.168.2.1:8080 o http://[::1]:8080 para IPv6)."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL on virheellinen. Tarkista muoto (esim. http://192.168.2.1:8080 tai http://[::1]:8080 IPv6:lle)."
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17233,22 +16723,10 @@
             "value" : "L'URL non è valido. Controlla il formato (es. http://192.168.2.1:8080 o http://[::1]:8080 per IPv6)."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL-en er ugyldig. Sjekk formatet (f.eks. http://192.168.2.1:8080 eller http://[::1]:8080 for IPv6)."
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De URL is ongeldig. Controleer het formaat (bijv. http://192.168.2.1:8080 of http://[::1]:8080 voor IPv6)."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL недействителен. Проверьте формат (например, http://192.168.2.1:8080 или http://[::1]:8080 для IPv6)."
           }
         }
       }
@@ -17270,14 +16748,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mosaicos"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruudut"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17294,8 +16772,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fliser"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17306,8 +16784,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Плитки"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17329,14 +16807,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temporización"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajoitus"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17353,8 +16831,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17365,8 +16843,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Синхронизация"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17381,18 +16859,6 @@
             "value" : "Um eine Verbindung zu deinem lokalen openHAB-Server herzustellen, erlauben bitte den Zugriff auf das lokale Netzwerk, wenn du dazu aufgefordert wirst. Wenn du es zuvor abgelehnt hast, aktiviere es unter Einstellungen → Datenschutz & Sicherheit → Lokales Netzwerk."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para conectarse a su servidor openHAB local, permita el acceso a la red local cuando se le solicite. Si lo denegó anteriormente, actívelo en Ajustes → Privacidad y seguridad → Red local."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muodosta yhteys paikalliseen openHAB-palvelimeen sallimalla lähiverkkoyhteys pyydettäessä. Jos olet aiemmin kieltänyt sen, ota se käyttöön kohdassa Asetukset → Tietosuoja ja turvallisuus → Lähiverkko."
-          }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17405,22 +16871,71 @@
             "value" : "Per connetterti al tuo server openHAB locale, consenti l'accesso alla rete locale quando richiesto. Se in precedenza hai negato l'accesso, abilitalo in Impostazioni → Privacy e sicurezza → Rete locale."
           }
         },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For å koble til din lokale openHAB-server, vennligst tillat tilgang til lokalt nettverk når du blir bedt om det. Hvis du tidligere nektet det, aktiver det i Innstillinger → Personvern og sikkerhet → Lokalt nettverk."
-          }
-        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om verbinding te maken met uw lokale openHAB-server, sta toegang tot het lokale netwerk toe wanneer hierom wordt gevraagd. Als u dit eerder heeft geweigerd, schakel het in via Instellingen → Privacy en beveiliging → Lokaal netwerk."
           }
+        }
+      }
+    },
+    "toggle" : {
+      "comment" : "Action to toggle a switch between on and off states",
+      "extractionState" : "stale",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "umschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "toggle"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alternar"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vaihda"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "basculer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alternare"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "veksle"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "omschakelen"
+          }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для подключения к локальному серверу openHAB разрешите доступ к локальной сети при появлении запроса. Если вы ранее отказали, включите его в Настройки → Конфиденциальность и безопасность → Локальная сеть."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17442,14 +16957,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternar"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaihda"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17466,8 +16981,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bytt"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17478,8 +16993,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переключить"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17631,14 +17146,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error inesperado: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odottamaton virhe: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17655,8 +17170,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uventet feil: %@"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17667,8 +17182,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Непредвиденная ошибка: %@"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17809,8 +17324,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivitetään…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17827,8 +17342,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oppdaterer…"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17839,8 +17354,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновление…"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -17868,8 +17383,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -17886,8 +17401,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -17898,8 +17413,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18044,8 +17559,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käyttäjänimi"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18062,8 +17577,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brukernavn"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18074,8 +17589,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Имя пользователя"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18103,8 +17618,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arvo"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18133,8 +17648,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Значение"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18214,14 +17729,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muy frío"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hyvin viileä"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18238,8 +17753,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Svært kjølig"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18250,8 +17765,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очень холодный"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18273,14 +17788,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muy cálido"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hyvin lämmin"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18297,8 +17812,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Svært varm"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18309,8 +17824,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очень тёплый"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18332,14 +17847,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blanco cálido"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lämmin valkoinen"
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18356,8 +17871,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varm hvit"
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18368,8 +17883,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тёплый белый"
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18449,14 +17964,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advertencia: Cambiar el nombre del hogar puede hacer que las integraciones externas, como los atajos, fallen hasta que se reconfiguren."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varoitus: Kodin uudelleennimeäminen voi aiheuttaa ulkoisten integraatioiden, kuten pikakomentojen, epäonnistumisen, kunnes ne on uudelleenmääritetty."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18473,8 +17988,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advarsel: Å gi hjemmet nytt navn kan føre til at eksterne integrasjoner som snarveier mislykkes inntil de er rekonfigurert."
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18485,8 +18000,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предупреждение: переименование дома может привести к сбою внешних интеграций, таких как ярлыки, до их перенастройки."
+            "state" : "new",
+            "value" : ""
           }
         }
       }
@@ -18508,14 +18023,14 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parece que estás sin conexión. Comprueba tu conexión a internet."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näyttää siltä, että olet offline. Tarkista internet-yhteytesi."
+            "state" : "new",
+            "value" : ""
           }
         },
         "fr" : {
@@ -18532,8 +18047,8 @@
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du ser ut til å være frakoblet. Sjekk internettilkoblingen din."
+            "state" : "new",
+            "value" : ""
           }
         },
         "nl" : {
@@ -18544,8 +18059,8 @@
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Похоже, вы не в сети. Проверьте подключение к интернету."
+            "state" : "new",
+            "value" : ""
           }
         }
       }

--- a/openHAB/Supporting Files/openHAB-Info.plist
+++ b/openHAB/Supporting Files/openHAB-Info.plist
@@ -94,7 +94,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>
@@ -106,6 +106,15 @@
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
 					<string>Main</string>
+				</dict>
+			</array>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
 				</dict>
 			</array>
 		</dict>

--- a/openHAB/Supporting Files/openHAB.entitlements
+++ b/openHAB/Supporting Files/openHAB.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.carplay-driving-task</key>
+	<true/>
 	<key>com.apple.developer.siri</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/openHAB/UI/DrawerView.swift
+++ b/openHAB/UI/DrawerView.swift
@@ -120,6 +120,7 @@ struct DrawerView: View {
     @ScaledMetric var iconWidth = 20.0
 
     @State private var sitemapForWatch: String?
+    @State private var sitemapForCarPlay: String?
 
     var mainSection: some View {
         Section(header: Text("Main")) {
@@ -152,19 +153,27 @@ struct DrawerView: View {
     var sitemapsSection: some View {
         Section(header: Text("Sitemaps")) {
             ForEach(sitemaps, id: \.name) { sitemap in
-                menuEntry(
-                    image: sitemapIcon(for: sitemap),
-                    goTo: .sitemap(sitemap.name)
-                ) {
-                    HStack {
-                        Text(sitemap.label)
-                        if sitemap.name == sitemapForWatch {
-                            Spacer()
-                            Image(systemSymbol: .applewatchWatchface)
+                HStack {
+                    sitemapIcon(for: sitemap)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: iconWidth, height: iconWidth)
+                    Text(sitemap.label)
+                    Spacer()
+                    let isWatch = sitemap.name == sitemapForWatch
+                    let isCar = sitemap.name == sitemapForCarPlay
+                    if isWatch { Image(systemSymbol: .applewatchWatchface) }
+                    if isCar {
+                        if #available(iOS 16.1, *) {
+                            Image(systemSymbol: .steeringwheel)
+                        } else {
+                            Image(systemSymbol: .car)
                         }
                     }
                 }
+                .contentShape(Rectangle())
                 .onTapGesture(count: 2) { toggleWatchSitemap(sitemap) }
+                .onTapGesture { onDismiss(.sitemap(sitemap.name)) }
+                .onLongPressGesture { toggleCarPlaySitemap(sitemap) }
             }
         }
     }
@@ -202,6 +211,7 @@ struct DrawerView: View {
         .task(id: networkTracker.activeConnection) {
             await updateSitemapsAndUITiles(activeConnection: networkTracker.activeConnection)
             sitemapForWatch = Preferences.shared.currentHomePreferences.sitemapForWatch
+            sitemapForCarPlay = Preferences.shared.currentHomePreferences.sitemapForCarPlay
         }
     }
 
@@ -272,6 +282,18 @@ struct DrawerView: View {
                 sitemapForWatch = sitemap.name
                 prefs.sitemapForWatch = sitemap.name
                 prefs.sitemapForWatchLabel = sitemap.label
+            }
+        }
+    }
+
+    func toggleCarPlaySitemap(_ sitemap: OpenHABSitemap) {
+        Preferences.shared.modifyActiveHome { prefs in
+            if sitemap.name == sitemapForCarPlay {
+                sitemapForCarPlay = nil
+                prefs.sitemapForCarPlay = ""
+            } else {
+                sitemapForCarPlay = sitemap.name
+                prefs.sitemapForCarPlay = sitemap.name
             }
         }
     }

--- a/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
+++ b/openHAB/UI/ScreenSaver/ScreenSaverManager.swift
@@ -112,7 +112,10 @@ final class ScreenSaverManager: NSObject {
             overlay = UIWindow(windowScene: scene)
             overlay.frame = scene.coordinateSpace.bounds
         } else {
-            overlay = UIWindow(frame: (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.screen.bounds ?? .zero)
+            let fallbackScene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first
+            overlay = UIWindow(frame: fallbackScene?.screen.bounds ?? .zero)
         }
         overlay.windowLevel = .alert + 1 // ensure above status bar
         overlay.backgroundColor = .clear

--- a/openHAB/UI/SettingsView/SettingsView.swift
+++ b/openHAB/UI/SettingsView/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
     @State private var settingsDefaultMainUIPath = ""
     @State private var settingsAlwaysAllowWebRTC = true
     @State private var settingsSitemapForWatch = ""
+    @State private var settingsSitemapForCarPlay = ""
 
     @State private var sitemaps: [OpenHABSitemap] = []
     @State private var settingsLocalConnectionConfiguration = ConnectionConfiguration(url: "", username: "", password: "")
@@ -67,6 +68,7 @@ struct SettingsView: View {
                 settingsIconType: $settingsIconType,
                 settingsSortSitemapsBy: $settingsSortSitemapsBy,
                 settingsSitemapForWatch: $settingsSitemapForWatch,
+                settingsSitemapForCarPlay: $settingsSitemapForCarPlay,
                 sitemaps: $sitemaps
             )
 
@@ -160,6 +162,7 @@ struct SettingsView: View {
         settingsDefaultMainUIPath = Preferences.shared.currentHomePreferences.defaultMainUIPath
         settingsAlwaysAllowWebRTC = Preferences.shared.currentHomePreferences.alwaysAllowWebRTC
         settingsSitemapForWatch = Preferences.shared.currentHomePreferences.sitemapForWatch
+        settingsSitemapForCarPlay = Preferences.shared.currentHomePreferences.sitemapForCarPlay
         settingsLocalConnectionConfiguration = Preferences.shared.currentHomePreferences.localConnectionConfig
         settingsRemoteConnectionConfiguration = Preferences.shared.currentHomePreferences.remoteConnectionConfig
         loadedLocalURL = Preferences.shared.currentHomePreferences.localConnectionConfig.url
@@ -177,6 +180,7 @@ struct SettingsView: View {
             homePreferences.alwaysAllowWebRTC = settingsAlwaysAllowWebRTC
             homePreferences.sitemapForWatch = settingsSitemapForWatch
             homePreferences.sitemapForWatchLabel = sitemaps.first { $0.name == settingsSitemapForWatch }?.label ?? "unknown"
+            homePreferences.sitemapForCarPlay = settingsSitemapForCarPlay
             homePreferences.localConnectionConfig = settingsLocalConnectionConfiguration
             homePreferences.remoteConnectionConfig = settingsRemoteConnectionConfiguration
             homePreferences.sseCommandItem = settingsSSECommandItem

--- a/openHAB/UI/SettingsView/SitemapSettingsView.swift
+++ b/openHAB/UI/SettingsView/SitemapSettingsView.swift
@@ -20,6 +20,7 @@ struct SitemapSettingsView: View {
     @Binding var settingsIconType: IconType
     @Binding var settingsSortSitemapsBy: SortSitemapsOrder
     @Binding var settingsSitemapForWatch: String
+    @Binding var settingsSitemapForCarPlay: String
     @Binding var sitemaps: [OpenHABSitemap]
 
     @State private var showingCacheAlert = false
@@ -33,6 +34,7 @@ struct SitemapSettingsView: View {
             iconTypePicker
             sortOrderPicker
             watchSitemapPicker
+            carPlaySitemapPicker
         }
     }
 
@@ -102,6 +104,18 @@ struct SitemapSettingsView: View {
         .disabled(sitemaps.isEmpty)
     }
 
+    private var carPlaySitemapPicker: some View {
+        Picker("Sitemap for CarPlay", selection: $settingsSitemapForCarPlay) {
+            Text("None").tag("")
+            if !sitemaps.isEmpty {
+                ForEach(sitemaps, id: \.name) { sitemap in
+                    Text(sitemap.label).tag(sitemap.name)
+                }
+            }
+        }
+        .disabled(sitemaps.isEmpty)
+    }
+
     @ViewBuilder
     private func cacheAlertActions(_ result: Result<UInt, KingfisherError>) -> some View {
         switch result {
@@ -142,6 +156,7 @@ struct SitemapSettingsView: View {
         @State var iconType: IconType = .svg
         @State var sortSitemapsBy: SortSitemapsOrder = .label
         @State var sitemapForWatch = "Home"
+        @State var sitemapForCarPlay = ""
         @State var sitemaps: [OpenHABSitemap] = [
             OpenHABSitemap(
                 name: "home",
@@ -167,6 +182,7 @@ struct SitemapSettingsView: View {
                         settingsIconType: $iconType,
                         settingsSortSitemapsBy: $sortSitemapsBy,
                         settingsSitemapForWatch: $sitemapForWatch,
+                        settingsSitemapForCarPlay: $sitemapForCarPlay,
                         sitemaps: $sitemaps
                     )
                 }


### PR DESCRIPTION
## Summary

- Adds a **CarPlay scene** (`CarPlaySceneDelegate`) that streams a designated sitemap (max 8 widgets) via long-poll and renders them as a `CPListTemplate`
- Supports **Switch** (toggle ON/OFF or pick from mappings), **Button** (send command), **Selection** (pick mapping), and **Text** (read-only) widgets
- **Settings**: new CarPlay sitemap picker in Settings → Sitemap Settings
- **Drawer**: steering wheel icon (iOS 16.1+) next to the assigned sitemap; long-press a sitemap row to assign/unassign it as the CarPlay sitemap without triggering navigation
- Preference changes are observed via `UserDefaults.didChangeNotification` and restart the stream automatically
- Requires `com.apple.developer.carplay-driving-task` entitlement (Apple approval needed for production profiles)

## Wiring

| File | Change |
|---|---|
| `Info.plist` | `UIApplicationSupportsMultipleScenes: true` + `CPTemplateApplicationSceneSessionRoleApplication` config |
| `AppDelegate` | Routes `carTemplateApplication` sessions to `CarPlaySceneDelegate` |
| `openHAB.entitlements` | `com.apple.developer.carplay-driving-task` |
| `project.pbxproj` | Links `CarPlay.framework` |

## Test plan

- [ ] Open CarPlay Simulator (Xcode → I/O → External Displays → CarPlay) with iPhone simulator focused
- [ ] Configure a sitemap in Settings → Sitemap for CarPlay
- [ ] Verify the sitemap's widgets appear in CarPlay (max 8, Switch/Button/Selection/Text only)
- [ ] Tap a Switch widget → state toggles
- [ ] Tap a Switch with mappings / Selection → sub-list appears, picking sends command
- [ ] Tap a Button widget → command sent
- [ ] Change the CarPlay sitemap in Settings → CarPlay updates automatically
- [ ] Long-press a sitemap in the Drawer → steering wheel icon toggles; tapping the row still navigates normally
- [ ] Disconnect CarPlay → stream stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)