### PR TITLE
feat(sitemap): add command confirmation prompt (commandConfirmMessage)

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
@@ -3245,6 +3245,15 @@ public enum Components {
                     yield &self.storage.value.iconcolor
                 }
             }
+            /// - Remark: Generated from `#/components/schemas/WidgetDTO/commandConfirmMessage`.
+            public var commandConfirmMessage: Swift.String? {
+                get  {
+                    self.storage.value.commandConfirmMessage
+                }
+                _modify {
+                    yield &self.storage.value.commandConfirmMessage
+                }
+            }
             /// - Remark: Generated from `#/components/schemas/WidgetDTO/pattern`.
             public var pattern: Swift.String? {
                 get  {
@@ -3511,6 +3520,7 @@ public enum Components {
             ///   - labelcolor:
             ///   - valuecolor:
             ///   - iconcolor:
+            ///   - commandConfirmMessage:
             ///   - pattern:
             ///   - unit:
             ///   - mappings:
@@ -3551,6 +3561,7 @@ public enum Components {
                 labelcolor: Swift.String? = nil,
                 valuecolor: Swift.String? = nil,
                 iconcolor: Swift.String? = nil,
+                commandConfirmMessage: Swift.String? = nil,
                 pattern: Swift.String? = nil,
                 unit: Swift.String? = nil,
                 mappings: [Components.Schemas.MappingDTO]? = nil,
@@ -3592,6 +3603,7 @@ public enum Components {
                     labelcolor: labelcolor,
                     valuecolor: valuecolor,
                     iconcolor: iconcolor,
+                    commandConfirmMessage: commandConfirmMessage,
                     pattern: pattern,
                     unit: unit,
                     mappings: mappings,
@@ -3634,6 +3646,7 @@ public enum Components {
                 case labelcolor
                 case valuecolor
                 case iconcolor
+                case commandConfirmMessage
                 case pattern
                 case unit
                 case mappings
@@ -3694,6 +3707,8 @@ public enum Components {
                 var valuecolor: Swift.String?
                 /// - Remark: Generated from `#/components/schemas/WidgetDTO/iconcolor`.
                 var iconcolor: Swift.String?
+                /// - Remark: Generated from `#/components/schemas/WidgetDTO/commandConfirmMessage`.
+                var commandConfirmMessage: Swift.String?
                 /// - Remark: Generated from `#/components/schemas/WidgetDTO/pattern`.
                 var pattern: Swift.String?
                 /// - Remark: Generated from `#/components/schemas/WidgetDTO/unit`.
@@ -3762,6 +3777,7 @@ public enum Components {
                     labelcolor: Swift.String? = nil,
                     valuecolor: Swift.String? = nil,
                     iconcolor: Swift.String? = nil,
+                    commandConfirmMessage: Swift.String? = nil,
                     pattern: Swift.String? = nil,
                     unit: Swift.String? = nil,
                     mappings: [Components.Schemas.MappingDTO]? = nil,
@@ -3802,6 +3818,7 @@ public enum Components {
                     self.labelcolor = labelcolor
                     self.valuecolor = valuecolor
                     self.iconcolor = iconcolor
+                    self.commandConfirmMessage = commandConfirmMessage
                     self.pattern = pattern
                     self.unit = unit
                     self.mappings = mappings
@@ -3850,6 +3867,8 @@ public enum Components {
             public var valuecolor: Swift.String?
             /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent/iconcolor`.
             public var iconcolor: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent/commandConfirmMessage`.
+            public var commandConfirmMessage: Swift.String?
             /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent/state`.
             public var state: Swift.String?
             /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent/reloadIcon`.
@@ -3874,6 +3893,7 @@ public enum Components {
             ///   - labelcolor:
             ///   - valuecolor:
             ///   - iconcolor:
+            ///   - commandConfirmMessage:
             ///   - state:
             ///   - reloadIcon:
             ///   - visibility:
@@ -3889,6 +3909,7 @@ public enum Components {
                 labelcolor: Swift.String? = nil,
                 valuecolor: Swift.String? = nil,
                 iconcolor: Swift.String? = nil,
+                commandConfirmMessage: Swift.String? = nil,
                 state: Swift.String? = nil,
                 reloadIcon: Swift.Bool? = nil,
                 visibility: Swift.Bool? = nil,
@@ -3904,6 +3925,7 @@ public enum Components {
                 self.labelcolor = labelcolor
                 self.valuecolor = valuecolor
                 self.iconcolor = iconcolor
+                self.commandConfirmMessage = commandConfirmMessage
                 self.state = state
                 self.reloadIcon = reloadIcon
                 self.visibility = visibility
@@ -3920,6 +3942,7 @@ public enum Components {
                 case labelcolor
                 case valuecolor
                 case iconcolor
+                case commandConfirmMessage
                 case state
                 case reloadIcon
                 case visibility

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemapWidgetEvent.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABSitemapWidgetEvent.swift
@@ -22,6 +22,7 @@ public struct OpenHABSitemapWidgetEvent: Sendable {
     public let labelcolor: String?
     public let valuecolor: String?
     public let iconcolor: String?
+    public let commandConfirmMessage: String?
     public let visibility: Bool?
     public let state: String?
     public let enrichedItem: OpenHABItem?
@@ -37,6 +38,7 @@ public struct OpenHABSitemapWidgetEvent: Sendable {
                 labelcolor: String? = nil,
                 valuecolor: String? = nil,
                 iconcolor: String? = nil,
+                commandConfirmMessage: String? = nil,
                 visibility: Bool? = nil,
                 state: String? = nil,
                 enrichedItem: OpenHABItem? = nil,
@@ -51,6 +53,7 @@ public struct OpenHABSitemapWidgetEvent: Sendable {
         self.labelcolor = labelcolor
         self.valuecolor = valuecolor
         self.iconcolor = iconcolor
+        self.commandConfirmMessage = commandConfirmMessage
         self.visibility = visibility
         self.state = state
         self.enrichedItem = enrichedItem
@@ -70,6 +73,7 @@ public struct OpenHABSitemapWidgetEvent: Sendable {
             labelcolor: event.labelcolor,
             valuecolor: event.valuecolor,
             iconcolor: event.iconcolor,
+            commandConfirmMessage: event.commandConfirmMessage,
             visibility: event.visibility,
             state: event.state,
             enrichedItem: OpenHABItem(event.item),

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABWidget.swift
@@ -91,6 +91,10 @@ public class OpenHABWidget: NSObject, MKAnnotation, Identifiable, ObservableObje
     @Published public var iconColor = ""
     @Published public var labelcolor = ""
     @Published public var valuecolor = ""
+    /// A confirmation prompt to show before sending a command from this widget, or nil if none
+    /// is required. Set server-side (openHAB core sitemap `confirmCmd`) and, like visibility/icon/
+    /// labelcolor, can change dynamically via SSE.
+    @Published public var commandConfirmMessage: String?
     public var service = ""
     @Published public var state = ""
     public var text = ""
@@ -169,7 +173,8 @@ public extension OpenHABWidget {
                      staticIcon: Bool? = nil,
                      unit: String? = nil,
                      pattern: String? = nil,
-                     yAxisDecimalPattern: String? = nil) {
+                     yAxisDecimalPattern: String? = nil,
+                     commandConfirmMessage: String? = nil) {
         self.init()
         id = widgetId
         self.widgetId = widgetId
@@ -191,6 +196,7 @@ public extension OpenHABWidget {
         self.iconColor = iconColor ?? ""
         labelcolor = labelColor ?? ""
         valuecolor = valueColor ?? ""
+        self.commandConfirmMessage = commandConfirmMessage
         self.service = service ?? ""
         self.state = state ?? ""
         self.text = text ?? ""
@@ -275,12 +281,14 @@ public extension OpenHABWidget {
                 || event.enrichedItem != nil || event.labelcolor != nil
                 || event.valuecolor != nil || event.iconcolor != nil
                 || event.visibility != nil || event.labelSource != nil
+                || event.commandConfirmMessage != nil
             else { return .unchanged }
             if let label = event.label { self.label = label }
             if let icon = event.icon { self.icon = icon }
             if let labelcolor = event.labelcolor { self.labelcolor = labelcolor }
             if let valuecolor = event.valuecolor { self.valuecolor = valuecolor }
             if let iconcolor = event.iconcolor { iconColor = iconcolor }
+            if let commandConfirmMessage = event.commandConfirmMessage { self.commandConfirmMessage = commandConfirmMessage }
             if let visibility = event.visibility { self.visibility = visibility }
             if let state = event.state {
                 self.state = state
@@ -345,7 +353,8 @@ extension OpenHABWidget {
             staticIcon: widget.staticIcon,
             unit: widget.unit,
             pattern: widget.pattern,
-            yAxisDecimalPattern: widget.yAxisDecimalPattern
+            yAxisDecimalPattern: widget.yAxisDecimalPattern,
+            commandConfirmMessage: widget.commandConfirmMessage
         )
     }
 }

--- a/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandDispatcher.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandDispatcher.swift
@@ -16,6 +16,15 @@ import os.log
 public final class WidgetCommandDispatcher {
     private var pendingTasks: [String: Task<Void, Never>] = [:]
 
+    /// When set, an `.immediate`-policy widget dispatch whose widget has a non-empty
+    /// commandConfirmMessage is routed through this instead of sending directly -- it's expected
+    /// to present a confirmation UI and call `proceed()` if the user confirms. Only `.immediate`
+    /// is gated: `.debounce`/`.finalOnly`/`.pressRelease` back continuous-drag interactions
+    /// (Slider, Setpoint, ColorPicker dragging), which can reach dispatch repeatedly during a
+    /// single gesture -- confirming each one would prompt mid-drag. Confirming a continuous
+    /// gesture once, up front, is a different UX pattern that isn't implemented here.
+    public var confirmationHandler: ((_ message: String, _ proceed: @escaping () -> Void) -> Void)?
+
     public init() {}
 
     @MainActor
@@ -29,7 +38,7 @@ public final class WidgetCommandDispatcher {
 
         switch policy {
         case .immediate:
-            dispatch(command: command, for: widget, fallbackItem: fallbackItem)
+            dispatchConfirmingIfNeeded(command: command, for: widget, fallbackItem: fallbackItem)
         case let .debounce(duration):
             guard phase != .release else {
                 dispatch(command: command, for: widget, fallbackItem: fallbackItem)
@@ -207,6 +216,17 @@ public final class WidgetCommandDispatcher {
             guard !Task.isCancelled else { return }
             execute(itemname, command)
             self?.pendingTasks.removeValue(forKey: taskKey)
+        }
+    }
+
+    @MainActor
+    private func dispatchConfirmingIfNeeded(command: String, for widget: OpenHABWidget, fallbackItem: OpenHABItem?) {
+        guard let message = widget.commandConfirmMessage, !message.isEmpty, let confirmationHandler else {
+            dispatch(command: command, for: widget, fallbackItem: fallbackItem)
+            return
+        }
+        confirmationHandler(message) { [weak self] in
+            self?.dispatch(command: command, for: widget, fallbackItem: fallbackItem)
         }
     }
 

--- a/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandPolicy.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/WidgetCommandPolicy.swift
@@ -44,3 +44,18 @@ public enum WidgetCommandPolicy: Sendable {
     /// Dispatches only for `.press` and `.release` phases.
     case pressRelease
 }
+
+/// A discrete command held for user confirmation before it's actually sent. Shared between the
+/// iOS and watchOS apps: each presents this as an alert; confirming runs `onConfirm`, cancelling
+/// just discards it.
+@MainActor
+public struct PendingCommandConfirmation: Identifiable {
+    public let id = UUID()
+    public let message: String
+    public let onConfirm: () -> Void
+
+    public init(message: String, onConfirm: @escaping () -> Void) {
+        self.message = message
+        self.onConfirm = onConfirm
+    }
+}

--- a/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
+++ b/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
@@ -9472,6 +9472,9 @@
           "iconcolor": {
             "type": "string"
           },
+          "commandConfirmMessage": {
+              "type": "string"
+          },
           "pattern": {
             "type": "string"
           },
@@ -9591,6 +9594,9 @@
               "type": "string"
           },
           "iconcolor": {
+              "type": "string"
+          },
+          "commandConfirmMessage": {
               "type": "string"
           },
           "state": {

--- a/openHAB/Models/SitemapPageViewModel+Commands.swift
+++ b/openHAB/Models/SitemapPageViewModel+Commands.swift
@@ -64,18 +64,35 @@ extension SitemapPageViewModel {
             phase: phase,
             key: key
         ) { [weak self] itemname, command in
-            self?.sendCommand(itemname: itemname, command: command, origin: .command)
+            self?.dispatchConfirmingIfNeeded(itemname: itemname, command: command, policy: policy)
         }
     }
 
     func sendCommand(_ item: OpenHABItem?, commandToSend command: String?) {
         commandDispatcher.send(command, for: item, policy: .immediate, phase: .change) { [weak self] itemname, command in
-            self?.sendCommand(itemname: itemname, command: command, origin: .command)
+            self?.dispatchConfirmingIfNeeded(itemname: itemname, command: command, policy: .immediate)
         }
     }
 
     func sendCommand(itemname: String, command: String) {
-        sendCommand(itemname: itemname, command: command, origin: .command)
+        dispatchConfirmingIfNeeded(itemname: itemname, command: command, policy: .immediate)
+    }
+
+    /// Gates a discrete, single-shot command behind a confirmation alert if the originating
+    /// widget has a `commandConfirmMessage` set. Only `.immediate`-policy dispatches are gated:
+    /// continuous-drag interactions (Slider dragging, Setpoint's live update, ColorPicker's
+    /// debounced wheel drag -- all routed through sendToUpdate or a .debounce policy) can fire
+    /// their completion closure repeatedly during a single gesture, so confirming each one would
+    /// prompt mid-drag. Confirming a continuous gesture once, up front, is a different UX pattern
+    /// that isn't implemented here.
+    private func dispatchConfirmingIfNeeded(itemname: String, command: String, policy: WidgetCommandPolicy) {
+        guard case .immediate = policy, let message = commandConfirmMessagesByItemName[itemname] else {
+            sendCommand(itemname: itemname, command: command, origin: .command)
+            return
+        }
+        pendingCommandConfirmation = PendingCommandConfirmation(message: message) { [weak self] in
+            self?.sendCommand(itemname: itemname, command: command, origin: .command)
+        }
     }
 
     func sendToUpdate(item: OpenHABItem?,

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -64,6 +64,10 @@ class SitemapPageViewModel: ObservableObject {
     var commandStateVersions: [String: Int] = [:]
     var queuedCommands: [String: QueuedCommand] = [:]
     private var rowWidgetIndex: [RowID: OpenHABWidget] = [:]
+    var commandConfirmMessagesByItemName: [String: String] = [:]
+    /// Set while a command is being held for user confirmation. SitemapPageView presents this as
+    /// an alert; confirming or cancelling clears it and, if confirmed, runs `onConfirm`.
+    @Published var pendingCommandConfirmation: PendingCommandConfirmation?
     private var previousBuildRenderKeys: [WidgetRenderKey] = []
     private var previousBuildRowIDs: [RowID] = []
     var sliderValueOverrides: [String: Double] = [:]
@@ -713,6 +717,18 @@ extension SitemapPageViewModel {
         for (rowID, widget) in zip(result.rowIDs, widgets) {
             index[rowID] = widget
         }
+
+        // Keyed by item name (not by widget) to match the granularity SitemapPageViewModel+Commands
+        // already tracks command state at (commandStates[itemname], queuedCommands[itemname]). If
+        // multiple widgets on the same page target the same item with different confirm messages,
+        // the last one wins -- an acceptable simplification, not a new limitation.
+        var confirmMessages: [String: String] = [:]
+        for widget in widgets {
+            guard let itemname = widget.item?.name, let message = widget.commandConfirmMessage,
+                  !message.isEmpty else { continue }
+            confirmMessages[itemname] = message
+        }
+        commandConfirmMessagesByItemName = confirmMessages
 
         let rowInputLayoutChanged = SitemapRowLayoutIdentity.makeIdentities(from: result.inputs) !=
             SitemapRowLayoutIdentity.makeIdentities(from: rowInputs)

--- a/openHAB/UI/SwiftUI/SitemapPageView.swift
+++ b/openHAB/UI/SwiftUI/SitemapPageView.swift
@@ -62,6 +62,16 @@ struct SitemapPageView: View {
                         .ohTextToken(.secondary)
                 }
             })
+            .alert(
+                "Confirm",
+                isPresented: commandConfirmationPresented,
+                presenting: viewModel.pendingCommandConfirmation
+            ) { pending in
+                Button("Cancel", role: .cancel) {}
+                Button("Confirm") { pending.onConfirm() }
+            } message: { pending in
+                Text(pending.message)
+            }
     }
 
     @ViewBuilder
@@ -134,6 +144,13 @@ struct SitemapPageView: View {
         Binding(
             get: { viewModel.error != nil && !(viewModel.error is SitemapPageError) },
             set: { if !$0 { Task { @MainActor in viewModel.error = nil } } }
+        )
+    }
+
+    private var commandConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { viewModel.pendingCommandConfirmation != nil },
+            set: { if !$0 { viewModel.pendingCommandConfirmation = nil } }
         )
     }
 

--- a/openHABWatch/Domain/UserData.swift
+++ b/openHABWatch/Domain/UserData.swift
@@ -26,6 +26,7 @@ final class UserData: ObservableObject {
     @Published var showCertificateAlert = false
     @Published var certificateErrorDescription = ""
     @Published var isLoadingSitemap = false
+    @Published var pendingCommandConfirmation: PendingCommandConfirmation?
 
     // Cache last successful widgets to prevent empty state during reconnections
     private var cachedWidgets: [OpenHABWidget] = []

--- a/openHABWatch/Preview Content/PreviewNavigationContainer.swift
+++ b/openHABWatch/Preview Content/PreviewNavigationContainer.swift
@@ -47,6 +47,7 @@ struct InteractiveStateTokenPreview<Content: View>: View {
 
 struct PreviewNavigationContainer<Content: View>: View {
     @State private var settings = AppSettings()
+    @State private var userData = UserData(preview: true)
     private let content: Content
 
     var body: some View {
@@ -54,6 +55,7 @@ struct PreviewNavigationContainer<Content: View>: View {
             content
         }
         .environmentObject(settings)
+        .environmentObject(userData)
     }
 
     init(@ViewBuilder content: () -> Content) {

--- a/openHABWatch/Views/Rows/ColorPickerRow.swift
+++ b/openHABWatch/Views/Rows/ColorPickerRow.swift
@@ -18,6 +18,7 @@ struct ColorPickerRow: View {
     let widget: OpenHABWidget
     let stateToken: String
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     @State private var viewModel: WidgetRowViewModel
     @State private var commandSender = WidgetCommandDispatcher()
     var body: some View {
@@ -66,6 +67,11 @@ struct ColorPickerRow: View {
             }
             .onChange(of: stateToken, initial: false) { _, _ in
                 viewModel.update(from: widget)
+            }
+            .onAppear {
+                commandSender.confirmationHandler = { message, proceed in
+                    pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+                }
             }
     }
 

--- a/openHABWatch/Views/Rows/RollershutterRow.swift
+++ b/openHABWatch/Views/Rows/RollershutterRow.swift
@@ -17,6 +17,7 @@ import SwiftUI
 struct RollershutterRow: View {
     let widget: OpenHABWidget
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     @State private var commandSender = WidgetCommandDispatcher()
 
     var body: some View {
@@ -45,6 +46,11 @@ struct RollershutterRow: View {
             .frame(height: 50)
         }
         .accessibilityLabel(widget.labelText)
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
+        }
     }
 }
 

--- a/openHABWatch/Views/Rows/SegmentRow.swift
+++ b/openHABWatch/Views/Rows/SegmentRow.swift
@@ -17,6 +17,7 @@ struct SegmentRow: View {
     let widget: OpenHABWidget
     let stateToken: String
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     @State private var pressedIndex: Int?
     @State private var singlePressed = false
     @State private var triggerPressFeedback = false
@@ -40,6 +41,11 @@ struct SegmentRow: View {
         .sensoryFeedback(.impact(weight: .medium), trigger: triggerPressFeedback)
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
+        }
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
         }
     }
 

--- a/openHABWatch/Views/Rows/SegmentSelectionView.swift
+++ b/openHABWatch/Views/Rows/SegmentSelectionView.swift
@@ -17,6 +17,7 @@ struct SegmentSelectionView: View {
     let stateToken: String
     @Binding var selectedIndex: Int?
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var pageData: UserData
     @State private var pressedIndex: Int?
     @State private var viewModel: WidgetRowViewModel
     @State private var commandSender = WidgetCommandDispatcher()
@@ -46,6 +47,11 @@ struct SegmentSelectionView: View {
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
             selectedIndex = viewModel.selectedIndex
+        }
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
         }
     }
 

--- a/openHABWatch/Views/Rows/SelectionRow.swift
+++ b/openHABWatch/Views/Rows/SelectionRow.swift
@@ -21,6 +21,7 @@ struct SelectionListView: View {
     let title: String
     @Binding var selectedIndex: Int?
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var pageData: UserData
     @State private var commandSender = WidgetCommandDispatcher()
 
     var body: some View {
@@ -59,6 +60,11 @@ struct SelectionListView: View {
         }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
+        }
     }
 
     private func selectOption(at index: Int) {

--- a/openHABWatch/Views/Rows/SetpointRow.swift
+++ b/openHABWatch/Views/Rows/SetpointRow.swift
@@ -19,6 +19,7 @@ struct SetpointRow: View {
     let widget: OpenHABWidget
     let stateToken: String
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     private let setpointService = SetPointService()
     private let logger = Logger(subsystem: "org.openhab.watch", category: "SetpointRow")
     @State private var viewModel: WidgetRowViewModel
@@ -94,6 +95,11 @@ struct SetpointRow: View {
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
             localValue = nil
+        }
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
         }
     }
 

--- a/openHABWatch/Views/Rows/SliderRow.swift
+++ b/openHABWatch/Views/Rows/SliderRow.swift
@@ -19,6 +19,7 @@ struct SliderRow: View {
     let widget: OpenHABWidget
     let stateToken: String
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     var fallbackSymbol: SFSymbol?
     @State private var pendingValue: Double?
     @State private var viewModel: WidgetRowViewModel
@@ -119,6 +120,11 @@ struct SliderRow: View {
         .onChange(of: stateToken, initial: false) { _, _ in
             viewModel.update(from: widget)
             pendingValue = nil
+        }
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
         }
     }
 

--- a/openHABWatch/Views/Rows/SwitchRow.swift
+++ b/openHABWatch/Views/Rows/SwitchRow.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct SwitchRow: View {
     let widget: OpenHABWidget
     @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var pageData: UserData
     let stateToken: String
     @State private var localIsOn: Bool?
     @State private var commandSender = WidgetCommandDispatcher()
@@ -50,6 +51,11 @@ struct SwitchRow: View {
         .accessibilityValue(isOn ? "On" : "Off")
         .onChange(of: stateToken) {
             localIsOn = nil
+        }
+        .onAppear {
+            commandSender.confirmationHandler = { message, proceed in
+                pageData.pendingCommandConfirmation = PendingCommandConfirmation(message: message, onConfirm: proceed)
+            }
         }
     }
 }

--- a/openHABWatch/Views/SitemapPageView.swift
+++ b/openHABWatch/Views/SitemapPageView.swift
@@ -125,6 +125,20 @@ struct SitemapPageView: View {
         .refreshable {
             await viewModel.refreshUrl(force: true)
         }
+        .environmentObject(viewModel)
+        .alert(
+            "Confirm",
+            isPresented: Binding(
+                get: { viewModel.pendingCommandConfirmation != nil },
+                set: { if !$0 { viewModel.pendingCommandConfirmation = nil } }
+            ),
+            presenting: viewModel.pendingCommandConfirmation
+        ) { pending in
+            Button("Cancel", role: .cancel) {}
+            Button("Confirm") { pending.onConfirm() }
+        } message: { pending in
+            Text(pending.message)
+        }
     }
 
     init(viewModel: UserData, isRoot: Bool = true) {


### PR DESCRIPTION
## Summary
Implements client support for [openhab-core#5769](https://github.com/openhab/openhab-core/pull/5769), which adds a per-widget `confirmCmd` sitemap parameter. The REST API and SSE expose it to clients as a plain string field, `commandConfirmMessage`: if present on a widget, show a confirmation prompt with that text before sending the widget's command; if absent/null, send immediately as before.

**⚠️ Not testable yet.** The core PR is still under review/unmerged as of this writing — no released openHAB core build supports this field. This branch adds it to our checked-in `openapi.json` speculatively so the app is ready the moment core support ships. There is currently no server to verify end-to-end behavior against; only local build/compile/unit-test verification has been done. Opening as a draft for that reason — please don't merge until there's a core build to test against.

### OpenHABCore
- Added `commandConfirmMessage` to `WidgetDTO` and `SitemapWidgetEvent` in `openapi.json`; regenerated `Types.swift` via the documented CLI invocation.
- `OpenHABWidget`: new `commandConfirmMessage` property, wired through the `WidgetDTO` init and `apply(event:)` so it can change dynamically via SSE, same as visibility/icon/labelcolor.
- `OpenHABSitemapWidgetEvent`: added the field to the SSE event model.
- `WidgetCommandDispatcher`: new `confirmationHandler` closure, invoked only for `.immediate`-policy widget dispatches with a non-empty `commandConfirmMessage`. `.debounce`/`.finalOnly`/`.pressRelease` are deliberately **not** gated — continuous-drag interactions (Slider, Setpoint, ColorPicker dragging) can reach dispatch repeatedly during a single gesture, so confirming each would prompt mid-drag. Confirming a continuous gesture once, up front, is a different UX pattern not implemented here.
- `PendingCommandConfirmation` moved here (shared by both apps).

### Main iOS app
- `SitemapPageViewModel` maintains an item-name-keyed confirm-message lookup, rebuilt alongside `rowInputs`, and gates both command-sending entry points — every row view already funnels through one of these two methods, so no `RowInput` struct or row view needed to change.
- `SitemapPageView` presents the confirmation alert.

### Apple Watch app
Each row view creates its own `WidgetCommandDispatcher` instance (no shared view model to gate centrally), so each of the 8 row views wires `confirmationHandler` to `UserData.pendingCommandConfirmation` in `onAppear`. `SitemapPageView` (watch) presents the alert. `PreviewNavigationContainer` now also injects a `UserData` environment object so existing row previews keep working.

## Test plan
- [x] `openHAB` scheme builds
- [x] `openHABWatch` scheme builds
- [x] `OpenHABCoreTests` (including `WidgetCommandDispatcherTests`) pass
- [ ] No automated test coverage for the confirmation-gating behavior itself yet
- [ ] End-to-end verification against a real server blocked on openhab-core#5769 shipping