### PR TITLE
Add Garage Door icon to CarPlay icons

### DIFF
--- a/openHAB/CarPlaySceneDelegate.swift
+++ b/openHAB/CarPlaySceneDelegate.swift
@@ -248,6 +248,8 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         let icon = widget.icon.lowercased()
         let symbolName: SFSymbol = if icon.contains("power") {
             isOn ? .powerCircleFill : .powerCircle
+        } else if icon.contains("garage") {
+            isOn ? .doorGarageDoubleBayOpen : .doorGarageDoubleBayClosed
         } else if icon.contains("lamp") || icon.contains("light") || icon.contains("bulb") {
             isOn ? .lightbulbFill : .lightbulb
         } else if icon.contains("lock") || icon.contains("security") || icon.contains("alarm") {


### PR DESCRIPTION
Might possibly become the most frequently used icon button for CarPlay ;)

<img width="91" height="91" alt="Screenshot 2026-07-20 at 18 09 49" src="https://github.com/user-attachments/assets/b50b326f-e444-4dff-b89e-e0fa3d894377" />

<img width="93" height="84" alt="Screenshot 2026-07-20 at 18 09 57" src="https://github.com/user-attachments/assets/ae294759-6a58-4b17-9d9a-21aad7b524da" />
