### PR TITLE
Fix registrations not working since May/June

### DIFF
--- a/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/openHAB.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e25ac93ead9b27de70925a4e476cd8ce136e46f772a5fbc41ea5379a05a2fd56",
+  "originHash" : "225f713206a4b02e698ba5f1f327fabf70d7a5eac750973f2302953447904b97",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
-        "version" : "12.18.0"
+        "revision" : "cf44bf2fa90b1dbba999ee2bb4dce4eaf7bceae8",
+        "version" : "12.19.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
-        "version" : "3.6.1"
+        "revision" : "0208e2681ec81f8a9c81084696f60fcce26cb7ee",
+        "version" : "3.7.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
-        "version" : "12.18.0"
+        "revision" : "8fe40b69bd53241847814422101188465f7ff728",
+        "version" : "12.19.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -185,6 +185,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
     }
 
+    /// FCM only mints a new registration token once it sees the APNs token change. Without this
+    /// it can keep serving a token whose APNs token Apple has since disabled, which my.openHAB
+    /// then accepts as a registration and pushes to forever, getting
+    /// registration-token-not-registered back on every send.
+    /// https://firebase.google.com/docs/cloud-messaging/ios/client#disable-swizzling-token
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
         Logger.appDelegate.error("Failed to get token for notifications: \(error.localizedDescription)")
     }

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -176,6 +176,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// launch post-install. Fixed upstream in 12.19.0 (unreleased as of 2026-09-09).
     @MainActor
     private func publishCurrentFCMToken() {
+        #if DEBUG
+        // do not register with the cloud if running UITest, as registerForPushNotifications does
+        if ProcessInfo.processInfo.environment["UITest"] != nil {
+            return
+        }
+        #endif
+
         // Deprecated in favour of FID registration, but my.openHAB expects the FCM token as regId.
         if let cachedToken = Messaging.messaging().fcmToken, !cachedToken.isEmpty {
             AppDelegate.postApsRegistration(fcmToken: cachedToken)

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -95,7 +95,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     @MainActor
     private func performDeferredSetup() {
         registerForPushNotifications()
-        publishCurrentFCMToken()
         Logger.appDelegate.info("uniq id: \(UIDevice.current.identifierForVendor?.uuidString ?? "")")
         Logger.appDelegate.info("device name: \(UIDevice.current.name)")
 
@@ -162,45 +161,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     Logger.appDelegate.info("Calling registerForRemoteNotifications")
                     UIApplication.shared.registerForRemoteNotifications()
                 }
-            }
-        }
-    }
-
-    /// Publishes the current FCM registration token to `PushRegistrationService`.
-    ///
-    /// Remove this method and its call site in `performDeferredSetup()` once we are on Firebase
-    /// 12.19.0 or later.
-    ///
-    /// Why it exists: FCM 12.18.0 stopped calling `messaging(_:didReceiveRegistrationToken:)` at
-    /// launch for a cached, unchanged token, so nothing triggered registration after the first
-    /// launch post-install. Fixed upstream in 12.19.0 (unreleased as of 2026-09-09).
-    @MainActor
-    private func publishCurrentFCMToken() {
-        #if DEBUG
-        // do not register with the cloud if running UITest, as registerForPushNotifications does
-        if ProcessInfo.processInfo.environment["UITest"] != nil {
-            return
-        }
-        #endif
-
-        // Deprecated in favour of FID registration, but my.openHAB expects the FCM token as regId.
-        if let cachedToken = Messaging.messaging().fcmToken, !cachedToken.isEmpty {
-            AppDelegate.postApsRegistration(fcmToken: cachedToken)
-            return
-        }
-
-        Logger.appDelegate.info("No cached FCM token, requesting one")
-        Messaging.messaging().token { token, error in
-            if let error {
-                Logger.appDelegate.error("Failed to fetch FCM token: \(error.localizedDescription)")
-                return
-            }
-            guard let token, !token.isEmpty else {
-                Logger.appDelegate.error("Fetched FCM token was empty")
-                return
-            }
-            Task { @MainActor in
-                AppDelegate.postApsRegistration(fcmToken: token)
             }
         }
     }

--- a/openHAB/AppDelegate.swift
+++ b/openHAB/AppDelegate.swift
@@ -95,6 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     @MainActor
     private func performDeferredSetup() {
         registerForPushNotifications()
+        publishCurrentFCMToken()
         Logger.appDelegate.info("uniq id: \(UIDevice.current.identifierForVendor?.uuidString ?? "")")
         Logger.appDelegate.info("device name: \(UIDevice.current.name)")
 
@@ -158,17 +159,63 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 guard settings.authorizationStatus == .authorized else { return }
                 Task { @MainActor in
+                    Logger.appDelegate.info("Calling registerForRemoteNotifications")
                     UIApplication.shared.registerForRemoteNotifications()
                 }
             }
         }
     }
 
