### PR TITLE
Migrate MainActorNetworkTracker to @Observable

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/NetworkTracker.swift
@@ -9,9 +9,9 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
-import Combine
 import Foundation
 import Network
+import Observation
 import OpenAPIRuntime
 import os.log
 import Timeout
@@ -155,12 +155,13 @@ public actor ConnectionFailureTracker {
 }
 
 @MainActor
-public class MainActorNetworkTracker: ObservableObject {
+@Observable
+public final class MainActorNetworkTracker {
     public static let shared = MainActorNetworkTracker()
-    @Published public var activeConnection: ConnectionInfo?
-    @Published public var status: NetworkStatus = .stopped
-    @Published public var nextRetryDate: Date?
-    @Published public var isNetworkAvailable = true
+    public var activeConnection: ConnectionInfo?
+    public var status: NetworkStatus = .stopped
+    public var nextRetryDate: Date?
+    public var isNetworkAvailable = true
 
     public init(tracker: NetworkTracker = NetworkTracker.shared) {
         Task {

--- a/openHAB/Models/SitemapPageViewModel.swift
+++ b/openHAB/Models/SitemapPageViewModel.swift
@@ -44,8 +44,7 @@ class SitemapPageViewModel: ObservableObject {
     private var pageHandlingTask: Task<Void, Never>?
     var sseStreamTask: Task<Void, Never>?
     private var foregroundRefreshTask: Task<Void, Never>?
-    private var connectionObserverTask: Task<Void, Never>?
-    private var networkStatusObserverTask: Task<Void, Never>?
+    private var networkObserverTask: Task<Void, Never>?
     let commandDispatcher = WidgetCommandDispatcher()
     let sitemapEventStream = SitemapEventStream()
     var defaultSitemap = ""
@@ -158,23 +157,27 @@ class SitemapPageViewModel: ObservableObject {
     private func startObservers() {
         trackerStatus = networkTracker.status
 
-        // Observe connection changes (skip initial value) — initial load is triggered by .task in the view.
-        connectionObserverTask = Task { [weak self] in
-            guard let tracker = self?.networkTracker else { return }
-            for await connection in tracker.$activeConnection.values.dropFirst() {
-                await MainActor.run { [weak self] in
-                    self?.handleActiveConnectionChange(connection)
+        // Observe connection and status changes together via the actor's own state stream.
+        // Connection changes skip the initial value (initial load is triggered by .task in
+        // the view); status changes are handled from the first emitted value, matching
+        // trackerStatus's synchronous seed above.
+        networkObserverTask = Task { [weak self] in
+            var previousConnection = self?.networkTracker.activeConnection
+            var previousStatus: NetworkStatus?
+            for await state in await NetworkTracker.shared.stateStream() {
+                if state.activeConnection != previousConnection {
+                    previousConnection = state.activeConnection
+                    await MainActor.run { [weak self] in
+                        self?.handleActiveConnectionChange(state.activeConnection)
+                    }
                 }
-            }
-        }
-
-        networkStatusObserverTask = Task { [weak self] in
-            guard let tracker = self?.networkTracker else { return }
-            for await status in tracker.$status.values {
-                await MainActor.run { [weak self] in
-                    self?.trackerStatus = status
-                    if status == .connected {
-                        self?.flushQueuedCommands()
+                if state.status != previousStatus {
+                    previousStatus = state.status
+                    await MainActor.run { [weak self] in
+                        self?.trackerStatus = state.status
+                        if state.status == .connected {
+                            self?.flushQueuedCommands()
+                        }
                     }
                 }
             }
@@ -237,8 +240,7 @@ class SitemapPageViewModel: ObservableObject {
     }
 
     deinit {
-        connectionObserverTask?.cancel()
-        networkStatusObserverTask?.cancel()
+        networkObserverTask?.cancel()
         foregroundObserverTask?.cancel()
         pageHandlingTask?.cancel()
         sseStreamTask?.cancel()

--- a/openHAB/UI/MenuDataService.swift
+++ b/openHAB/UI/MenuDataService.swift
@@ -9,7 +9,6 @@
 //
 // SPDX-License-Identifier: EPL-2.0
 
-import Combine
 import OpenHABCore
 import os.log
 
@@ -22,17 +21,22 @@ class MenuDataService: ObservableObject {
     @Published var uiPages: [OpenHABUIPage] = []
     @Published var isLoading = false
 
-    private var cancellables = Set<AnyCancellable>()
+    private var networkObservationTask: Task<Void, Never>?
 
     init() {
-        MainActorNetworkTracker.shared.$activeConnection
-            .sink { [weak self] activeConnection in
+        networkObservationTask = Task { [weak self] in
+            var previousConnection: ConnectionInfo?
+            for await state in await NetworkTracker.shared.stateStream() {
+                guard state.activeConnection != previousConnection else { continue }
+                previousConnection = state.activeConnection
                 self?.clearAll()
-                Task { [weak self] in
-                    await self?.fetchData(activeConnection: activeConnection)
-                }
+                await self?.fetchData(activeConnection: state.activeConnection)
             }
-            .store(in: &cancellables)
+        }
+    }
+
+    deinit {
+        networkObservationTask?.cancel()
     }
 
     /// Clears all data immediately (shows empty state while fetching).

--- a/openHAB/UI/NotificationsView.swift
+++ b/openHAB/UI/NotificationsView.swift
@@ -128,8 +128,8 @@ struct NotificationRow: View {
 #if DEBUG
 
 @MainActor
-class MockNetworkTracker: NetworkTracking, ObservableObject {
-    @Published var activeConnection: ConnectionInfo?
+final class MockNetworkTracker: NetworkTracking {
+    var activeConnection: ConnectionInfo?
 
     init(connection: ConnectionInfo?) {
         activeConnection = connection
@@ -169,8 +169,8 @@ protocol NetworkTracking {
     var activeConnection: ConnectionInfo? { get }
 }
 
-struct NotificationsView<Tracker: NetworkTracking>: View where Tracker: ObservableObject {
-    @ObservedObject var networkTracker: Tracker
+struct NotificationsView<Tracker: NetworkTracking>: View {
+    var networkTracker: Tracker
     @State var notifications: [OpenHABNotification] = []
     let loadNotifications: NotificationLoader
     @Environment(\.dismiss) private var dismiss

--- a/openHAB/UI/OpenHABRootView.swift
+++ b/openHAB/UI/OpenHABRootView.swift
@@ -115,8 +115,11 @@ struct OpenHABRootView: View {
             webViewModel.syncActiveConnection()
         }
         .task {
-            for await connection in MainActorNetworkTracker.shared.$activeConnection.values {
-                activeNetworkConnection = connection
+            var previousConnection: ConnectionInfo?
+            for await state in await NetworkTracker.shared.stateStream() {
+                guard state.activeConnection != previousConnection else { continue }
+                previousConnection = state.activeConnection
+                activeNetworkConnection = state.activeConnection
             }
         }
         .sheet(isPresented: $showNotifications) {
@@ -557,7 +560,7 @@ struct OpenHABRootView: View {
 /// has given up — a static "cannot connect" message. On an adaptive background so the blank
 /// page reads as intentional in both light and dark mode.
 private struct ConnectingPlaceholder: View {
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
 
     private enum Phase: Equatable {
         case connecting

--- a/openHAB/UI/OpenHABWebViewModel.swift
+++ b/openHAB/UI/OpenHABWebViewModel.swift
@@ -87,7 +87,7 @@ class OpenHABWebViewModel: ObservableObject {
     private var viewAccessOrder: [UUID] = []
     private var etagChecker: ETagChecker?
     private var etagCheckerConfigURL: String?
-    private var trackerCancellables = Set<AnyCancellable>()
+    private var networkObservationTask: Task<Void, Never>?
 
     /// JS injected after each page load to proxy the MainUI Framework7 navbar
     /// into the native bar and hide the web navbar.
@@ -358,14 +358,18 @@ class OpenHABWebViewModel: ObservableObject {
     // MARK: - Network observation
 
     private func observeNetworkChanges() {
-        MainActorNetworkTracker.shared.$activeConnection
-            .sink { [weak self] connection in
-                // Use the value the publisher delivers, not a re-read of
-                // MainActorNetworkTracker.activeConnection: @Published notifies in willSet,
-                // so the stored property still holds the previous value inside this closure.
-                self?.syncActiveConnection(with: connection)
+        networkObservationTask = Task { [weak self] in
+            var previousConnection: ConnectionInfo?
+            for await state in await NetworkTracker.shared.stateStream() {
+                guard state.activeConnection != previousConnection else { continue }
+                previousConnection = state.activeConnection
+                self?.syncActiveConnection(with: state.activeConnection)
             }
-            .store(in: &trackerCancellables)
+        }
+    }
+
+    deinit {
+        networkObservationTask?.cancel()
     }
 
     /// Reconciles the web view with the current active connection. Safe to call outside a

--- a/openHAB/UI/PushRegistrationService.swift
+++ b/openHAB/UI/PushRegistrationService.swift
@@ -18,6 +18,7 @@ class PushRegistrationService: ObservableObject {
     // MARK: - Private state
 
     private var cancellables = Set<AnyCancellable>()
+    private var networkObservationTask: Task<Void, Never>?
     private var apsDeviceToken: String?
     private var apsDeviceId: String?
     private var apsDeviceName: String?
@@ -37,14 +38,16 @@ class PushRegistrationService: ObservableObject {
             }
         }
 
-        MainActorNetworkTracker.shared.$activeConnection
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] activeConnection in
-                if let activeConnection {
-                    self?.activeConnection = activeConnection
-                }
+        networkObservationTask = Task { [weak self] in
+            for await state in await NetworkTracker.shared.stateStream() {
+                guard let activeConnection = state.activeConnection else { continue }
+                self?.activeConnection = activeConnection
             }
-            .store(in: &cancellables)
+        }
+    }
+
+    deinit {
+        networkObservationTask?.cancel()
     }
 
     // MARK: - APS Registration

--- a/openHAB/UI/SettingsView/HomeSettingsView.swift
+++ b/openHAB/UI/SettingsView/HomeSettingsView.swift
@@ -14,7 +14,7 @@ import os
 import SwiftUI
 
 struct HomeSettingsView: View {
-    @StateObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
     /// When non-nil, the view edits the specified stored home instead of the active home.
     var homeId: UUID?
 

--- a/openHAB/UI/SwiftUI/IconURLView.swift
+++ b/openHAB/UI/SwiftUI/IconURLView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A SwiftUI view that displays widget icons with openHAB-specific styling and caching
 struct IconURLView: View {
     @State var iconURL: URL
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
 
     let size: CGSize
 

--- a/openHAB/UI/SwiftUI/IconView.swift
+++ b/openHAB/UI/SwiftUI/IconView.swift
@@ -88,7 +88,7 @@ struct IconInputView: View {
     let input: RowIconInput
     let rowIdentity: String
     let fallbackSymbol: SFSymbol?
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
     @ObservedObject private var iconReloader = IconReloadCoordinator.shared
     @Environment(\.colorScheme) private var colorScheme
 
@@ -276,7 +276,7 @@ struct IconInputView: View {
 /// A SwiftUI view that displays widget icons with openHAB-specific styling and caching
 struct IconView: View {
     @ObservedObject var widget: OpenHABWidget
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
     @ObservedObject private var iconReloader = IconReloadCoordinator.shared
     @Environment(\.colorScheme) private var colorScheme
 

--- a/openHAB/UI/SwiftUI/ImageView.swift
+++ b/openHAB/UI/SwiftUI/ImageView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 struct ImageView: View {
     let url: String
 
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
 
     var body: some View {
         if !url.isEmpty {

--- a/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
+++ b/openHAB/UI/SwiftUI/Rows/ImageRowView.swift
@@ -39,7 +39,7 @@ private struct ImageRowContent: View {
 
     let input: MediaRowInput
     @ObservedObject var viewModel: SitemapPageViewModel
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
     @Environment(\.colorScheme) var colorScheme
     @State private var refreshTimer: Timer?
     @State private var forceRefreshKey = UUID()

--- a/openHAB/UI/ToolbarMenu.swift
+++ b/openHAB/UI/ToolbarMenu.swift
@@ -35,7 +35,7 @@ enum TargetController: Equatable {
 struct ConnectionView: View {
     static let cornerRadius: CGFloat = 14
 
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
 
     var body: some View {
         HStack {

--- a/openHABWatch/Views/Rows/ImageRow.swift
+++ b/openHABWatch/Views/Rows/ImageRow.swift
@@ -62,7 +62,7 @@ struct ImageRow: View, Equatable {
     let refresh: Int // Refresh interval in milliseconds, 0 means no refresh
 
     @StateObject private var refreshTimer = ImageRefreshTimer()
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
 
     /// For refreshing images, append a query parameter to bust the cache
     private var displayUrl: URL? {

--- a/openHABWatch/Views/Utils/WatchIconView.swift
+++ b/openHABWatch/Views/Utils/WatchIconView.swift
@@ -28,7 +28,7 @@ struct IconRenderModel: Equatable {
 struct WatchIconView: View {
     let model: IconRenderModel
     @ObservedObject var settings = AppSettings.shared
-    @ObservedObject private var networkTracker = MainActorNetworkTracker.shared
+    var networkTracker = MainActorNetworkTracker.shared
     @State private var lastResolvedIconURL: URL?
     @State private var lastResolvedConnection: ConnectionInfo?
     @State private var keepLastResolvedIconURLUntil: Date = .distantPast


### PR DESCRIPTION
## Summary

Converts `MainActorNetworkTracker` from `ObservableObject`/`@Published` to `@Observable`, and updates every consumer:

- **Trivial `@ObservedObject`/`@StateObject` reads** become plain properties (`ToolbarMenu`, `IconView` ×2, `ImageView`, `IconURLView`, `ImageRowView`, `HomeSettingsView`, `OpenHABRootView`'s `ConnectingPlaceholder`, and the watch app's `ImageRow`/`WatchIconView`). Left non-`private` — a `private` stored property with a default value pulls the struct's synthesized memberwise init down to `private` too, breaking cross-file callers (hit this on `WatchIconView`, called from `TextRow` and its own `#Preview`).

- **The four Combine push-subscribers** (`PushRegistrationService`, `OpenHABWebViewModel`, `MenuDataService`, `OpenHABRootView`'s `.task`) had no `@Observable` equivalent to `$activeConnection.sink`/`.values`, so they now consume `NetworkTracker.shared.stateStream()` directly instead of going through `MainActorNetworkTracker`'s publisher surface. Each tracks the previously-seen value itself to preserve `$activeConnection`/`$status`'s "only fires on an actual change" semantics (the raw stream emits on every `NetworkState` field, not just the one being watched). `SitemapPageViewModel`'s two separate `$activeConnection`/`$status` subscriptions merge into one task over the shared stream.

- **`NotificationsView<Tracker: NetworkTracking>`**'s `where Tracker: ObservableObject` constraint and `@ObservedObject` wrapper are gone; the preview-only `MockNetworkTracker` drops `@Published`/`ObservableObject` too, since `NotificationsView` no longer needs live observation of it.

`MainActorNetworkTracker` itself needs no reactive API anymore — every long-lived subscription now goes straight to the actor's own stream.

## Test plan
- [x] `openHAB` (iOS) builds
- [x] `openHABWatch` builds
- [x] Full `openHABTestsSwift` suite passes (654 tests, 0 failures), including `MenuDataTests`, `SitemapPageViewModelForegroundTests`, and `SliderOverrideSyncTests` which exercise the touched classes
- [ ] Manual spot-check of the connecting/retry UI (`ConnectingPlaceholder`) and notifications sheet, since those are the most state-transition-sensitive surfaces touched