### PR TITLE
Sitemap settings optimisations

### DIFF
--- a/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
+++ b/OpenHABCore/Sources/OpenHABCore/Util/Endpoint.swift
@@ -74,20 +74,20 @@ public extension SortSitemapsOrder {
 /// `SortSitemapsOrder`, which only affects ordering and — for `.both` — which
 /// field leads.
 public enum SitemapNameLabelDisplayMode: Int, CaseIterable, Identifiable, CustomStringConvertible, Codable, Sendable {
-    case name
     case label
+    case name
     case both
 
     public var id: Self { self }
 
     public var description: String {
         switch self {
-        case .name:
-            String(localized: "Name")
         case .label:
             String(localized: "Label")
+        case .name:
+            String(localized: "Name")
         case .both:
-            String(localized: "Label and name")
+            String(localized: "Name and label")
         }
     }
 }

--- a/openHAB/UI/SettingsView/SitemapSettingsView.swift
+++ b/openHAB/UI/SettingsView/SitemapSettingsView.swift
@@ -101,10 +101,13 @@ struct SitemapSettingsView: View {
         Picker("Sitemap for Apple Watch", selection: $settingsSitemapForWatch) {
             Text("None").tag("")
             if sitemaps.isEmpty {
-                // Tag the placeholder with the stored selection so the Picker has a
-                // matching tag (avoids the "invalid selection" warning while the
-                // sitemap list is still loading).
-                Text("No sitemaps available").tag(settingsSitemapForWatch).foregroundStyle(.secondary)
+                // "None" above already covers the empty selection, so only add this
+                // placeholder when the stored selection is some other, not-yet-loaded
+                // sitemap — otherwise it would tag "" a second time (avoids the
+                // "invalid selection" warning while the sitemap list is still loading).
+                if !settingsSitemapForWatch.isEmpty {
+                    Text("No sitemaps available").tag(settingsSitemapForWatch).foregroundStyle(.secondary)
+                }
             } else {
                 ForEach(sitemaps, id: \.name) { sitemap in
                     Text(settingsSitemapNameLabelDisplayMode.combinedText(for: sitemap, sortedBy: settingsSortSitemapsBy)).tag(sitemap.name)

--- a/openHAB/UI/SettingsView/SitemapSettingsView.swift
+++ b/openHAB/UI/SettingsView/SitemapSettingsView.swift
@@ -99,6 +99,7 @@ struct SitemapSettingsView: View {
 
     private var watchSitemapPicker: some View {
         Picker("Sitemap for Apple Watch", selection: $settingsSitemapForWatch) {
+            Text("None").tag("")
             if sitemaps.isEmpty {
                 // Tag the placeholder with the stored selection so the Picker has a
                 // matching tag (avoids the "invalid selection" warning while the
@@ -108,15 +109,14 @@ struct SitemapSettingsView: View {
                 ForEach(sitemaps, id: \.name) { sitemap in
                     Text(settingsSitemapNameLabelDisplayMode.combinedText(for: sitemap, sortedBy: settingsSortSitemapsBy)).tag(sitemap.name)
                 }
-                if !sitemaps.contains(where: { $0.name == settingsSitemapForWatch }) {
-                    // The stored selection isn't among the available sitemaps (e.g. a
-                    // renamed/removed sitemap, or the default before one is chosen);
-                    // surface it so the Picker always has a tag for its selection.
-                    Text(settingsSitemapForWatch).tag(settingsSitemapForWatch).foregroundStyle(.secondary)
-                }
             }
         }
         .disabled(sitemaps.isEmpty)
+        .onChange(of: sitemaps) { _, newList in
+            if !settingsSitemapForWatch.isEmpty && !newList.contains(where: { $0.name == settingsSitemapForWatch }) {
+                settingsSitemapForWatch = ""
+            }
+        }
     }
 
     private var carPlaySitemapPicker: some View {
@@ -129,6 +129,11 @@ struct SitemapSettingsView: View {
             }
         }
         .disabled(sitemaps.isEmpty)
+        .onChange(of: sitemaps) { _, newList in
+            if !settingsSitemapForCarPlay.isEmpty && !newList.contains(where: { $0.name == settingsSitemapForCarPlay }) {
+                settingsSitemapForCarPlay = ""
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
• Harmonise `Show sitemaps by` and `Sort sitemaps by` menu entries
• Added None menu entry option to avoid empty menu entry for `Sitemap for Apple Watch` when the watch assignment has been double tap removed in the sitemaps menu section 
<img width="383" height="143" alt="Screenshot 2026-09-11 at 18 59 48" src="https://github.com/user-attachments/assets/0a1d3f09-ded2-4e72-8928-c61a4530c4f3" />
<img width="388" height="228" alt="Screenshot 2026-09-11 at 19 00 02" src="https://github.com/user-attachments/assets/a58664c9-2c51-432b-a69e-078ccfc550c6" />
•Set menu entries to None if Watch  or CarPlay sitemap has been deleted/renamed.