-    /// This is only informational - on success - DID Register
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        // TODO: remove before shipping
-        // Logger.appDelegate.info("APNs token: \(deviceToken.map { String(format: "%02x", $0) }.joined())")
-        // Do nothing now, we are using FCM
+    /// Publishes the current FCM registration token to `PushRegistrationService`.
+    ///
+    /// Remove this method and its call site in `performDeferredSetup()` once we are on Firebase
+    /// 12.19.0 or later.
+    ///
+    /// Why it exists: FCM 12.18.0 stopped calling `messaging(_:didReceiveRegistrationToken:)` at
+    /// launch for a cached, unchanged token, so nothing triggered registration after the first
+    /// launch post-install. Fixed upstream in 12.19.0 (unreleased as of 2026-09-09).
+    @MainActor
+    private func publishCurrentFCMToken() {
+        // Deprecated in favour of FID registration, but my.openHAB expects the FCM token as regId.
+        if let cachedToken = Messaging.messaging().fcmToken, !cachedToken.isEmpty {
+            AppDelegate.postApsRegistration(fcmToken: cachedToken)
+            return
+        }
+
+        Logger.appDelegate.info("No cached FCM token, requesting one")
+        Messaging.messaging().token { token, error in
+            if let error {
+                Logger.appDelegate.error("Failed to fetch FCM token: \(error.localizedDescription)")
+                return
+            }
+            guard let token, !token.isEmpty else {
+                Logger.appDelegate.error("Fetched FCM token was empty")
+                return
+            }
+            Task { @MainActor in
+                AppDelegate.postApsRegistration(fcmToken: token)
+            }
+        }
+    }
+
+    @MainActor
+    private static func postApsRegistration(fcmToken: String) {
+        let deviceID = UIDevice.current.identifierForVendor?.uuidString ?? "UnknownDeviceID"
+        let deviceName = UIDevice.current.name
+
+        Logger.appDelegate.info("My FCM token is: \(fcmToken, privacy: .private)")
+
+        let dataDict: [String: Any] = [
+            "deviceToken": fcmToken,
+            "deviceId": deviceID,
+            "deviceName": deviceName
+        ]
+
+        NotificationCenter.default.post(
+            name: NSNotification.Name("apsRegistered"),
+            object: nil,
+            userInfo: dataDict
+        )
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
@@ -287,25 +334,14 @@ extension AppDelegate {
 }
 
 extension AppDelegate: MessagingDelegate {
+    /// Called when the FCM token is created or refreshed.
     nonisolated func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken, !fcmToken.isEmpty else {
+            Logger.appDelegate.error("Received an empty FCM token")
+            return
+        }
         Task { @MainActor in
-            let safeToken = fcmToken ?? ""
-            let deviceID = UIDevice.current.identifierForVendor?.uuidString ?? "UnknownDeviceID"
-            let deviceName = UIDevice.current.name
-
-            Logger.appDelegate.info("My FCM token is: \(safeToken, privacy: .private)")
-
-            let dataDict: [String: Any] = [
-                "deviceToken": safeToken,
-                "deviceId": deviceID,
-                "deviceName": deviceName
-            ]
-
-            NotificationCenter.default.post(
-                name: NSNotification.Name("apsRegistered"),
-                object: self,
-                userInfo: dataDict
-            )
+            AppDelegate.postApsRegistration(fcmToken: fcmToken)
         }
     }
 }

--- a/openHAB/UI/PushRegistrationService.swift
+++ b/openHAB/UI/PushRegistrationService.swift
@@ -68,8 +68,10 @@ class PushRegistrationService: ObservableObject {
 
         networkObservationTask = Task { [weak self] in
             for await state in await NetworkTracker.shared.stateStream() {
-                guard let activeConnection = state.activeConnection else { continue }
-                self?.activeConnection = activeConnection
+                guard let activeConnection = state.activeConnection, let self else { continue }
+                guard activeConnection != self.activeConnection else { continue }
+                self.activeConnection = activeConnection
+                registerPendingConnections()
             }
         }
 
@@ -167,12 +169,13 @@ class PushRegistrationService: ObservableObject {
                 if let cloudUserId = try await client.register(prefsURL: config.url, deviceToken: deviceToken, deviceId: deviceId, deviceName: deviceName) {
                     await Preferences.shared.setCloudUserId(cloudUserId, for: uuid)
                     Logger.viewController.info("my.openHAB registration succeeded with cloudUserId \(cloudUserId)")
+                } else {
+                    Logger.viewController.info("my.openHAB registration succeeded without cloudUserId")
                 }
-                Logger.viewController.info("my.openHAB registration succeeded without cloudUserId")
             } catch {
                 let detail = (error as? URLError).map { "URLError \($0.errorCode)" } ?? String(describing: error)
                 Logger.viewController.error("my.openHAB registration failed for \(config.url): \(error.localizedDescription) (\(detail))")
-                // Allow a later trigger to retry this home.
+                // Retried when the active connection changes, see networkObservationTask.
                 registeredConnections.remove(UuidWithConnection(uuid: uuid, connection: config))
             }
         }

