### PR TITLE
feat(sitemap): decode SSE events via SitemapEvent oneOf schema

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Client.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Client.swift
@@ -2691,8 +2691,7 @@ public struct Client: APIProtocol {
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
-                            "text/event-stream",
-                            "application/json"
+                            "text/event-stream"
                         ]
                     )
                     switch chosenContentType {
@@ -2702,14 +2701,6 @@ public struct Client: APIProtocol {
                             from: responseBody,
                             transforming: { value in
                                 .text_event_hyphen_stream(value)
-                            }
-                        )
-                    case "application/json":
-                        body = try await converter.getResponseBodyAsJSON(
-                            Components.Schemas.SitemapWidgetEvent.self,
-                            from: responseBody,
-                            transforming: { value in
-                                .json(value)
                             }
                         )
                     default:

--- a/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
+++ b/OpenHABCore/Sources/OpenHABCore/GeneratedSources/openapi/Types.swift
@@ -1133,10 +1133,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1155,10 +1155,10 @@ public enum Components {
                 public init(additionalProperties: [String: Swift.String] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1216,10 +1216,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1238,10 +1238,10 @@ public enum Components {
                 public init(additionalProperties: [String: Swift.String] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1299,10 +1299,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1400,10 +1400,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1459,10 +1459,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1618,10 +1618,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1671,10 +1671,10 @@ public enum Components {
                 public init(additionalProperties: [String: Swift.String] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1736,10 +1736,10 @@ public enum Components {
                 public init(additionalProperties: [String: Swift.String] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -1951,10 +1951,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -2404,10 +2404,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -2467,10 +2467,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -3097,10 +3097,10 @@ public enum Components {
                 case timeout
                 case widgets
             }
-            public init(from decoder: any Decoder) throws {
+            public init(from decoder: any Swift.Decoder) throws {
                 self.storage = try .init(from: decoder)
             }
-            public func encode(to encoder: any Encoder) throws {
+            public func encode(to encoder: any Swift.Encoder) throws {
                 try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
@@ -3663,10 +3663,10 @@ public enum Components {
                 case linkedPage
                 case widgets
             }
-            public init(from decoder: any Decoder) throws {
+            public init(from decoder: any Swift.Decoder) throws {
                 self.storage = try .init(from: decoder)
             }
-            public func encode(to encoder: any Encoder) throws {
+            public func encode(to encoder: any Swift.Encoder) throws {
                 try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
@@ -3834,6 +3834,51 @@ public enum Components {
                 typealias CodingKeys = Components.Schemas.WidgetDTO.CodingKeys
             }
         }
+        /// - Remark: Generated from `#/components/schemas/SitemapEvent`.
+        @frozen public enum SitemapEvent: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/SitemapEvent/case1`.
+            case SitemapWidgetEvent(Components.Schemas.SitemapWidgetEvent)
+            /// - Remark: Generated from `#/components/schemas/SitemapEvent/case2`.
+            case SitemapChangedEvent(Components.Schemas.SitemapChangedEvent)
+            /// - Remark: Generated from `#/components/schemas/SitemapEvent/case3`.
+            case ServerAliveEvent(Components.Schemas.ServerAliveEvent)
+            public init(from decoder: any Swift.Decoder) throws {
+                var errors: [any Swift.Error] = []
+                do {
+                    self = .SitemapWidgetEvent(try .init(from: decoder))
+                    return
+                } catch {
+                    errors.append(error)
+                }
+                do {
+                    self = .SitemapChangedEvent(try .init(from: decoder))
+                    return
+                } catch {
+                    errors.append(error)
+                }
+                do {
+                    self = .ServerAliveEvent(try .init(from: decoder))
+                    return
+                } catch {
+                    errors.append(error)
+                }
+                throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                    type: Self.self,
+                    codingPath: decoder.codingPath,
+                    errors: errors
+                )
+            }
+            public func encode(to encoder: any Swift.Encoder) throws {
+                switch self {
+                case let .SitemapWidgetEvent(value):
+                    try value.encode(to: encoder)
+                case let .SitemapChangedEvent(value):
+                    try value.encode(to: encoder)
+                case let .ServerAliveEvent(value):
+                    try value.encode(to: encoder)
+                }
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent`.
         public struct SitemapWidgetEvent: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/SitemapWidgetEvent/widgetId`.
@@ -3929,6 +3974,72 @@ public enum Components {
                 case pageId
             }
         }
+        /// - Remark: Generated from `#/components/schemas/SitemapChangedEvent`.
+        public struct SitemapChangedEvent: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/SitemapChangedEvent/sitemapName`.
+            public var sitemapName: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/SitemapChangedEvent/pageId`.
+            public var pageId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/SitemapChangedEvent/TYPE`.
+            @frozen public enum TYPEPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case SITEMAP_CHANGED = "SITEMAP_CHANGED"
+            }
+            /// - Remark: Generated from `#/components/schemas/SitemapChangedEvent/TYPE`.
+            public var TYPE: Components.Schemas.SitemapChangedEvent.TYPEPayload
+            /// Creates a new `SitemapChangedEvent`.
+            ///
+            /// - Parameters:
+            ///   - sitemapName:
+            ///   - pageId:
+            ///   - TYPE:
+            public init(
+                sitemapName: Swift.String? = nil,
+                pageId: Swift.String? = nil,
+                TYPE: Components.Schemas.SitemapChangedEvent.TYPEPayload
+            ) {
+                self.sitemapName = sitemapName
+                self.pageId = pageId
+                self.TYPE = TYPE
+            }
+            public enum CodingKeys: String, CodingKey {
+                case sitemapName
+                case pageId
+                case TYPE
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/ServerAliveEvent`.
+        public struct ServerAliveEvent: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/ServerAliveEvent/sitemapName`.
+            public var sitemapName: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ServerAliveEvent/pageId`.
+            public var pageId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ServerAliveEvent/TYPE`.
+            @frozen public enum TYPEPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case ALIVE = "ALIVE"
+            }
+            /// - Remark: Generated from `#/components/schemas/ServerAliveEvent/TYPE`.
+            public var TYPE: Components.Schemas.ServerAliveEvent.TYPEPayload
+            /// Creates a new `ServerAliveEvent`.
+            ///
+            /// - Parameters:
+            ///   - sitemapName:
+            ///   - pageId:
+            ///   - TYPE:
+            public init(
+                sitemapName: Swift.String? = nil,
+                pageId: Swift.String? = nil,
+                TYPE: Components.Schemas.ServerAliveEvent.TYPEPayload
+            ) {
+                self.sitemapName = sitemapName
+                self.pageId = pageId
+                self.TYPE = TYPE
+            }
+            public enum CodingKeys: String, CodingKey {
+                case sitemapName
+                case pageId
+                case TYPE
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/SitemapDTO`.
         public struct SitemapDTO: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/SitemapDTO/name`.
@@ -3985,10 +4096,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -4005,10 +4116,10 @@ public enum Components {
                 public init(additionalProperties: [String: [Components.Schemas.UIComponent]] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -4080,10 +4191,10 @@ public enum Components {
                 public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                     self.additionalProperties = additionalProperties
                 }
-                public init(from decoder: any Decoder) throws {
+                public init(from decoder: any Swift.Decoder) throws {
                     additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                 }
-                public func encode(to encoder: any Encoder) throws {
+                public func encode(to encoder: any Swift.Encoder) throws {
                     try encoder.encodeAdditionalProperties(additionalProperties)
                 }
             }
@@ -5493,10 +5604,10 @@ public enum Operations {
                     public init(additionalProperties: [String: OpenAPIRuntime.OpenAPIObjectContainer] = .init()) {
                         self.additionalProperties = additionalProperties
                     }
-                    public init(from decoder: any Decoder) throws {
+                    public init(from decoder: any Swift.Decoder) throws {
                         additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                     }
-                    public func encode(to encoder: any Encoder) throws {
+                    public func encode(to encoder: any Swift.Encoder) throws {
                         try encoder.encodeAdditionalProperties(additionalProperties)
                     }
                 }
@@ -6485,10 +6596,10 @@ public enum Operations {
                     public init(additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()) {
                         self.additionalProperties = additionalProperties
                     }
-                    public init(from decoder: any Decoder) throws {
+                    public init(from decoder: any Swift.Decoder) throws {
                         additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
                     }
-                    public func encode(to encoder: any Encoder) throws {
+                    public func encode(to encoder: any Swift.Encoder) throws {
                         try encoder.encodeAdditionalProperties(additionalProperties)
                     }
                 }
@@ -11079,30 +11190,6 @@ public enum Operations {
                             switch self {
                             case let .text_event_hyphen_stream(body):
                                 return body
-                            default:
-                                try throwUnexpectedResponseBody(
-                                    expectedContent: "text/event-stream",
-                                    body: self
-                                )
-                            }
-                        }
-                    }
-                    /// - Remark: Generated from `#/paths/sitemaps/events/{subscriptionid}/GET/responses/200/content/application\/json`.
-                    case json(Components.Schemas.SitemapWidgetEvent)
-                    /// The associated value of the enum case if `self` is `.json`.
-                    ///
-                    /// - Throws: An error if `self` is not `.json`.
-                    /// - SeeAlso: `.json`.
-                    public var json: Components.Schemas.SitemapWidgetEvent {
-                        get throws {
-                            switch self {
-                            case let .json(body):
-                                return body
-                            default:
-                                try throwUnexpectedResponseBody(
-                                    expectedContent: "application/json",
-                                    body: self
-                                )
                             }
                         }
                     }
@@ -11217,14 +11304,11 @@ public enum Operations {
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case text_event_hyphen_stream
-            case json
             case other(Swift.String)
             public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "text/event-stream":
                     self = .text_event_hyphen_stream
-                case "application/json":
-                    self = .json
                 default:
                     self = .other(rawValue)
                 }
@@ -11235,14 +11319,11 @@ public enum Operations {
                     return string
                 case .text_event_hyphen_stream:
                     return "text/event-stream"
-                case .json:
-                    return "application/json"
                 }
             }
             public static var allCases: [Self] {
                 [
-                    .text_event_hyphen_stream,
-                    .json
+                    .text_event_hyphen_stream
                 ]
             }
         }

--- a/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/OpenAPIService.swift
@@ -278,7 +278,29 @@ public extension OpenAPIService {
 }
 
 public extension OpenAPIService {
-    private static func parseSitemapEvent(_ sse: ServerSentEvent) -> SitemapEventMessage? {
+    /// Lightweight view of the `TYPE` discriminator shared by every sitemap event.
+    ///
+    /// The `SitemapEvent` schema is a `oneOf` over the concrete event types, but
+    /// `SitemapWidgetEvent` has no required properties and would match any payload,
+    /// so we peek at `TYPE` once instead of relying on decode order.
+    private struct SitemapEventEnvelope: Decodable {
+        enum EventType: String, Decodable {
+            case alive = "ALIVE"
+            case sitemapChanged = "SITEMAP_CHANGED"
+        }
+
+        let type: EventType?
+
+        enum CodingKeys: String, CodingKey {
+            case type = "TYPE"
+        }
+    }
+
+    /// Maps a raw sitemap SSE event to a ``SitemapEventMessage``.
+    ///
+    /// Not `private` so it can be unit-tested directly; treat it as an
+    /// implementation detail of ``openHABSitemapWidgetEvents(subscriptionid:sitemap:pageId:)``.
+    internal static func parseSitemapEvent(_ sse: ServerSentEvent) -> SitemapEventMessage? {
         if let event = sse.event?.lowercased(), event == "alive" {
             Logger.openAPIService.debug("Sitemap SSE alive event")
             return .alive
@@ -286,27 +308,24 @@ public extension OpenAPIService {
         guard let raw = sse.data else { return nil }
         Logger.openAPIService.debug("Sitemap SSE raw event: \(raw, privacy: .public)")
         let data = Data(raw.utf8)
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let type = json["TYPE"] as? String {
-            switch type {
-            case "ALIVE":
-                return .alive
-            case "SITEMAP_CHANGED":
-                Logger.openAPIService.info("Sitemap SSE SITEMAP_CHANGED event")
-                return .sitemapChanged(
-                    sitemap: json["sitemapName"] as? String,
-                    pageId: json["pageId"] as? String
-                )
-            default:
-                break
+        let decoder = JSONDecoder()
+
+        switch try? decoder.decode(SitemapEventEnvelope.self, from: data).type {
+        case .alive:
+            Logger.openAPIService.debug("Sitemap SSE ALIVE event")
+            return .alive
+        case .sitemapChanged:
+            Logger.openAPIService.info("Sitemap SSE SITEMAP_CHANGED event")
+            let changed = try? decoder.decode(Components.Schemas.SitemapChangedEvent.self, from: data)
+            return .sitemapChanged(sitemap: changed?.sitemapName, pageId: changed?.pageId)
+        case .none:
+            if let decoded = try? decoder.decode(Components.Schemas.SitemapWidgetEvent.self, from: data),
+               let event = OpenHABSitemapWidgetEvent(decoded) {
+                Logger.openAPIService.debug("Sitemap SSE widget event decoded: \(event.widgetId.orEmpty, privacy: .public)")
+                return .widget(event)
             }
+            return .unknown(raw: raw)
         }
-        if let decoded = try? JSONDecoder().decode(Components.Schemas.SitemapWidgetEvent.self, from: data),
-           let event = OpenHABSitemapWidgetEvent(decoded) {
-            Logger.openAPIService.debug("Sitemap SSE widget event decoded: \(event.widgetId.orEmpty, privacy: .public)")
-            return .widget(event)
-        }
-        return .unknown(raw: raw)
     }
 
     /// Returns subscription id or nil

--- a/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
+++ b/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json
@@ -5868,11 +5868,10 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/event-stream": {},
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SitemapWidgetEvent"
-                }
+              "text/event-stream": {
+                  "schema": {
+                      "$ref": "#/components/schemas/SitemapEvent"
+                  }
               }
             }
           },
@@ -9569,6 +9568,18 @@
           }
         }
       },
+      "SitemapEvent" : {
+             "type" : "object",
+             "properties" : {
+               "sitemapName" : { "type" : "string" },
+               "pageId" : { "type" : "string" }
+             },
+             "oneOf" : [
+               { "$ref" : "#/components/schemas/SitemapWidgetEvent" },
+               { "$ref" : "#/components/schemas/SitemapChangedEvent" },
+               { "$ref" : "#/components/schemas/ServerAliveEvent" }
+             ]
+           },
       "SitemapWidgetEvent": {
         "type": "object",
         "properties": {
@@ -9616,6 +9627,25 @@
           }
         }
       },
+      "SitemapChangedEvent" : {
+            "required" : [ "TYPE" ],
+            "type" : "object",
+            "properties" : {
+              "sitemapName" : { "type" : "string" },
+              "pageId" : { "type" : "string" },
+              "TYPE" : { "type" : "string", "readOnly" : true, "enum" : [ "SITEMAP_CHANGED" ] }
+            }
+          },
+          "ServerAliveEvent" : {
+            "required" : [ "TYPE" ],
+            "type" : "object",
+            "properties" : {
+              "sitemapName" : { "type" : "string" },
+              "pageId" : { "type" : "string" },
+              "TYPE" : { "type" : "string", "readOnly" : true, "enum" : [ "ALIVE" ] }
+            }
+          },
+      
       "SitemapDTO": {
         "type": "object",
         "properties": {

--- a/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceParseSitemapEventTests.swift
+++ b/OpenHABCore/Tests/OpenHABCoreTests/OpenAPIServiceParseSitemapEventTests.swift
@@ -1,0 +1,98 @@
+// Copyright (c) 2010-2026 Contributors to the openHAB project
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+import OpenAPIRuntime
+
+@testable import OpenHABCore
+import Testing
+
+struct OpenAPIServiceParseSitemapEventTests {
+    @Test
+    func aliveEventHeaderIsRecognised() {
+        let sse = ServerSentEvent(event: "alive", data: nil)
+
+        guard case .alive = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .alive")
+            return
+        }
+    }
+
+    @Test
+    func aliveEventPayloadIsRecognised() {
+        let sse = ServerSentEvent(data: #"{"TYPE":"ALIVE","sitemapName":"home","pageId":"home"}"#)
+
+        guard case .alive = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .alive")
+            return
+        }
+    }
+
+    @Test
+    func sitemapChangedEventIsRecognised() {
+        let sse = ServerSentEvent(
+            data: #"{"TYPE":"SITEMAP_CHANGED","sitemapName":"home","pageId":"1234"}"#
+        )
+
+        guard case let .sitemapChanged(sitemap, pageId) = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .sitemapChanged")
+            return
+        }
+        #expect(sitemap == "home")
+        #expect(pageId == "1234")
+    }
+
+    @Test
+    func widgetEventIsDecoded() {
+        let sse = ServerSentEvent(
+            data: #"""
+            {"widgetId":"0202","label":"Kitchen Light","state":"ON","sitemapName":"home","pageId":"0000"}
+            """#
+        )
+
+        guard case let .widget(event) = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .widget")
+            return
+        }
+        #expect(event.widgetId == "0202")
+        #expect(event.label == "Kitchen Light")
+        #expect(event.state == "ON")
+        #expect(event.sitemapName == "home")
+        #expect(event.pageId == "0000")
+    }
+
+    @Test
+    func widgetEventWithoutTypeIsNotMisclassifiedAsAlive() {
+        // A payload carrying no `TYPE` must never resolve to `.alive`/`.sitemapChanged`
+        // even though `SitemapWidgetEvent` has no required properties.
+        let sse = ServerSentEvent(data: #"{"widgetId":"0300","state":"42"}"#)
+
+        guard case .widget = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .widget")
+            return
+        }
+    }
+
+    @Test
+    func missingDataReturnsNil() {
+        #expect(OpenAPIService.parseSitemapEvent(ServerSentEvent(data: nil)) == nil)
+    }
+
+    @Test
+    func nonJSONPayloadIsReportedAsUnknown() {
+        let sse = ServerSentEvent(data: "this is not json")
+
+        guard case let .unknown(raw) = OpenAPIService.parseSitemapEvent(sse) else {
+            Issue.record("Expected .unknown")
+            return
+        }
+        #expect(raw == "this is not json")
+    }
+}


### PR DESCRIPTION
### What

Adapts the generated OpenAPI client to a reworked `openapi.json` for the sitemap event stream.

- **`openapi.json`**: the `sitemaps/events/{subscriptionid}` `200` response now uses a single `text/event-stream` body referencing a new `SitemapEvent` schema — a `oneOf` over `SitemapWidgetEvent`, `SitemapChangedEvent` and `ServerAliveEvent` — and no longer offers an `application/json` variant.
- **Generated sources**: regenerated `Client.swift` / `Types.swift` (swift-openapi-generator) to match — adds `SitemapEvent`, `SitemapChangedEvent`, `ServerAliveEvent`; drops the `.json` response case and `application/json` accept type for that operation.
- **`OpenAPIService.parseSitemapEvent`**: reworked to peek at the `TYPE` discriminator once (via a small `SitemapEventEnvelope`) and then decode the matching generated type, replacing the previous `JSONSerialization` payload sniffing. `SitemapWidgetEvent` has no required properties, so it would otherwise match any payload and swallow `ALIVE` / `SITEMAP_CHANGED` events — the discriminator peek also avoids decoding a widget payload up to three times. Made `internal` (it was `private`) so it can be unit-tested directly.

### Tests

New `OpenAPIServiceParseSitemapEventTests` (swift-testing), 7 cases: `alive` SSE header, `TYPE: ALIVE` / `TYPE: SITEMAP_CHANGED` payloads, widget-event decoding, the discriminator-ordering guard, missing data, and non-JSON input → `.unknown`.