### PR TITLE
fix: guard against empty string in device:tts and empty action parts

### DIFF
--- a/openHAB/UI/OpenHABRootViewController.swift
+++ b/openHAB/UI/OpenHABRootViewController.swift
@@ -658,6 +658,7 @@ class OpenHABRootViewController: UIViewController {
 
         guard let action else { return }
         let actionParts = action.split(separator: ":")
+        guard !actionParts.isEmpty else { return }
         let cmd = actionParts.dropFirst().joined(separator: ":")
 
         switch actionParts[0] {
@@ -836,6 +837,10 @@ class OpenHABRootViewController: UIViewController {
                 view.window?.windowScene?.screen.brightness = target
             }
         case "tts":
+            guard !arg1.isEmpty else {
+                Logger.viewController.warning("device:tts received with empty text, ignoring")
+                return
+            }
             func normalizeVoiceName(from input: String) -> String {
                 input
                     .lowercased()


### PR DESCRIPTION
## Summary

- `AVSpeechUtterance(string:)` crashes with `NSInvalidArgumentException` when passed an empty string. This fires when an SSE item state update carries the value `device:tts` with no text after the command token.
- Also adds a defensive guard on `actionParts` before subscripting `[0]`, which would crash if an item state is an empty string `""`.

Fixes crash observed in Crashlytics session `4f1f9507dcb94d6e8bede752ba189af0` (3.3.7 / build 301), where the main-thread crash stack was:

```
handleNotificationInternal(_:notification:) :675
handleSSEMessage(_:)                        :237
closure #2 in startSSEListening()           :203
```

## Test plan

- [ ] Send a `device:tts` command (no text) via a rule or HABPanel — app should log a warning and not crash
- [ ] Verify normal `device:tts:Hello world` TTS still works
- [ ] Confirm no regression on other `device:` sub-commands (screensaver, idletimer, brightness)