--- a/openHAB/UI/PushRegistrationService.swift
+++ b/openHAB/UI/PushRegistrationService.swift
@@ -15,15 +15,42 @@ import os.log
 
 @MainActor
 class PushRegistrationService: ObservableObject {
+    private struct UuidWithConnection: Hashable, Equatable {
+        let uuid: UUID
+        // not only URL, because auth and certs might be relevant for establishing the connection
+        let connection: ConnectionConfiguration
+
+        /// cloudUserId is written back by a successful registration, so comparing it would make
+        /// every registration look like a configuration change and register a second time.
+        private var identity: ConnectionConfiguration {
+            var identity = connection
+            identity.cloudUserId = nil
+            return identity
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.uuid == rhs.uuid && lhs.identity == rhs.identity
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(uuid)
+            hasher.combine(identity)
+        }
+    }
+
     // MARK: - Private state
 
-    private var cancellables = Set<AnyCancellable>()
     private var networkObservationTask: Task<Void, Never>?
     private var storedHomesTask: Task<Void, Never>?
     private var apsDeviceToken: String?
     private var apsDeviceId: String?
     private var apsDeviceName: String?
     private var activeConnection: ConnectionInfo?
+
+    /// Connections that are currently configured for notifications.
+    private var knownConnections = Set<UuidWithConnection>()
+    /// Connections already registered with the cloud for the current `apsDeviceToken`.
+    private var registeredConnections = Set<UuidWithConnection>()
 
     init() {
         NotificationCenter.default.addObserver(
@@ -45,71 +72,92 @@ class PushRegistrationService: ObservableObject {
                 self?.activeConnection = activeConnection
             }
         }
+
+        // Tracked independently of the push token, so a home added in a later session still
+        // registers. Whichever of the two arrives second, `registerPendingConnections` joins them.
+        subscribeToOpenhabConnectionChanges()
     }
 
     deinit {
         networkObservationTask?.cancel()
+        storedHomesTask?.cancel()
     }
 
     // MARK: - APS Registration
 
     private func handleApsRegistration(deviceToken: String?, deviceId: String?, deviceName: String?) {
         Logger.viewController.info("handleApsRegistration")
+        if deviceToken != apsDeviceToken {
+            // A new device token invalidates every registration made with the previous one.
+            registeredConnections.removeAll()
+        }
         apsDeviceToken = deviceToken
         apsDeviceId = deviceId
         apsDeviceName = deviceName
-        subscribeToOpenhabConnectionChanges()
+        registerPendingConnections()
     }
 
     private func subscribeToOpenhabConnectionChanges() {
-        struct UuidWithConnection: Hashable, Equatable {
-            let uuid: UUID
-            let connection: ConnectionConfiguration
-        }
-
         storedHomesTask?.cancel()
         storedHomesTask = Task { @MainActor [weak self] in
-            var previousConnections = Set<UuidWithConnection>()
             var debounceTask: Task<Void, Never>?
 
             for await storedHomes in await Preferences.shared.storedHomesStream {
                 debounceTask?.cancel()
                 let capturedHomes = storedHomes
                 debounceTask = Task { @MainActor [weak self] in
+                    // avoid overexcited registrations / deregistrations in batch updates
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     guard !Task.isCancelled, let self else { return }
-
-                    let currentConnections = Set<UuidWithConnection>(capturedHomes.compactMap { (uuid, homeConfig) in
-                        guard let connection = Preferences.getNotificationConnection(of: homeConfig) else { return nil }
-                        return UuidWithConnection(uuid: uuid, connection: connection)
-                    })
-                    let newValues = currentConnections.subtracting(previousConnections)
-                    let deletedValues = previousConnections.subtracting(currentConnections)
-                    previousConnections = currentConnections
-
-                    Logger.viewController.info("openhabConnectionSubscription updated")
-                    for newHome in newValues {
-                        Logger.viewController.info("openhabConnectionSubscription uuid \(newHome.uuid) registering for push notifications")
-                        self.registerHome(uuid: newHome.uuid, connection: newHome.connection)
-                    }
-                    for deletedHome in deletedValues {
-                        Logger.viewController.warning("APNS Deregistration is missing (wanted to deregister \(deletedHome.connection.url))")
-                    }
+                    await self.updateKnownConnections(from: capturedHomes)
                 }
             }
             debounceTask?.cancel()
         }
     }
 
-    private func registerHome(uuid: UUID, connection: ConnectionConfiguration) {
+    private func updateKnownConnections(from storedHomes: [UUID: HomePreferences]) async {
+        var currentConnections = Set<UuidWithConnection>()
+        for uuid in storedHomes.keys {
+            // The persisted record carries no credentials, they live in the Keychain. Using it
+            // raw authenticates against the cloud with an empty username and password.
+            guard let homeConfig = await Preferences.shared.storedHomeWithCredentials(forId: uuid),
+                  let connection = Preferences.getNotificationConnection(of: homeConfig) else { continue }
+            currentConnections.insert(UuidWithConnection(uuid: uuid, connection: connection))
+        }
+        guard !Task.isCancelled else { return }
+
+        let deletedValues = knownConnections.subtracting(currentConnections)
+        knownConnections = currentConnections
+        // Anything no longer configured must not count as registered any more, so that a home
+        // coming back later is registered again.
+        registeredConnections.formIntersection(currentConnections)
+
+        Logger.viewController.info("openhabConnectionSubscription updated")
+        for deletedHome in deletedValues {
+            Logger.viewController.warning("APNS Deregistration is missing (wanted to deregister \(deletedHome.connection.url))")
+        }
+        registerPendingConnections()
+    }
+
+    /// Registers every known connection not yet registered with the current device token.
+    /// Waits if no registration data is available, `handleApsRegistration` runs it again.
+    private func registerPendingConnections() {
+        let pendingConnections = knownConnections.subtracting(registeredConnections)
+        guard !pendingConnections.isEmpty else { return }
+
         guard let deviceId = apsDeviceId,
               let deviceToken = apsDeviceToken,
               let deviceName = apsDeviceName else {
-            Logger.viewController.fault("Cannot register homes for push notifications, no notification registration data available")
+            Logger.viewController.info("Deferring push notification registration of \(pendingConnections.count) home(s), no notification registration data available yet")
             return
         }
-        Logger.viewController.info("Registering notifications with \(connection.url)")
-        _ = registerHome(uuid, connection, deviceToken, deviceId, deviceName)
+
+        for pendingHome in pendingConnections {
+            registeredConnections.insert(pendingHome)
+            Logger.viewController.info("Registering notifications for home \(pendingHome.uuid) with \(pendingHome.connection.url)")
+            _ = registerHome(pendingHome.uuid, pendingHome.connection, deviceToken, deviceId, deviceName)
+        }
     }
 
     private func registerHome(_ uuid: UUID, _ config: ConnectionConfiguration, _ deviceToken: String, _ deviceId: String, _ deviceName: String) -> Task<Void, Never> {
@@ -122,7 +170,10 @@ class PushRegistrationService: ObservableObject {
                 }
                 Logger.viewController.info("my.openHAB registration succeeded without cloudUserId")
             } catch {
-                Logger.viewController.error("my.openHAB registration failed \(error.localizedDescription)")
+                let detail = (error as? URLError).map { "URLError \($0.errorCode)" } ?? String(describing: error)
+                Logger.viewController.error("my.openHAB registration failed for \(config.url): \(error.localizedDescription) (\(detail))")
+                // Allow a later trigger to retry this home.
+                registeredConnections.remove(UuidWithConnection(uuid: uuid, connection: config))
             }
         }
     }

