### PR TITLE
fix(lifecycle): disarm screensaver on applicationWillResignActive

### DIFF
--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -205,6 +205,13 @@ extension Notification.Name {
 }
 
 extension AppDelegate {
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Mirrors the pre-refactor SceneDelegate.sceneWillResignActive: dismiss the
+        // screensaver overlay and restore brightness before the app leaves the
+        // foreground, rather than leaving that to the next touch after returning.
+        NotificationCenter.default.post(name: .disableScreenSaver, object: nil)
+    }
+
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.


### PR DESCRIPTION
## Summary
- The old `SceneDelegate.sceneWillResignActive` posted `.disableScreenSaver` to dismiss the screensaver overlay and restore brightness before the app left the foreground.
- That hook was dropped when the scene manifest / `SceneDelegate` were removed in favor of the SwiftUI app lifecycle (`OpenHABApp` + `AppDelegate` via `UIApplicationDelegateAdaptor`), leaving the overlay/dimmed brightness to linger into the background and app-switcher snapshot until the next touch.
- Adds the missing `applicationWillResignActive` to `AppDelegate`, restoring the original behavior via the classic `UIApplicationDelegate` callback (still delivered normally since there's no custom scene delegate anymore).

## Test plan
- [x] `xcodebuild build` for the `openHAB` scheme succeeds
- [ ] Manually verify: enable screensaver auto-dimming, let it activate, then background the app without touching the screen — brightness/overlay should reset immediately instead of on next foreground touch