### PR TITLE
fix(widget): use server transformedState in Sensor Home Screen widget

### DIFF
--- a/AppIntents/Intents/GetItemStateIntent.swift
+++ b/AppIntents/Intents/GetItemStateIntent.swift
@@ -92,18 +92,9 @@ struct GetItemStateIntent: AppIntent {
         guard let item = await OpenHABItemCache.instance.getItemUncached(name: itemEntity.itemName, home: homeId) else {
             throw ItemStateError.itemNotFound(itemEntity.itemName)
         }
-        let rawState = item.state ?? "Unknown state"
-
-        // Prefer the server-formatted state, then fall back to local number formatting,
-        // then fall back to the raw state string.
-        let displayState: String = if let transformed = item.transformedState, !transformed.isEmpty {
-            transformed
-        } else if let pattern = item.stateDescription?.numberPattern,
-                  Double(rawState.components(separatedBy: " ").first ?? "") != nil {
-            rawState.parseAsNumber(format: pattern).toString(locale: .current)
-        } else {
-            rawState
-        }
+        // See OpenHABItem.displayState (OpenHABCore) for the shared formatting rules —
+        // also used by the Home Screen widgets in SensorWidgetEntryView.swift.
+        let displayState = item.displayState ?? "Unknown state"
 
         let stateDisplay = LocalizedItemState(rawValue: displayState)
 

--- a/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Model/OpenHABItem.swift
@@ -82,6 +82,26 @@ public struct OpenHABItem: Sendable {
 extension OpenHABItem.ItemType: Decodable {}
 
 public extension OpenHABItem {
+    /// Best-effort human-readable state, shared by call sites that show an item's state
+    /// outside of a sitemap widget (Shortcuts intents, Home Screen widgets): prefers the
+    /// server-computed `transformedState`, then falls back to local number formatting —
+    /// but only when the raw state's leading token actually parses as a number, so a
+    /// non-numeric string (e.g. a String item) that merely starts with a digit isn't
+    /// truncated to that leading number — and otherwise returns the raw state unchanged.
+    /// Returns nil only when the item has no state at all; callers supply their own
+    /// "no state" fallback text.
+    var displayState: String? {
+        guard let rawState = state else { return nil }
+        if let transformed = transformedState, !transformed.isEmpty {
+            return transformed
+        }
+        if let pattern = stateDescription?.numberPattern,
+           Double(rawState.components(separatedBy: " ").first ?? "") != nil {
+            return rawState.parseAsNumber(format: pattern).toString(locale: .current)
+        }
+        return rawState
+    }
+
     func stateAsDouble() -> Double {
         state?.numberValue?.doubleValue ?? 0
     }

--- a/openHABWidget/SensorWidgetEntryView.swift
+++ b/openHABWidget/SensorWidgetEntryView.swift
@@ -147,11 +147,10 @@ struct SensorLargeProvider: AppIntentTimelineProvider {
 
 // MARK: - State formatting
 
+// See OpenHABItem.displayState (OpenHABCore) for the shared formatting rules —
+// also used by the "Get Item State" Shortcuts intent in GetItemStateIntent.swift.
 private func formattedState(for item: OpenHABItem) -> String {
-    guard let state = item.state else { return "—" }
-    guard let pattern = item.stateDescription?.numberPattern, !pattern.isEmpty else { return state }
-    let formatted = state.parseAsNumber(format: pattern).toString(locale: .current)
-    return formatted.isEmpty ? state : formatted
+    item.displayState ?? "—"
 }
 
 // MARK: - Unconfigured placeholder


### PR DESCRIPTION
## Summary
- The Home Screen "Sensor" widget's state formatting (introduced in #1312, part of 3.4.25) ignored the server-computed `transformedState` and unconditionally reformatted the raw state using the item's number pattern.
- For a non-numeric item (e.g. a String item like `"42 items available"`), this truncated the display down to just the leading number, since the number-formatting helper only keeps the first space-separated token.
- Extracted the already-correct transformedState-first, numeric-guarded logic from `GetItemStateIntent` (the "Get Item State" Shortcuts intent) into a shared `OpenHABItem.displayState` property in OpenHABCore, and switched both call sites to use it so they can't diverge again.

Fixes the regression reported in https://community.openhab.org/t/ios-shortcuts-access-to-group-items/169441/2

## Test plan
- [x] `xcodebuild -workspace openHAB.xcworkspace -scheme openHAB -configuration Debug build -destination 'generic/platform=iOS'` succeeds
- [ ] Manually verify Sensor Home Screen widget shows full displayState for a String item and a Group item with a server-side transform