--- a/openHAB/UI/PushRegistrationService.swift
+++ b/openHAB/UI/PushRegistrationService.swift
@@ -175,6 +175,10 @@ class PushRegistrationService: ObservableObject {
             } catch {
                 let detail = (error as? URLError).map { "URLError \($0.errorCode)" } ?? String(describing: error)
                 Logger.viewController.error("my.openHAB registration failed for \(config.url): \(error.localizedDescription) (\(detail))")
+                // Only the attempt for the current token may clear the marker. A slow failing
+                // attempt for a token that has since been replaced would otherwise remove the
+                // marker of the attempt that replaced it, and register that home twice over.
+                guard deviceToken == apsDeviceToken else { return }
                 // Retried when the active connection changes, see networkObservationTask.
                 registeredConnections.remove(UuidWithConnection(uuid: uuid, connection: config))
             }


### PR DESCRIPTION
I think 2 PRs silently broke notification registration.  Fortunately registration tokens can last a very long time, so only testflight users with no existing connections would notice this....or when you are switching between local builds and testflight like i do which mints a new app id.

#1216  "Store connection credentials in Keychain instead of UserDefaults", merged 27 May 2026. Registration was still reading credentials from the old location, so it sent a blank username/password and got a 401.

#1320  "chore(deps): update Firebase SDK to 12.18.0", 28 Aug 2026. Firebase stopped handing us the push token at startup, so registration stopped running at all.

This second issue is actually a bug in the firebase version, the next verion of firebase has already fixed this, but has not released a stable build yet.

This also fixes registrations from happening twice by using the connectionConfig for hashing.