### PR TITLE
Make Circular Accessory Switch icon state aware

### DIFF
--- a/openHABWidget/SwitchWidgetEntryView.swift
+++ b/openHABWidget/SwitchWidgetEntryView.swift
@@ -368,11 +368,13 @@ struct SwitchAccessoryCircularView: View {
         ZStack {
             AccessoryWidgetBackground()
             if let slot = entry.slots.compactMap(\.self).first {
+                let isOn = slot.item.state == "ON"
                 if let home = entry.home {
                     Button(intent: createToggleIntent(item: slot.item, homeUUID: slot.homeUUID, home: home)) {
                         VStack(spacing: 2) {
-                            Image(systemSymbol: .switch2)
-                                .font(.caption)
+                            let symbol: SFSymbol = isOn ? .powerCircleFill : .powerCircle
+                            Image(systemSymbol: symbol)
+                                .font(.callout)
                             Text(slot.item.state ?? "?")
                                 .font(.caption2)
                                 .fontWeight(.bold)
@@ -383,8 +385,9 @@ struct SwitchAccessoryCircularView: View {
                     .buttonStyle(.plain)
                 } else {
                     VStack(spacing: 2) {
-                        Image(systemSymbol: .switch2)
-                            .font(.caption)
+                        let symbol: SFSymbol = isOn ? .powerCircleFill : .powerCircle
+                        Image(systemSymbol: symbol)
+                            .font(.callout)
                         Text(slot.item.state ?? "?")
                             .font(.caption2)
                             .fontWeight(.bold)


### PR DESCRIPTION
<img width="74" height="69" alt="Screenshot 2026-07-06 at 21 04 21" src="https://github.com/user-attachments/assets/b59f344e-de05-42fa-9dc8-b85ae0453dda" />
<img width="80" height="76" alt="Screenshot 2026-07-06 at 21 04 04" src="https://github.com/user-attachments/assets/43d685e7-6895-4c7e-b589-c481a5474260" />
