### PR TITLE
Slightly widening the new menu

### DIFF
--- a/openHAB/UI/ToolbarMenu.swift
+++ b/openHAB/UI/ToolbarMenu.swift
@@ -363,7 +363,7 @@ struct ToolbarMenu: View {
             }
 
         }
-        .frame(width: 280)
+        .frame(width: 300)
     }
 
     // MARK: - Home header


### PR DESCRIPTION
Slightly widening the new menu by 20 to avoid potential awkward URL line wrappings.

Before

<img width="426" height="252" alt="Screenshot 2026-08-25 at 21 51 16" src="https://github.com/user-attachments/assets/74fcf9cf-066e-4a5a-847e-fc76b58827d3" />

<img width="412" height="254" alt="Screenshot 2026-08-25 at 21 50 40" src="https://github.com/user-attachments/assets/664c7db8-de82-4295-accf-a6b82ce8651a" />

Slightly wider

<img width="426" height="281" alt="Screenshot 2026-08-25 at 21 52 59" src="https://github.com/user-attachments/assets/87ae8c74-225a-4b14-9efd-2c5c913c529f" />
